### PR TITLE
feat(lua-tools): inspect saved Platform state without running Mods

### DIFF
--- a/ai/lua-first-roadmap.yml
+++ b/ai/lua-first-roadmap.yml
@@ -677,4 +677,5 @@ capabilities:
     verification: not_run
     next_actions:
       - The initial declaration-snapshot, scaffold/editor and static-diagnostic slice passed local tool tests and the real LuaLS gate; it does not implement an in-game debugger, state/task inspector or native compatibility negotiation.
+      - A read-only saved-state inspector and test source now summarize state keys, task identities and participant records without starting the game; its tool acceptance is pending and it is not a live runtime inspector.
       - Continue runtime debugging, cookbook and author-workflow improvements as independent batches with their own evidence; do not make the whole author-experience capability a core Platform closure dependency.

--- a/tools/lua_api/README.md
+++ b/tools/lua_api/README.md
@@ -78,9 +78,36 @@ native content IDs, or prove gameplay/save correctness. The library has existing
 annotation gaps, so dynamically typed/undeclared portions need runtime validation.
 
 Lua runtime failures still use the engine's existing Mod/handler context and
-Lua error text in `debug.log`. This tooling does not add an in-game debugger or
-state/task inspector. Use the game's existing `--check-mods` path for actual
+Lua error text in `debug.log`. The SDK checker does not add an in-game debugger. The separate saved-state
+inspector below reads persisted records without starting the game. Use the game's existing `--check-mods` path for actual
 loading, and exercise the affected behavior for runtime acceptance.
+
+## Inspect saved state without starting the game
+
+```sh
+python3 tools/lua_api/inspect_state.py /path/world/lua_platform_world.json
+python3 tools/lua_api/inspect_state.py /path/player.lua_platform.json --mod MyMod
+python3 tools/lua_api/inspect_state.py /path/player.lua_platform.json --values --limit 50
+```
+
+The inspector reads one explicit Platform v1 save file and emits JSON containing
+saved Mod owners, state key/type summaries, task IDs, handler names, due turns,
+recurrence intervals and saved participant/actor records. Values are included
+only with `--values`. Each displayed list defaults to 20 entries; total counts
+remain visible, and `--limit` accepts 1–200. It never executes Mod metadata or Lua,
+loads native libraries, resolves participants against a world, or rewrites the
+save. The world and character files are separate scopes; inspect both when a Mod
+uses both.
+
+An absent/uninstalled Mod can still have a retained saved record. Finding a
+record does not establish that its handler currently exists, its participants
+are live, or its task will run. This is a saved-snapshot diagnostic, not a runtime
+debugger or a replacement for the engine's save loader. Basic malformed input,
+duplicate IDs/members and unsupported versions produce an error and exit code 2;
+successful inspection returns 0. A report is not full save compatibility proof.
+
+The Python tool regressions exercise snapshot reporting and malformed input.
+Actual restoration still requires the native game and its acceptance checks.
 
 ## Review an API upgrade
 
@@ -116,30 +143,3 @@ python3 tools/test_create_lua_mod.py
 The editor gate checks both real templates and deliberately invalid author code
 for unknown APIs, missing arguments and wrong argument types. It is a static
 acceptance gate and does not trigger a C++ build or a full content audit.
-
-## Inspect saved state without starting the game
-
-```sh
-python3 tools/lua_api/inspect_state.py /path/world/lua_platform_world.json
-python3 tools/lua_api/inspect_state.py /path/player.lua_platform.json --mod MyMod
-python3 tools/lua_api/inspect_state.py /path/player.lua_platform.json --values --limit 50
-```
-
-The inspector reads one explicit Platform v1 save file and emits JSON containing
-saved Mod owners, state key/type summaries, task IDs, handler names, due turns,
-recurrence intervals and saved participant/actor records. Values are included
-only with `--values`. Each displayed list defaults to 20 entries; total counts
-remain visible, and `--limit` accepts 1–200. It never executes Mod metadata or Lua,
-loads native libraries, resolves participants against a world, or rewrites the
-save. The world and character files are separate scopes; inspect both when a Mod
-uses both.
-
-An absent/uninstalled Mod can still have a retained saved record. Finding a
-record does not establish that its handler currently exists, its participants
-are live, or its task will run. This is a saved-snapshot diagnostic, not a runtime
-debugger or a replacement for the engine's save loader. Basic malformed input,
-duplicate IDs/members and unsupported versions produce an error and exit code 2;
-successful inspection returns 0. A report is not full save compatibility proof.
-
-Implementation and regression source are currently awaiting the deferred
-acceptance gate; no native game build is needed to exercise this tool later.

--- a/tools/lua_api/README.md
+++ b/tools/lua_api/README.md
@@ -93,8 +93,10 @@ python3 tools/lua_api/inspect_state.py /path/player.lua_platform.json --values -
 
 The inspector reads one explicit Platform v1 save file and emits JSON containing
 saved Mod owners, state key/type summaries, task IDs, handler names, due turns,
-recurrence intervals and saved participant/actor records. Values are included
-only with `--values`. Each displayed list defaults to 20 entries; total counts
+recurrence intervals and saved participant/actor records. State/payload values are
+included only with `--values`. Actor output includes only native identity/hint
+fields and checks their range, completeness and mutual exclusivity.
+Each displayed list defaults to 20 entries; total counts
 remain visible, and `--limit` accepts 1–200. It never executes Mod metadata or Lua,
 loads native libraries, resolves participants against a world, or rewrites the
 save. The world and character files are separate scopes; inspect both when a Mod

--- a/tools/lua_api/README.md
+++ b/tools/lua_api/README.md
@@ -87,6 +87,7 @@ loading, and exercise the affected behavior for runtime acceptance.
 ```sh
 python3 tools/lua_api/inspect_state.py /path/world/lua_platform_world.json
 python3 tools/lua_api/inspect_state.py /path/player.lua_platform.json --mod MyMod
+python3 tools/lua_api/inspect_state.py /path/player.lua_platform.json --mod MyMod --task 225
 python3 tools/lua_api/inspect_state.py /path/player.lua_platform.json --values --limit 50
 ```
 
@@ -97,7 +98,9 @@ only with `--values`. Each displayed list defaults to 20 entries; total counts
 remain visible, and `--limit` accepts 1–200. It never executes Mod metadata or Lua,
 loads native libraries, resolves participants against a world, or rewrites the
 save. The world and character files are separate scopes; inspect both when a Mod
-uses both.
+uses both. Use `--mod MyMod --task ID` to follow a task ID from an error message,
+including records beyond the displayed list limit. Task IDs are local to a Mod,
+so the task filter requires a Mod ID. Total and matched task counts stay separate.
 
 An absent/uninstalled Mod can still have a retained saved record. Finding a
 record does not establish that its handler currently exists, its participants

--- a/tools/lua_api/README.md
+++ b/tools/lua_api/README.md
@@ -116,3 +116,30 @@ python3 tools/test_create_lua_mod.py
 The editor gate checks both real templates and deliberately invalid author code
 for unknown APIs, missing arguments and wrong argument types. It is a static
 acceptance gate and does not trigger a C++ build or a full content audit.
+
+## Inspect saved state without starting the game
+
+```sh
+python3 tools/lua_api/inspect_state.py /path/world/lua_platform_world.json
+python3 tools/lua_api/inspect_state.py /path/player.lua_platform.json --mod MyMod
+python3 tools/lua_api/inspect_state.py /path/player.lua_platform.json --values --limit 50
+```
+
+The inspector reads one explicit Platform v1 save file and emits JSON containing
+saved Mod owners, state key/type summaries, task IDs, handler names, due turns,
+recurrence intervals and saved participant/actor records. Values are included
+only with `--values`. Each displayed list defaults to 20 entries; total counts
+remain visible, and `--limit` accepts 1–200. It never executes Mod metadata or Lua,
+loads native libraries, resolves participants against a world, or rewrites the
+save. The world and character files are separate scopes; inspect both when a Mod
+uses both.
+
+An absent/uninstalled Mod can still have a retained saved record. Finding a
+record does not establish that its handler currently exists, its participants
+are live, or its task will run. This is a saved-snapshot diagnostic, not a runtime
+debugger or a replacement for the engine's save loader. Basic malformed input,
+duplicate IDs/members and unsupported versions produce an error and exit code 2;
+successful inspection returns 0. A report is not full save compatibility proof.
+
+Implementation and regression source are currently awaiting the deferred
+acceptance gate; no native game build is needed to exercise this tool later.

--- a/tools/lua_api/README.md
+++ b/tools/lua_api/README.md
@@ -148,3 +148,9 @@ python3 tools/test_create_lua_mod.py
 The editor gate checks both real templates and deliberately invalid author code
 for unknown APIs, missing arguments and wrong argument types. It is a static
 acceptance gate and does not trigger a C++ build or a full content audit.
+
+The saved-state inspector also reports each Mod's `last_task_id` and
+`task_counter_persisted`. New counter-bearing records retain allocated IDs even
+with no pending tasks. For older records, the displayed counter is derived only
+from remaining task IDs; completed IDs cannot be reconstructed. Counters outside
+the signed task-ID range, or below a stored task ID, are rejected.

--- a/tools/lua_api/inspect_state.py
+++ b/tools/lua_api/inspect_state.py
@@ -170,6 +170,10 @@ def summarize(document: object, mod: str | None = None,
         tasks = record.get("tasks", [])
         if not isinstance(tasks, list):
             raise ValueError(f"{owner}.tasks: expected array")
+        counter_persisted = "last_task_id" in record
+        last_task_id = record.get("last_task_id", 0)
+        if not integer(last_task_id) or not 0 <= last_task_id < 2**63:
+            raise ValueError(f"{owner}: invalid last_task_id")
         task_rows, seen = [], set()
         for index, task in enumerate(tasks):
             location = f"{owner}.tasks[{index}]"
@@ -178,6 +182,9 @@ def summarize(document: object, mod: str | None = None,
             stored_id = task.get("id")
             if not integer(stored_id) or not 0 < stored_id < 2**63:
                 raise ValueError(f"{location}: invalid task id")
+            if counter_persisted and stored_id > last_task_id:
+                raise ValueError(f"{location}: task id exceeds saved last_task_id")
+            last_task_id = max(last_task_id, stored_id)
             if stored_id in seen:
                 raise ValueError(f"{location}: duplicate task id {stored_id}")
             seen.add(stored_id)
@@ -211,7 +218,9 @@ def summarize(document: object, mod: str | None = None,
         if task_id is not None and not task_rows:
             raise ValueError(f"{owner}: task {task_id} is absent from this snapshot")
         rows.append({
-            "mod": owner, "state_count": len(values),
+            "mod": owner, "last_task_id": last_task_id,
+            "task_counter_persisted": counter_persisted,
+            "state_count": len(values),
             "state": values[:limit], "task_count": len(tasks),
             "matched_task_count": len(task_rows), "tasks": sorted(task_rows, key=lambda row: row["id"])[:limit],
         })

--- a/tools/lua_api/inspect_state.py
+++ b/tools/lua_api/inspect_state.py
@@ -96,7 +96,8 @@ def task_participants(values: object, location: str) -> list:
 
 
 def summarize(document: object, mod: str | None = None,
-              limit: int = 20, show_values: bool = False) -> dict:
+              limit: int = 20, show_values: bool = False,
+              task_id: int | None = None) -> dict:
     if not isinstance(document, dict) or not integer(document.get("version")):
         raise ValueError("expected Platform state with an integer version")
     if document["version"] != 1:
@@ -112,6 +113,11 @@ def summarize(document: object, mod: str | None = None,
         raise ValueError(f"Mod {mod!r} is absent from this snapshot")
     if not 1 <= limit <= 200:
         raise ValueError("limit must be between 1 and 200")
+    if task_id is not None:
+        if mod is None:
+            raise ValueError("a task ID requires --mod because IDs are local to each Mod")
+        if not integer(task_id) or not 0 < task_id < 2**63:
+            raise ValueError("task ID must be a positive native integer")
     rows = []
     for owner, record in sorted(mods.items()):
         if mod is not None and owner != mod:
@@ -127,12 +133,12 @@ def summarize(document: object, mod: str | None = None,
             location = f"{owner}.tasks[{index}]"
             if not isinstance(task, dict):
                 raise ValueError(f"{location}: expected task object")
-            task_id = task.get("id")
-            if not integer(task_id) or not 0 < task_id < 2**63:
+            stored_id = task.get("id")
+            if not integer(stored_id) or not 0 < stored_id < 2**63:
                 raise ValueError(f"{location}: invalid task id")
-            if task_id in seen:
-                raise ValueError(f"{location}: duplicate task id {task_id}")
-            seen.add(task_id)
+            if stored_id in seen:
+                raise ValueError(f"{location}: duplicate task id {stored_id}")
+            seen.add(stored_id)
             if not isinstance(task.get("handler"), str) or not task["handler"]:
                 raise ValueError(f"{location}: missing handler")
             due = task.get("due_turn")
@@ -161,11 +167,14 @@ def summarize(document: object, mod: str | None = None,
                 key: value for key, value in task.items()
                 if key.startswith("actor_")
             }
-            task_rows.append(row)
+            if task_id is None or task["id"] == task_id:
+                task_rows.append(row)
+        if task_id is not None and not task_rows:
+            raise ValueError(f"{owner}: task {task_id} is absent from this snapshot")
         rows.append({
             "mod": owner, "state_count": len(values),
-            "state": values[:limit], "task_count": len(task_rows),
-            "tasks": sorted(task_rows, key=lambda row: row["id"])[:limit],
+            "state": values[:limit], "task_count": len(tasks),
+            "matched_task_count": len(task_rows), "tasks": sorted(task_rows, key=lambda row: row["id"])[:limit],
         })
     return {"version": 1, "scope": scope, "mod_count": len(mods),
             "matched_mod_count": len(rows), "mods": rows[:limit],
@@ -177,6 +186,7 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("file", type=Path)
     parser.add_argument("--mod", help="show only one saved Mod record")
+    parser.add_argument("--task", type=int, help="show one saved task ID; requires --mod")
     parser.add_argument("--limit", type=int, default=20,
                         help="maximum displayed entries per list (1-200)")
     parser.add_argument("--values", action="store_true",
@@ -184,7 +194,7 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     try:
         report = summarize(read_snapshot(args.file), args.mod,
-                           args.limit, args.values)
+                           args.limit, args.values, args.task)
         report["file"] = str(args.file.resolve())
         print(json.dumps(report, indent=2, ensure_ascii=True, allow_nan=False))
     except (OSError, ValueError, OverflowError, RecursionError) as error:

--- a/tools/lua_api/inspect_state.py
+++ b/tools/lua_api/inspect_state.py
@@ -95,6 +95,48 @@ def task_participants(values: object, location: str) -> list:
     return rows
 
 
+def task_actor(task: dict, location: str) -> dict:
+    """Report only native actor fields, validating saved identity and hint shape."""
+    result = {}
+    actor_count = 0
+    for kind in ("character", "item", "monster", "vehicle"):
+        prefix = f"actor_{kind}"
+        identity_key = prefix + ("_id" if kind == "character" else "_uid")
+        hint_keys = [prefix + "_hint_" + axis for axis in ("scope", "x", "y", "z")]
+        pending_key = prefix + "_pending"
+        metadata = [] if kind == "character" else hint_keys + [pending_key]
+        if identity_key not in task:
+            if any(key in task for key in metadata):
+                raise ValueError(f"{location}: actor metadata requires {identity_key}")
+            continue
+        actor_count += 1
+        identity = task[identity_key]
+        maximum = 2**31 if kind == "character" else 2**63
+        if not integer(identity) or not 0 < identity < maximum:
+            raise ValueError(f"{location}: invalid {identity_key}")
+        result[identity_key] = identity
+        if kind == "character":
+            continue
+        if any(key in task for key in hint_keys):
+            if not all(key in task for key in hint_keys):
+                raise ValueError(f"{location}: incomplete {prefix} hint")
+            scope = task[hint_keys[0]]
+            if (not isinstance(scope, str) or "\0" in scope
+                    or len(scope.encode("utf-8")) > 64):
+                raise ValueError(f"{location}: invalid {prefix} hint scope")
+            for key in hint_keys[1:]:
+                if not integer(task[key]) or not -(2**31) <= task[key] < 2**31:
+                    raise ValueError(f"{location}: invalid {key}")
+            result.update((key, task[key]) for key in hint_keys)
+        if pending_key in task:
+            if not isinstance(task[pending_key], bool):
+                raise ValueError(f"{location}: invalid {pending_key}")
+            result[pending_key] = task[pending_key]
+    if actor_count > 1:
+        raise ValueError(f"{location}: multiple actor identities")
+    return result
+
+
 def summarize(document: object, mod: str | None = None,
               limit: int = 20, show_values: bool = False,
               task_id: int | None = None) -> dict:
@@ -163,10 +205,7 @@ def summarize(document: object, mod: str | None = None,
             row["payload_count"] = len(payload)
             row["participants"] = participants[:limit]
             row["participant_count"] = len(participants)
-            row["actor"] = {
-                key: value for key, value in task.items()
-                if key.startswith("actor_")
-            }
+            row["actor"] = task_actor(task, location)
             if task_id is None or task["id"] == task_id:
                 task_rows.append(row)
         if task_id is not None and not task_rows:

--- a/tools/lua_api/inspect_state.py
+++ b/tools/lua_api/inspect_state.py
@@ -134,7 +134,8 @@ def summarize(document: object, mod: str | None = None,
             "state": values[:limit], "task_count": len(task_rows),
             "tasks": sorted(task_rows, key=lambda row: row["id"])[:limit],
         })
-    return {"version": 1, "scope": scope, "mods": rows,
+    return {"version": 1, "scope": scope, "mod_count": len(mods),
+            "matched_mod_count": len(rows), "mods": rows[:limit],
             "note": "Saved snapshot only; handler availability, participant "
                     "liveness and runtime execution are not verified."}
 

--- a/tools/lua_api/inspect_state.py
+++ b/tools/lua_api/inspect_state.py
@@ -44,12 +44,12 @@ def typed_values(values: object, location: str, show_values: bool) -> list:
             raise ValueError(f"{location}.{key}: missing typed value")
         kind, value = entry.get("type"), entry["value"]
         valid = (
-            (kind == "boolean" and isinstance(value, bool))
-            or (kind == "integer" and integer(value)
-                and -(2**63) <= value < 2**63)
-            or (kind == "float" and isinstance(value, (int, float))
-                and not isinstance(value, bool) and math.isfinite(value))
-            or (kind == "string" and isinstance(value, str))
+            (kind == "boolean" and isinstance(value, bool)) or
+            (kind == "integer" and integer(value) and
+                -(2**63) <= value < 2**63) or
+            (kind == "float" and isinstance(value, (int, float)) and
+                not isinstance(value, bool) and math.isfinite(value)) or
+            (kind == "string" and isinstance(value, str))
         )
         if not valid:
             raise ValueError(f"{location}.{key}: invalid {kind!r} value")
@@ -58,7 +58,6 @@ def typed_values(values: object, location: str, show_values: bool) -> list:
             row["value"] = value
         result.append(row)
     return result
-
 
 
 def task_participants(values: object, location: str) -> list:
@@ -80,8 +79,8 @@ def task_participants(values: object, location: str) -> list:
         if not integer(stable_id) or not 0 < stable_id < maximum:
             raise ValueError(f"{where}: invalid participant stable_id")
         hint_scope = participant.get("hint_scope")
-        if (not isinstance(hint_scope, str) or "\0" in hint_scope
-                or len(hint_scope.encode("utf-8")) > 64):
+        if (not isinstance(hint_scope, str) or "\0" in hint_scope or
+                len(hint_scope.encode("utf-8")) > 64):
             raise ValueError(f"{where}: invalid participant hint_scope")
         for key in ("hint_x", "hint_y", "hint_z"):
             value = participant.get(key)
@@ -89,25 +88,34 @@ def task_participants(values: object, location: str) -> list:
                 raise ValueError(f"{where}: invalid participant {key}")
         if not isinstance(participant.get("pending", False), bool):
             raise ValueError(f"{where}: invalid participant pending flag")
-        rows.append({key: participant[key] for key in
-                     ("role", "kind", "stable_id", "hint_scope", "hint_x", "hint_y", "hint_z")})
+        rows.append({key: participant[key] for key in (
+            "role", "kind", "stable_id", "hint_scope",
+            "hint_x", "hint_y", "hint_z")})
         rows[-1]["pending"] = participant.get("pending", False)
     return rows
 
 
 def task_actor(task: dict, location: str) -> dict:
-    """Report only native actor fields, validating saved identity and hint shape."""
+    """Validate and report native actor identity and hint fields."""
     result = {}
     actor_count = 0
     for kind in ("character", "item", "monster", "vehicle"):
         prefix = f"actor_{kind}"
         identity_key = prefix + ("_id" if kind == "character" else "_uid")
-        hint_keys = [prefix + "_hint_" + axis for axis in ("scope", "x", "y", "z")]
+        hint_keys = [
+            prefix +
+            "_hint_" +
+            axis for axis in (
+                "scope",
+                "x",
+                "y",
+                "z")]
         pending_key = prefix + "_pending"
         metadata = [] if kind == "character" else hint_keys + [pending_key]
         if identity_key not in task:
             if any(key in task for key in metadata):
-                raise ValueError(f"{location}: actor metadata requires {identity_key}")
+                raise ValueError(
+                    f"{location}: actor metadata requires {identity_key}")
             continue
         actor_count += 1
         identity = task[identity_key]
@@ -121,8 +129,8 @@ def task_actor(task: dict, location: str) -> dict:
             if not all(key in task for key in hint_keys):
                 raise ValueError(f"{location}: incomplete {prefix} hint")
             scope = task[hint_keys[0]]
-            if (not isinstance(scope, str) or "\0" in scope
-                    or len(scope.encode("utf-8")) > 64):
+            if (not isinstance(scope, str) or "\0" in scope or
+                    len(scope.encode("utf-8")) > 64):
                 raise ValueError(f"{location}: invalid {prefix} hint scope")
             for key in hint_keys[1:]:
                 if not integer(task[key]) or not -(2**31) <= task[key] < 2**31:
@@ -157,7 +165,8 @@ def summarize(document: object, mod: str | None = None,
         raise ValueError("limit must be between 1 and 200")
     if task_id is not None:
         if mod is None:
-            raise ValueError("a task ID requires --mod because IDs are local to each Mod")
+            raise ValueError(
+                "a task ID requires --mod because IDs are local to each Mod")
         if not integer(task_id) or not 0 < task_id < 2**63:
             raise ValueError("task ID must be a positive native integer")
     rows = []
@@ -183,7 +192,8 @@ def summarize(document: object, mod: str | None = None,
             if not integer(stored_id) or not 0 < stored_id < 2**63:
                 raise ValueError(f"{location}: invalid task id")
             if counter_persisted and stored_id > last_task_id:
-                raise ValueError(f"{location}: task id exceeds saved last_task_id")
+                raise ValueError(
+                    f"{location}: task id exceeds saved last_task_id")
             last_task_id = max(last_task_id, stored_id)
             if stored_id in seen:
                 raise ValueError(f"{location}: duplicate task id {stored_id}")
@@ -204,7 +214,8 @@ def summarize(document: object, mod: str | None = None,
                     f"{location}: owner_mod_id differs from record")
             payload = typed_values(task.get("payload"), location,
                                    show_values)
-            participants = task_participants(task.get("participants", []), location)
+            participants = task_participants(
+                task.get("participants", []), location)
             row = {key: task[key] for key in ("id", "handler", "due_turn")}
             row["interval_turns"] = interval
             row["payload_version"] = version
@@ -216,14 +227,18 @@ def summarize(document: object, mod: str | None = None,
             if task_id is None or task["id"] == task_id:
                 task_rows.append(row)
         if task_id is not None and not task_rows:
-            raise ValueError(f"{owner}: task {task_id} is absent from this snapshot")
-        rows.append({
-            "mod": owner, "last_task_id": last_task_id,
-            "task_counter_persisted": counter_persisted,
-            "state_count": len(values),
-            "state": values[:limit], "task_count": len(tasks),
-            "matched_task_count": len(task_rows), "tasks": sorted(task_rows, key=lambda row: row["id"])[:limit],
-        })
+            raise ValueError(
+                f"{owner}: task {task_id} is absent from this snapshot")
+        rows.append({"mod": owner,
+                     "last_task_id": last_task_id,
+                     "task_counter_persisted": counter_persisted,
+                     "state_count": len(values),
+                     "state": values[:limit],
+                     "task_count": len(tasks),
+                     "matched_task_count": len(task_rows),
+                     "tasks": sorted(task_rows,
+                                     key=lambda row: row["id"])[:limit],
+                     })
     return {"version": 1, "scope": scope, "mod_count": len(mods),
             "matched_mod_count": len(rows), "mods": rows[:limit],
             "note": "Saved snapshot only; handler availability, participant "
@@ -234,7 +249,10 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("file", type=Path)
     parser.add_argument("--mod", help="show only one saved Mod record")
-    parser.add_argument("--task", type=int, help="show one saved task ID; requires --mod")
+    parser.add_argument(
+        "--task",
+        type=int,
+        help="show one saved task ID; requires --mod")
     parser.add_argument("--limit", type=int, default=20,
                         help="maximum displayed entries per list (1-200)")
     parser.add_argument("--values", action="store_true",

--- a/tools/lua_api/inspect_state.py
+++ b/tools/lua_api/inspect_state.py
@@ -60,6 +60,41 @@ def typed_values(values: object, location: str, show_values: bool) -> list:
     return result
 
 
+
+def task_participants(values: object, location: str) -> list:
+    if not isinstance(values, list):
+        raise ValueError(f"{location}: expected participants array")
+    rows, roles = [], set()
+    for index, participant in enumerate(values):
+        where = f"{location}.participants[{index}]"
+        if not isinstance(participant, dict):
+            raise ValueError(f"{where}: expected participant object")
+        role, kind = participant.get("role"), participant.get("kind")
+        if not isinstance(role, str) or not role or role in roles:
+            raise ValueError(f"{where}: missing or repeated participant role")
+        roles.add(role)
+        if kind not in ("character", "item", "monster", "vehicle"):
+            raise ValueError(f"{where}: invalid participant kind")
+        stable_id = participant.get("stable_id")
+        maximum = 2**31 if kind == "character" else 2**63
+        if not integer(stable_id) or not 0 < stable_id < maximum:
+            raise ValueError(f"{where}: invalid participant stable_id")
+        hint_scope = participant.get("hint_scope")
+        if (not isinstance(hint_scope, str) or "\0" in hint_scope
+                or len(hint_scope.encode("utf-8")) > 64):
+            raise ValueError(f"{where}: invalid participant hint_scope")
+        for key in ("hint_x", "hint_y", "hint_z"):
+            value = participant.get(key)
+            if not integer(value) or not -(2**31) <= value < 2**31:
+                raise ValueError(f"{where}: invalid participant {key}")
+        if not isinstance(participant.get("pending", False), bool):
+            raise ValueError(f"{where}: invalid participant pending flag")
+        rows.append({key: participant[key] for key in
+                     ("role", "kind", "stable_id", "hint_scope", "hint_x", "hint_y", "hint_z")})
+        rows[-1]["pending"] = participant.get("pending", False)
+    return rows
+
+
 def summarize(document: object, mod: str | None = None,
               limit: int = 20, show_values: bool = False) -> dict:
     if not isinstance(document, dict) or not integer(document.get("version")):
@@ -107,16 +142,14 @@ def summarize(document: object, mod: str | None = None,
             if not integer(interval) or not 0 <= interval < 2**63:
                 raise ValueError(f"{location}: invalid interval_turns")
             version = task.get("payload_version")
-            if not integer(version) or version <= 0:
+            if not integer(version) or not 0 < version < 2**31:
                 raise ValueError(f"{location}: invalid payload_version")
             if task.get("owner_mod_id", owner) != owner:
                 raise ValueError(
                     f"{location}: owner_mod_id differs from record")
             payload = typed_values(task.get("payload"), location,
                                    show_values)
-            participants = task.get("participants", [])
-            if not isinstance(participants, list):
-                raise ValueError(f"{location}: expected participants array")
+            participants = task_participants(task.get("participants", []), location)
             row = {key: task[key] for key in ("id", "handler", "due_turn")}
             row["interval_turns"] = interval
             row["payload_version"] = version

--- a/tools/lua_api/inspect_state.py
+++ b/tools/lua_api/inspect_state.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Inspect saved Platform state without executing Lua or changing the save."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+
+MAX_FILE_BYTES = 16 * 1024 * 1024
+
+
+def unique_object(pairs: list[tuple[str, object]]) -> dict:
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON member: {key!r}")
+        result[key] = value
+    return result
+
+
+def read_snapshot(path: Path) -> dict:
+    if not path.is_file():
+        raise ValueError(f"not a regular file: {path}")
+    with path.open("rb") as stream:
+        content = stream.read(MAX_FILE_BYTES + 1)
+    if len(content) > MAX_FILE_BYTES:
+        raise ValueError("Platform state file exceeds 16 MiB")
+    return json.loads(content, object_pairs_hook=unique_object)
+
+
+def integer(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def typed_values(values: object, location: str, show_values: bool) -> list:
+    if not isinstance(values, dict):
+        raise ValueError(f"{location}: expected typed-value object")
+    result = []
+    for key, entry in sorted(values.items()):
+        if not isinstance(entry, dict) or "value" not in entry:
+            raise ValueError(f"{location}.{key}: missing typed value")
+        kind, value = entry.get("type"), entry["value"]
+        valid = (
+            (kind == "boolean" and isinstance(value, bool))
+            or (kind == "integer" and integer(value)
+                and -(2**63) <= value < 2**63)
+            or (kind == "float" and isinstance(value, (int, float))
+                and not isinstance(value, bool) and math.isfinite(value))
+            or (kind == "string" and isinstance(value, str))
+        )
+        if not valid:
+            raise ValueError(f"{location}.{key}: invalid {kind!r} value")
+        row = {"key": key, "type": kind}
+        if show_values:
+            row["value"] = value
+        result.append(row)
+    return result
+
+
+def summarize(document: object, mod: str | None = None,
+              limit: int = 20, show_values: bool = False) -> dict:
+    if not isinstance(document, dict) or not integer(document.get("version")):
+        raise ValueError("expected Platform state with an integer version")
+    if document["version"] != 1:
+        raise ValueError(
+            f"unsupported Platform state version: {document['version']}")
+    scope = document.get("scope")
+    if scope not in ("world", "character"):
+        raise ValueError("expected world or character scope")
+    mods = document.get("mods")
+    if not isinstance(mods, dict):
+        raise ValueError("expected mods object")
+    if mod is not None and mod not in mods:
+        raise ValueError(f"Mod {mod!r} is absent from this snapshot")
+    if not 1 <= limit <= 200:
+        raise ValueError("limit must be between 1 and 200")
+    rows = []
+    for owner, record in sorted(mods.items()):
+        if mod is not None and owner != mod:
+            continue
+        if not isinstance(record, dict):
+            raise ValueError(f"{owner}: expected Mod record")
+        values = typed_values(record.get("values"), owner, show_values)
+        tasks = record.get("tasks", [])
+        if not isinstance(tasks, list):
+            raise ValueError(f"{owner}.tasks: expected array")
+        task_rows, seen = [], set()
+        for index, task in enumerate(tasks):
+            location = f"{owner}.tasks[{index}]"
+            if not isinstance(task, dict):
+                raise ValueError(f"{location}: expected task object")
+            task_id = task.get("id")
+            if not integer(task_id) or not 0 < task_id < 2**63:
+                raise ValueError(f"{location}: invalid task id")
+            if task_id in seen:
+                raise ValueError(f"{location}: duplicate task id {task_id}")
+            seen.add(task_id)
+            if not isinstance(task.get("handler"), str) or not task["handler"]:
+                raise ValueError(f"{location}: missing handler")
+            due = task.get("due_turn")
+            interval = task.get("interval_turns", 0)
+            if not integer(due) or not -(2**63) <= due < 2**63:
+                raise ValueError(f"{location}: invalid due_turn")
+            if not integer(interval) or not 0 <= interval < 2**63:
+                raise ValueError(f"{location}: invalid interval_turns")
+            version = task.get("payload_version")
+            if not integer(version) or version <= 0:
+                raise ValueError(f"{location}: invalid payload_version")
+            if task.get("owner_mod_id", owner) != owner:
+                raise ValueError(
+                    f"{location}: owner_mod_id differs from record")
+            payload = typed_values(task.get("payload"), location,
+                                   show_values)
+            participants = task.get("participants", [])
+            if not isinstance(participants, list):
+                raise ValueError(f"{location}: expected participants array")
+            row = {key: task[key] for key in ("id", "handler", "due_turn")}
+            row["interval_turns"] = interval
+            row["payload_version"] = version
+            row["payload"] = payload[:limit]
+            row["payload_count"] = len(payload)
+            row["participants"] = participants[:limit]
+            row["participant_count"] = len(participants)
+            row["actor"] = {
+                key: value for key, value in task.items()
+                if key.startswith("actor_")
+            }
+            task_rows.append(row)
+        rows.append({
+            "mod": owner, "state_count": len(values),
+            "state": values[:limit], "task_count": len(task_rows),
+            "tasks": sorted(task_rows, key=lambda row: row["id"])[:limit],
+        })
+    return {"version": 1, "scope": scope, "mods": rows,
+            "note": "Saved snapshot only; handler availability, participant "
+                    "liveness and runtime execution are not verified."}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("file", type=Path)
+    parser.add_argument("--mod", help="show only one saved Mod record")
+    parser.add_argument("--limit", type=int, default=20,
+                        help="maximum displayed entries per list (1-200)")
+    parser.add_argument("--values", action="store_true",
+                        help="include state and payload values")
+    args = parser.parse_args(argv)
+    try:
+        report = summarize(read_snapshot(args.file), args.mod,
+                           args.limit, args.values)
+        report["file"] = str(args.file.resolve())
+        print(json.dumps(report, indent=2, ensure_ascii=True, allow_nan=False))
+    except (OSError, ValueError, OverflowError, RecursionError) as error:
+        print(f"{args.file}: {error}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lua_api/test_inspect_state.py
+++ b/tools/lua_api/test_inspect_state.py
@@ -25,7 +25,8 @@ def saved_state() -> dict:
                 "payload_version": 1, "payload": {},
                 "actor_character_id": 12,
                 "participants": [{"role": "target", "kind": "character",
-                                  "stable_id": 12, "pending": True}],
+                                  "stable_id": 12, "pending": True, "hint_scope": "npc",
+                                  "hint_x": 0, "hint_y": 0, "hint_z": 0}],
             }],
         }},
     }
@@ -84,12 +85,28 @@ class StateInspectorTests(unittest.TestCase):
         for field, value in (("id", True), ("id", 0),
                              ("owner_mod_id", "another-mod"),
                              ("interval_turns", -1),
-                             ("payload_version", 0)):
+                             ("payload_version", 0), ("payload_version", 2**31)):
             with self.subTest(field=field, value=value):
                 snapshot = saved_state()
                 snapshot["mods"]["tonic"]["tasks"][0][field] = value
                 with self.assertRaises(ValueError):
                     inspect_state.summarize(snapshot)
+
+    def test_participant_diagnostics_identify_the_bad_record(self):
+        for field, value in (("hint_x", True), ("hint_scope", "a\0b"),
+                             ("stable_id", 2**31), ("pending", "yes"),
+                             ("kind", "unknown")):
+            with self.subTest(field=field):
+                snapshot = saved_state()
+                participant = snapshot["mods"]["tonic"]["tasks"][0]["participants"][0]
+                participant[field] = value
+                with self.assertRaisesRegex(ValueError, r"tonic.tasks\[0\].participants\[0\]"):
+                    inspect_state.summarize(snapshot)
+        snapshot = saved_state()
+        participants = snapshot["mods"]["tonic"]["tasks"][0]["participants"]
+        participants.append(copy.deepcopy(participants[0]))
+        with self.assertRaisesRegex(ValueError, "repeated participant role"):
+            inspect_state.summarize(snapshot)
 
     def test_duplicate_tasks_and_typed_value_mismatch_are_rejected(self):
         snapshot = saved_state()

--- a/tools/lua_api/test_inspect_state.py
+++ b/tools/lua_api/test_inspect_state.py
@@ -59,6 +59,26 @@ class StateInspectorTests(unittest.TestCase):
         self.assertEqual(row["state"], [
             {"key": "active", "type": "boolean", "value": True}])
 
+    def test_saved_task_counter_and_legacy_pending_id_fallback(self):
+        snapshot = saved_state()
+        legacy = inspect_state.summarize(snapshot)["mods"][0]
+        self.assertEqual(legacy["last_task_id"], 3)
+        self.assertFalse(legacy["task_counter_persisted"])
+        record = snapshot["mods"]["tonic"]
+        record["last_task_id"] = 77
+        saved = inspect_state.summarize(snapshot)["mods"][0]
+        self.assertEqual(saved["last_task_id"], 77)
+        self.assertTrue(saved["task_counter_persisted"])
+        for invalid in (-1, True, 2**63, 3.5, 2):
+            record["last_task_id"] = invalid
+            with self.subTest(counter=invalid), self.assertRaisesRegex(
+                    ValueError, "last_task_id"):
+                inspect_state.summarize(snapshot)
+        record["tasks"] = []
+        record["last_task_id"] = 2**63 - 1
+        self.assertEqual(inspect_state.summarize(snapshot)["mods"][0]["last_task_id"],
+                         2**63 - 1)
+
     def test_actor_reports_known_identity_and_hints_only(self):
         snapshot = saved_state()
         task = snapshot["mods"]["tonic"]["tasks"][0]

--- a/tools/lua_api/test_inspect_state.py
+++ b/tools/lua_api/test_inspect_state.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import contextlib
+import copy
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+try:
+    from . import inspect_state
+except ImportError:
+    import inspect_state
+
+
+def saved_state() -> dict:
+    return {
+        "version": 1, "scope": "character",
+        "mods": {"tonic": {
+            "values": {"cooldown": {"type": "integer", "value": 42}},
+            "tasks": [{
+                "id": 3, "handler": "restore", "due_turn": 80,
+                "payload_version": 1, "payload": {},
+                "actor_character_id": 12,
+                "participants": [{"role": "target", "kind": "character",
+                                  "stable_id": 12, "pending": True}],
+            }],
+        }},
+    }
+
+
+class StateInspectorTests(unittest.TestCase):
+    def test_snapshot_preserves_identity_and_legacy_interval_default(self):
+        snapshot = saved_state()
+        original = copy.deepcopy(snapshot)
+        report = inspect_state.summarize(snapshot)
+        row = report["mods"][0]
+        self.assertEqual(row["mod"], "tonic")
+        self.assertEqual(row["state"], [
+            {"key": "cooldown", "type": "integer"}])
+        task = row["tasks"][0]
+        self.assertEqual(task["id"], 3)
+        self.assertEqual(task["interval_turns"], 0)
+        self.assertEqual(task["actor"], {"actor_character_id": 12})
+        self.assertTrue(task["participants"][0]["pending"])
+        self.assertEqual(snapshot, original)
+
+    def test_values_are_opt_in_and_counts_survive_truncation(self):
+        snapshot = saved_state()
+        snapshot["mods"]["tonic"]["values"]["active"] = {
+            "type": "boolean", "value": True,
+        }
+        report = inspect_state.summarize(snapshot, limit=1, show_values=True)
+        row = report["mods"][0]
+        self.assertEqual(row["state_count"], 2)
+        self.assertEqual(row["state"], [
+            {"key": "active", "type": "boolean", "value": True}])
+
+    def test_mod_filter_does_not_drop_unknown_saved_owners(self):
+        snapshot = saved_state()
+        snapshot["mods"]["uninstalled-mod"] = {"values": {}, "tasks": []}
+        report = inspect_state.summarize(snapshot, mod="uninstalled-mod")
+        self.assertEqual([row["mod"] for row in report["mods"]],
+                         ["uninstalled-mod"])
+        with self.assertRaisesRegex(ValueError, "absent"):
+            inspect_state.summarize(snapshot, mod="missing")
+
+    def test_invalid_task_identity_and_owner_are_reported(self):
+        for field, value in (("id", True), ("id", 0),
+                             ("owner_mod_id", "another-mod"),
+                             ("interval_turns", -1),
+                             ("payload_version", 0)):
+            with self.subTest(field=field, value=value):
+                snapshot = saved_state()
+                snapshot["mods"]["tonic"]["tasks"][0][field] = value
+                with self.assertRaises(ValueError):
+                    inspect_state.summarize(snapshot)
+
+    def test_duplicate_tasks_and_typed_value_mismatch_are_rejected(self):
+        snapshot = saved_state()
+        tasks = snapshot["mods"]["tonic"]["tasks"]
+        tasks.append(copy.deepcopy(tasks[0]))
+        with self.assertRaisesRegex(ValueError, "duplicate task"):
+            inspect_state.summarize(snapshot)
+        snapshot = saved_state()
+        snapshot["mods"]["tonic"]["values"]["cooldown"]["value"] = False
+        with self.assertRaisesRegex(ValueError, "invalid 'integer'"):
+            inspect_state.summarize(snapshot)
+
+    def test_cli_is_read_only_and_rejects_ambiguous_json(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "save.lua_platform.json"
+            original = json.dumps(saved_state()).encode()
+            path.write_bytes(original)
+            with contextlib.redirect_stdout(io.StringIO()) as stdout:
+                self.assertEqual(inspect_state.main([str(path)]), 0)
+            self.assertEqual(
+                json.loads(stdout.getvalue())["scope"], "character")
+            self.assertEqual(path.read_bytes(), original)
+            path.write_text('{"version":1,"version":2}', encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "duplicate JSON"):
+                inspect_state.read_snapshot(path)
+            path.write_bytes(original)
+            with patch.object(inspect_state, "MAX_FILE_BYTES", 8):
+                with self.assertRaisesRegex(ValueError, "exceeds"):
+                    inspect_state.read_snapshot(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/lua_api/test_inspect_state.py
+++ b/tools/lua_api/test_inspect_state.py
@@ -67,6 +67,19 @@ class StateInspectorTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "absent"):
             inspect_state.summarize(snapshot, mod="missing")
 
+    def test_mod_list_is_bounded_with_total_and_filtered_counts(self):
+        snapshot = saved_state()
+        snapshot["mods"]["another"] = {"values": {}, "tasks": []}
+        report = inspect_state.summarize(snapshot, limit=1)
+        self.assertEqual(report["mod_count"], 2)
+        self.assertEqual(report["matched_mod_count"], 2)
+        self.assertEqual(len(report["mods"]), 1)
+        self.assertEqual(report["mods"][0]["mod"], "another")
+        report = inspect_state.summarize(snapshot, mod="tonic", limit=1)
+        self.assertEqual(report["mod_count"], 2)
+        self.assertEqual(report["matched_mod_count"], 1)
+        self.assertEqual(report["mods"][0]["mod"], "tonic")
+
     def test_invalid_task_identity_and_owner_are_reported(self):
         for field, value in (("id", True), ("id", 0),
                              ("owner_mod_id", "another-mod"),

--- a/tools/lua_api/test_inspect_state.py
+++ b/tools/lua_api/test_inspect_state.py
@@ -59,6 +59,36 @@ class StateInspectorTests(unittest.TestCase):
         self.assertEqual(row["state"], [
             {"key": "active", "type": "boolean", "value": True}])
 
+    def test_actor_reports_known_identity_and_hints_only(self):
+        snapshot = saved_state()
+        task = snapshot["mods"]["tonic"]["tasks"][0]
+        del task["actor_character_id"]
+        actor = {"actor_item_uid": 99, "actor_item_pending": True,
+                 "actor_item_hint_scope": "map", "actor_item_hint_x": -4,
+                 "actor_item_hint_y": 5, "actor_item_hint_z": 0}
+        task.update(actor, actor_unrecognized={"large": ["not native actor data"]})
+        report = inspect_state.summarize(snapshot)
+        self.assertEqual(report["mods"][0]["tasks"][0]["actor"], actor)
+
+    def test_malformed_actor_records_report_the_task_location(self):
+        cases = [
+            {"actor_character_id": True},
+            {"actor_character_id": 2**31},
+            {"actor_character_id": 1, "actor_item_uid": 2},
+            {"actor_item_uid": 0},
+            {"actor_item_pending": True},
+            {"actor_item_uid": 1, "actor_item_hint_x": 0},
+            {"actor_monster_uid": 2, "actor_monster_pending": "yes"},
+        ]
+        for actor in cases:
+            with self.subTest(actor=actor):
+                snapshot = saved_state()
+                task = snapshot["mods"]["tonic"]["tasks"][0]
+                del task["actor_character_id"]
+                task.update(actor)
+                with self.assertRaisesRegex(ValueError, r"tonic\.tasks\[0\]"):
+                    inspect_state.summarize(snapshot)
+
     def test_mod_filter_does_not_drop_unknown_saved_owners(self):
         snapshot = saved_state()
         snapshot["mods"]["uninstalled-mod"] = {"values": {}, "tasks": []}

--- a/tools/lua_api/test_inspect_state.py
+++ b/tools/lua_api/test_inspect_state.py
@@ -25,7 +25,8 @@ def saved_state() -> dict:
                 "payload_version": 1, "payload": {},
                 "actor_character_id": 12,
                 "participants": [{"role": "target", "kind": "character",
-                                  "stable_id": 12, "pending": True, "hint_scope": "npc",
+                                  "stable_id": 12, "pending": True,
+                                  "hint_scope": "npc",
                                   "hint_x": 0, "hint_y": 0, "hint_z": 0}],
             }],
         }},
@@ -76,8 +77,8 @@ class StateInspectorTests(unittest.TestCase):
                 inspect_state.summarize(snapshot)
         record["tasks"] = []
         record["last_task_id"] = 2**63 - 1
-        self.assertEqual(inspect_state.summarize(snapshot)["mods"][0]["last_task_id"],
-                         2**63 - 1)
+        self.assertEqual(inspect_state.summarize(snapshot)[
+                         "mods"][0]["last_task_id"], 2**63 - 1)
 
     def test_actor_reports_known_identity_and_hints_only(self):
         snapshot = saved_state()
@@ -86,7 +87,9 @@ class StateInspectorTests(unittest.TestCase):
         actor = {"actor_item_uid": 99, "actor_item_pending": True,
                  "actor_item_hint_scope": "map", "actor_item_hint_x": -4,
                  "actor_item_hint_y": 5, "actor_item_hint_z": 0}
-        task.update(actor, actor_unrecognized={"large": ["not native actor data"]})
+        task.update(
+            actor, actor_unrecognized={
+                "large": ["not native actor data"]})
         report = inspect_state.summarize(snapshot)
         self.assertEqual(report["mods"][0]["tasks"][0]["actor"], actor)
 
@@ -135,8 +138,10 @@ class StateInspectorTests(unittest.TestCase):
         snapshot = saved_state()
         record = snapshot["mods"]["tonic"]
         template = record["tasks"][0]
-        record["tasks"] = [dict(template, id=number) for number in range(1, 251)]
-        row = inspect_state.summarize(snapshot, mod="tonic", limit=1, task_id=225)["mods"][0]
+        record["tasks"] = [dict(template, id=number)
+                           for number in range(1, 251)]
+        row = inspect_state.summarize(
+            snapshot, mod="tonic", limit=1, task_id=225)["mods"][0]
         self.assertEqual(row["task_count"], 250)
         self.assertEqual(row["matched_task_count"], 1)
         self.assertEqual([task["id"] for task in row["tasks"]], [225])
@@ -145,14 +150,16 @@ class StateInspectorTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "task 999 is absent"):
             inspect_state.summarize(snapshot, mod="tonic", task_id=999)
         for invalid in (0, -1, True, 2**63):
-            with self.subTest(task_id=invalid), self.assertRaisesRegex(ValueError, "positive"):
+            with self.subTest(task_id=invalid), self.assertRaisesRegex(
+                    ValueError, "positive"):
                 inspect_state.summarize(snapshot, mod="tonic", task_id=invalid)
 
     def test_invalid_task_identity_and_owner_are_reported(self):
         for field, value in (("id", True), ("id", 0),
                              ("owner_mod_id", "another-mod"),
                              ("interval_turns", -1),
-                             ("payload_version", 0), ("payload_version", 2**31)):
+                             ("payload_version", 0),
+                             ("payload_version", 2**31)):
             with self.subTest(field=field, value=value):
                 snapshot = saved_state()
                 snapshot["mods"]["tonic"]["tasks"][0][field] = value
@@ -165,9 +172,11 @@ class StateInspectorTests(unittest.TestCase):
                              ("kind", "unknown")):
             with self.subTest(field=field):
                 snapshot = saved_state()
-                participant = snapshot["mods"]["tonic"]["tasks"][0]["participants"][0]
+                task = snapshot["mods"]["tonic"]["tasks"][0]
+                participant = task["participants"][0]
                 participant[field] = value
-                with self.assertRaisesRegex(ValueError, r"tonic.tasks\[0\].participants\[0\]"):
+                with self.assertRaisesRegex(
+                        ValueError, r"tonic.tasks\[0\].participants\[0\]"):
                     inspect_state.summarize(snapshot)
         snapshot = saved_state()
         participants = snapshot["mods"]["tonic"]["tasks"][0]["participants"]

--- a/tools/lua_api/test_inspect_state.py
+++ b/tools/lua_api/test_inspect_state.py
@@ -81,6 +81,23 @@ class StateInspectorTests(unittest.TestCase):
         self.assertEqual(report["matched_mod_count"], 1)
         self.assertEqual(report["mods"][0]["mod"], "tonic")
 
+    def test_task_filter_reaches_entries_beyond_the_display_limit(self):
+        snapshot = saved_state()
+        record = snapshot["mods"]["tonic"]
+        template = record["tasks"][0]
+        record["tasks"] = [dict(template, id=number) for number in range(1, 251)]
+        row = inspect_state.summarize(snapshot, mod="tonic", limit=1, task_id=225)["mods"][0]
+        self.assertEqual(row["task_count"], 250)
+        self.assertEqual(row["matched_task_count"], 1)
+        self.assertEqual([task["id"] for task in row["tasks"]], [225])
+        with self.assertRaisesRegex(ValueError, "requires --mod"):
+            inspect_state.summarize(snapshot, task_id=225)
+        with self.assertRaisesRegex(ValueError, "task 999 is absent"):
+            inspect_state.summarize(snapshot, mod="tonic", task_id=999)
+        for invalid in (0, -1, True, 2**63):
+            with self.subTest(task_id=invalid), self.assertRaisesRegex(ValueError, "positive"):
+                inspect_state.summarize(snapshot, mod="tonic", task_id=invalid)
+
     def test_invalid_task_identity_and_owner_are_reported(self):
         for field, value in (("id", True), ("id", 0),
                              ("owner_mod_id", "another-mod"),


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

Adds a read-only CLI for one explicit Lua Platform saved-state file. It summarizes Mod-owned state keys and persistent tasks, with bounded list output and separate total/matched counts. --mod ID --task N finds a logged task even beyond display limits; state and payload values require --values.

Validates the saved schema, duplicate keys, task/participant identities and native actor descriptors. Reports only recognized actor fields, including complete location hints and pending flags. Also reports last_task_id and task_counter_persisted for the optional counter introduced by #766; older records derive the displayed counter from remaining task IDs, without claiming to recover completed legacy IDs.

It never executes Lua, loads the world or modifies saves, and cannot establish handler availability or current object liveness.

Validation: 12 focused StateInspectorTests passed (0.009 s), plus git diff --check. No native build, game execution or broad validation ran.

#### Responsible human

@LYHGLYTX

#### Documentation impact

Updates the Lua-first contract or author tooling guidance for the behavior described above.

#### Related CCB-Docs PR

https://github.com/CrimsonCrossBunker/CCB-Docs/pull/47 (draft; publish only after source acceptance).

#### Affected documentation IDs

cpp.lua-bridge

#### Generated reference impact

Generated native references are deferred to batch acceptance; no generated inventories were hand-edited.


#### Additional context

Keep draft; do not merge before morning review.