### PR TITLE
Improve Lua SDK setup, upgrade comparison and checker diagnostics

### DIFF
--- a/tools/lua_api/README.md
+++ b/tools/lua_api/README.md
@@ -116,7 +116,8 @@ python3 tools/lua_api/mod_sdk.py compare /path/OldMod /path/NewVersionScaffold
 ```
 
 The JSON report shows the two SDK identities and added, removed, or changed
-class/field/function declarations, including parameter and return annotations.
+class/field/function and alias declarations, including parameter/return annotations
+and consecutive multiline alias members (`---|`).
 It never overwrites either project. Review changed declarations, read the game's
 release/migration notes, then intentionally update the editor SDK and rerun static
 and affected runtime checks. Unchanged signatures do not prove behavior parity;

--- a/tools/lua_api/README.md
+++ b/tools/lua_api/README.md
@@ -59,6 +59,20 @@ editor metadata, not a runtime manifest or executable content; omit them with
 major version before registering content. An exact declaration revision check
 is an author upgrade aid, not a new mandatory runtime version system.
 
+## Add an editor SDK to an existing Mod
+
+```sh
+python3 tools/lua_api/mod_sdk.py init /path/ExistingMod \
+  --declarations /path/game/data/lua/types/ccb_platform_v1.d.lua
+```
+
+This adds the frozen `.ccb-sdk/` snapshot and `.luarc.json` editor configuration
+used by the scaffolder. It does not execute or modify author Lua files. Existing SDKs or
+editor configuration are never overwritten; keep or integrate them manually.
+A failed initialization removes only files created by that attempt. Without
+`--declarations`, the tool snapshots its own checkout's declaration file.
+The added JSON files configure the editor and are not runtime manifests.
+
 ## Diagnose a Mod
 
 With LuaLS installed (the CI/editor gate is tested with 3.19.1):

--- a/tools/lua_api/README.md
+++ b/tools/lua_api/README.md
@@ -84,7 +84,18 @@ loading, and exercise the affected behavior for runtime acceptance.
 
 ## Review an API upgrade
 
-Create a separate scaffold with the target version's declarations, then compare:
+Compare directly with the target game's bundled declaration file:
+
+```sh
+python3 tools/lua_api/mod_sdk.py compare-release /path/MyMod \
+  --declarations /path/TargetGame/data/lua/types/ccb_platform_v1.d.lua
+```
+
+This requires no second scaffold, never executes Lua, and leaves both the Mod's
+SDK and the target file unchanged. The report records the absolute target path
+and declaration hash; you explicitly choose which game package to inspect.
+
+Alternatively, compare two existing SDK snapshots:
 
 ```sh
 python3 tools/lua_api/mod_sdk.py compare /path/OldMod /path/NewVersionScaffold

--- a/tools/lua_api/mod_sdk.py
+++ b/tools/lua_api/mod_sdk.py
@@ -165,6 +165,11 @@ def check_mod(mod: Path, language_server: str) -> list[str]:
              "--logpath=" + directory],
             cwd=mod, capture_output=True, text=True, timeout=120,
         )
+        if result.returncode < 0:
+            raise RuntimeError(
+                f"LuaLS exited {result.returncode} before completing diagnostics: " +
+                (result.stderr or result.stdout)[-2000:]
+            )
         report = Path(directory) / "check.json"
         if not report.is_file():
             raise RuntimeError(
@@ -179,6 +184,20 @@ def check_mod(mod: Path, language_server: str) -> list[str]:
             raise ValueError("LuaLS report must map file URIs to diagnostics")
         diagnostics = []
         for uri, entries in sorted(data.items()):
+            if not isinstance(entries, list):
+                raise ValueError(f"LuaLS report for {uri}: expected diagnostic array")
+            for index, entry in enumerate(entries):
+                location = f"LuaLS report for {uri}, diagnostic {index}"
+                if not isinstance(entry, dict) or not isinstance(entry.get("message"), str):
+                    raise ValueError(f"{location}: missing diagnostic message")
+                span = entry.get("range")
+                start = span.get("start") if isinstance(span, dict) else None
+                if not isinstance(start, dict):
+                    raise ValueError(f"{location}: missing start position")
+                if any(not isinstance(start.get(key), int)
+                       or isinstance(start[key], bool) or start[key] < 0
+                       for key in ("line", "character")):
+                    raise ValueError(f"{location}: invalid start position")
             path = uri
             if uri.startswith("file:"):
                 parsed = urlparse(uri)

--- a/tools/lua_api/mod_sdk.py
+++ b/tools/lua_api/mod_sdk.py
@@ -57,51 +57,58 @@ def write_editor_files(target: Path, declarations: Path) -> None:
     )
 
 
-
 def initialize_sdk(mod: Path, declarations: Path) -> dict:
-    """Add editor metadata to an existing directory without replacing author files."""
+    """Add editor metadata without replacing existing author files."""
     mod = mod.resolve(strict=True)
     if not mod.is_dir():
         raise ValueError(f"{mod}: expected an existing Mod directory")
     sdk = mod / SDK_DIRECTORY
     for destination in (sdk, mod / ".luarc.json"):
         if destination.exists() or destination.is_symlink():
-            raise ValueError(f"{destination}: already exists; keep or integrate the existing editor setup")
+            raise ValueError(
+                f"{destination}: already exists; "
+                "keep or integrate the existing editor setup")
     with tempfile.TemporaryDirectory(prefix="ccb-sdk-init-") as directory:
         staging = Path(directory)
         write_editor_files(staging, declarations)
         created = []
-        sdk.mkdir()  # Exclusive reservation; never adopt an existing directory.
+        # Exclusive reservation; never adopt an existing directory.
+        sdk.mkdir()
         try:
-            for relative in (Path(SDK_DIRECTORY) / "ccb.lua",
-                             Path(SDK_DIRECTORY) / "version.json", Path(".luarc.json")):
+            for relative in (
+                    Path(SDK_DIRECTORY) / "ccb.lua",
+                    Path(SDK_DIRECTORY) / "version.json",
+                    Path(".luarc.json")):
                 destination = mod / relative
                 with destination.open("xb") as stream:
                     created.append(destination)
                     stream.write((staging / relative).read_bytes())
             return read_sdk(mod)[0]
         except BaseException:
-            # Remove only files created by this attempt; preserve a raced config.
+            # Remove only files created by this attempt; preserve a raced
+            # config.
             for destination in reversed(created):
                 destination.unlink(missing_ok=True)
             try:
                 sdk.rmdir()
             except OSError:
-                pass  # Do not remove any unexpected files added by another process.
+                # Do not remove any unexpected files added by another process.
+                pass
             raise
 
 
 def read_sdk(mod: Path) -> tuple[dict, str]:
     sdk = mod / SDK_DIRECTORY
     metadata = json.loads((sdk / "version.json").read_text(encoding="utf-8"))
-    if (not isinstance(metadata, dict)
-            or type(metadata.get("schema_version")) is not int
-            or metadata["schema_version"] != 1):
+    if (not isinstance(metadata, dict) or
+            type(metadata.get("schema_version")) is not int or
+            metadata["schema_version"] != 1):
         raise ValueError(f"{sdk}: unsupported SDK metadata format")
-    if (type(metadata.get("platform_version")) is not int
-            or metadata["platform_version"] != 1
-            or metadata.get("lua_version") != "5.4"):
-        raise ValueError(f"{sdk}: unsupported Platform/Lua version in SDK metadata")
+    if (type(metadata.get("platform_version")) is not int or
+            metadata["platform_version"] != 1 or
+            metadata.get("lua_version") != "5.4"):
+        raise ValueError(
+            f"{sdk}: unsupported Platform/Lua version in SDK metadata")
     contents = (sdk / "ccb.lua").read_bytes()
     if metadata.get("declarations_sha256") != digest(contents):
         raise ValueError(f"{sdk}: declaration checksum mismatch")
@@ -163,8 +170,8 @@ def compare_release(mod: Path, declarations: Path) -> dict:
     old_metadata, old_text = read_sdk(mod)
     content = declarations.read_bytes()
     new_text = content.decode("utf-8")
-    if ("---@class CcbPlatformV1" not in new_text
-            or "return ccb" not in new_text):
+    if ("---@class CcbPlatformV1" not in new_text or
+            "return ccb" not in new_text):
         raise ValueError("expected CCB Platform v1 LuaLS declarations")
     new_metadata = {
         "schema_version": 1,
@@ -213,7 +220,8 @@ def check_mod(mod: Path, language_server: str) -> list[str]:
         )
         if result.returncode < 0:
             raise RuntimeError(
-                f"LuaLS exited {result.returncode} before completing diagnostics: " +
+                f"LuaLS exited {result.returncode} "
+                "before completing diagnostics: " +
                 (result.stderr or result.stdout)[-2000:]
             )
         report = Path(directory) / "check.json"
@@ -231,17 +239,20 @@ def check_mod(mod: Path, language_server: str) -> list[str]:
         diagnostics = []
         for uri, entries in sorted(data.items()):
             if not isinstance(entries, list):
-                raise ValueError(f"LuaLS report for {uri}: expected diagnostic array")
+                raise ValueError(
+                    f"LuaLS report for {uri}: expected diagnostic array")
             for index, entry in enumerate(entries):
                 location = f"LuaLS report for {uri}, diagnostic {index}"
-                if not isinstance(entry, dict) or not isinstance(entry.get("message"), str):
+                if not isinstance(
+                        entry, dict) or not isinstance(
+                        entry.get("message"), str):
                     raise ValueError(f"{location}: missing diagnostic message")
                 span = entry.get("range")
                 start = span.get("start") if isinstance(span, dict) else None
                 if not isinstance(start, dict):
                     raise ValueError(f"{location}: missing start position")
-                if any(not isinstance(start.get(key), int)
-                       or isinstance(start[key], bool) or start[key] < 0
+                if any(not isinstance(start.get(key), int) or
+                       isinstance(start[key], bool) or start[key] < 0
                        for key in ("line", "character")):
                     raise ValueError(f"{location}: invalid start position")
             path = uri
@@ -271,10 +282,14 @@ def check_mod(mod: Path, language_server: str) -> list[str]:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     commands = parser.add_subparsers(dest="command", required=True)
-    initialize = commands.add_parser("init", help="add an editor SDK to an existing Mod directory")
+    initialize = commands.add_parser(
+        "init", help="add an editor SDK to an existing Mod directory")
     initialize.add_argument("mod", type=Path)
-    initialize.add_argument("--declarations", type=Path, default=DEFAULT_DECLARATIONS,
-                            help="declaration file from the target game package")
+    initialize.add_argument(
+        "--declarations",
+        type=Path,
+        default=DEFAULT_DECLARATIONS,
+        help="declaration file from the target game package")
     compare = commands.add_parser(
         "compare", help="compare two Mod SDK snapshots"
     )
@@ -295,7 +310,8 @@ def main() -> int:
     try:
         if args.command == "init":
             metadata = initialize_sdk(args.mod, args.declarations)
-            print(json.dumps({"mod": str(args.mod.resolve()), "sdk": metadata}, indent=2))
+            print(json.dumps(
+                {"mod": str(args.mod.resolve()), "sdk": metadata}, indent=2))
             return 0
         if args.command == "compare":
             print(json.dumps(compare_sdks(args.old, args.new),

--- a/tools/lua_api/mod_sdk.py
+++ b/tools/lua_api/mod_sdk.py
@@ -60,8 +60,14 @@ def write_editor_files(target: Path, declarations: Path) -> None:
 def read_sdk(mod: Path) -> tuple[dict, str]:
     sdk = mod / SDK_DIRECTORY
     metadata = json.loads((sdk / "version.json").read_text(encoding="utf-8"))
-    if not isinstance(metadata, dict) or metadata.get("schema_version") != 1:
+    if (not isinstance(metadata, dict)
+            or type(metadata.get("schema_version")) is not int
+            or metadata["schema_version"] != 1):
         raise ValueError(f"{sdk}: unsupported SDK metadata format")
+    if (type(metadata.get("platform_version")) is not int
+            or metadata["platform_version"] != 1
+            or metadata.get("lua_version") != "5.4"):
+        raise ValueError(f"{sdk}: unsupported Platform/Lua version in SDK metadata")
     contents = (sdk / "ccb.lua").read_bytes()
     if metadata.get("declarations_sha256") != digest(contents):
         raise ValueError(f"{sdk}: declaration checksum mismatch")

--- a/tools/lua_api/mod_sdk.py
+++ b/tools/lua_api/mod_sdk.py
@@ -113,8 +113,13 @@ def declaration_surface(text: str) -> dict[str, list[str]]:
     result: dict[str, list[str]] = {}
     owner = ""
     annotations: list[str] = []
+    alias_lines: list[str] | None = None
     for line in text.splitlines():
         line = line.strip()
+        if line.startswith("---|") and alias_lines is not None:
+            alias_lines.append(line)
+            continue
+        alias_lines = None
         match = re.match(r"---@class\s+(\w+)", line)
         if match:
             owner = match[1]
@@ -123,7 +128,8 @@ def declaration_surface(text: str) -> dict[str, list[str]]:
             continue
         match = re.match(r"---@alias\s+(\w+)", line)
         if match:
-            result[f"alias {match[1]}"] = [line]
+            alias_lines = [line]
+            result[f"alias {match[1]}"] = alias_lines
             annotations = []
             continue
         if line.startswith("---@operator") and owner:

--- a/tools/lua_api/mod_sdk.py
+++ b/tools/lua_api/mod_sdk.py
@@ -23,7 +23,7 @@ def digest(contents: bytes) -> str:
 
 
 def write_editor_files(target: Path, declarations: Path) -> None:
-    """Write only inside create_lua_mod's unpublished staging directory."""
+    """Write only inside an unpublished scaffold or SDK staging directory."""
     contents = declarations.read_bytes()
     text = contents.decode("utf-8")
     if "---@class CcbPlatformV1" not in text or "return ccb" not in text:
@@ -55,6 +55,40 @@ def write_editor_files(target: Path, declarations: Path) -> None:
     (target / ".luarc.json").write_text(
         json.dumps(settings, indent=2) + "\n", encoding="utf-8"
     )
+
+
+
+def initialize_sdk(mod: Path, declarations: Path) -> dict:
+    """Add editor metadata to an existing directory without replacing author files."""
+    mod = mod.resolve(strict=True)
+    if not mod.is_dir():
+        raise ValueError(f"{mod}: expected an existing Mod directory")
+    sdk = mod / SDK_DIRECTORY
+    for destination in (sdk, mod / ".luarc.json"):
+        if destination.exists() or destination.is_symlink():
+            raise ValueError(f"{destination}: already exists; keep or integrate the existing editor setup")
+    with tempfile.TemporaryDirectory(prefix="ccb-sdk-init-") as directory:
+        staging = Path(directory)
+        write_editor_files(staging, declarations)
+        created = []
+        sdk.mkdir()  # Exclusive reservation; never adopt an existing directory.
+        try:
+            for relative in (Path(SDK_DIRECTORY) / "ccb.lua",
+                             Path(SDK_DIRECTORY) / "version.json", Path(".luarc.json")):
+                destination = mod / relative
+                with destination.open("xb") as stream:
+                    created.append(destination)
+                    stream.write((staging / relative).read_bytes())
+            return read_sdk(mod)[0]
+        except BaseException:
+            # Remove only files created by this attempt; preserve a raced config.
+            for destination in reversed(created):
+                destination.unlink(missing_ok=True)
+            try:
+                sdk.rmdir()
+            except OSError:
+                pass  # Do not remove any unexpected files added by another process.
+            raise
 
 
 def read_sdk(mod: Path) -> tuple[dict, str]:
@@ -231,6 +265,10 @@ def check_mod(mod: Path, language_server: str) -> list[str]:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     commands = parser.add_subparsers(dest="command", required=True)
+    initialize = commands.add_parser("init", help="add an editor SDK to an existing Mod directory")
+    initialize.add_argument("mod", type=Path)
+    initialize.add_argument("--declarations", type=Path, default=DEFAULT_DECLARATIONS,
+                            help="declaration file from the target game package")
     compare = commands.add_parser(
         "compare", help="compare two Mod SDK snapshots"
     )
@@ -249,6 +287,10 @@ def main() -> int:
     check.add_argument("--language-server", default="lua-language-server")
     args = parser.parse_args()
     try:
+        if args.command == "init":
+            metadata = initialize_sdk(args.mod, args.declarations)
+            print(json.dumps({"mod": str(args.mod.resolve()), "sdk": metadata}, indent=2))
+            return 0
         if args.command == "compare":
             print(json.dumps(compare_sdks(args.old, args.new),
                              ensure_ascii=False, indent=2))

--- a/tools/lua_api/mod_sdk.py
+++ b/tools/lua_api/mod_sdk.py
@@ -109,6 +109,31 @@ def declaration_surface(text: str) -> dict[str, list[str]]:
 def compare_sdks(old: Path, new: Path) -> dict:
     old_metadata, old_text = read_sdk(old)
     new_metadata, new_text = read_sdk(new)
+    return compare_declarations(old_metadata, old_text, new_metadata, new_text)
+
+
+def compare_release(mod: Path, declarations: Path) -> dict:
+    """Compare against an explicitly selected game file, without a scaffold."""
+    old_metadata, old_text = read_sdk(mod)
+    content = declarations.read_bytes()
+    new_text = content.decode("utf-8")
+    if ("---@class CcbPlatformV1" not in new_text
+            or "return ccb" not in new_text):
+        raise ValueError("expected CCB Platform v1 LuaLS declarations")
+    new_metadata = {
+        "schema_version": 1,
+        "platform_version": 1,
+        "lua_version": "5.4",
+        "declarations_sha256": digest(content),
+    }
+    report = compare_declarations(
+        old_metadata, old_text, new_metadata, new_text)
+    report["target_declarations"] = str(declarations.resolve())
+    return report
+
+
+def compare_declarations(old_metadata: dict, old_text: str,
+                         new_metadata: dict, new_text: str) -> dict:
     before = declaration_surface(old_text)
     after = declaration_surface(new_text)
     return {
@@ -186,6 +211,12 @@ def main() -> int:
     )
     compare.add_argument("old", type=Path)
     compare.add_argument("new", type=Path)
+    release = commands.add_parser(
+        "compare-release", help="compare an SDK with target game declarations"
+    )
+    release.add_argument("mod", type=Path)
+    release.add_argument("--declarations", type=Path, required=True,
+                         help="declaration file from the target game package")
     check = commands.add_parser(
         "check", help="report LuaLS warnings and errors"
     )
@@ -195,6 +226,10 @@ def main() -> int:
     try:
         if args.command == "compare":
             print(json.dumps(compare_sdks(args.old, args.new),
+                             ensure_ascii=False, indent=2))
+            return 0
+        if args.command == "compare-release":
+            print(json.dumps(compare_release(args.mod, args.declarations),
                              ensure_ascii=False, indent=2))
             return 0
         diagnostics = check_mod(args.mod, args.language_server)

--- a/tools/lua_api/test_mod_sdk.py
+++ b/tools/lua_api/test_mod_sdk.py
@@ -83,6 +83,40 @@ class ModSdkTest(unittest.TestCase):
             self.assertEqual(report["added"], ["CcbPlatformV1.service"])
             self.assertEqual((before / ".ccb-sdk/ccb.lua").read_bytes(), saved)
 
+    def test_compare_release_needs_no_second_scaffold_and_writes_nothing(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            mod = self.make_sdk(root, "installed")
+            release = root / "target-game.d.lua"
+            release.write_text(DECLARATIONS.replace(
+                "---@param name string", "---@param name integer"
+            ), encoding="utf-8")
+            paths = [mod / ".ccb-sdk/ccb.lua", mod / ".ccb-sdk/version.json",
+                     mod / ".luarc.json", release]
+            before = {path: path.read_bytes() for path in paths}
+            report = mod_sdk.compare_release(mod, release)
+            self.assertIn("Runtime.hello", report["changed"])
+            self.assertEqual(
+                report["target_declarations"], str(release.resolve()))
+            self.assertEqual(report["new"]["declarations_sha256"],
+                             mod_sdk.digest(before[release]))
+            self.assertEqual(
+                {path: path.read_bytes() for path in paths}, before)
+            self.assertFalse((root / ".ccb-sdk").exists())
+
+    def test_compare_release_rejects_invalid_target_and_tampered_sdk(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            mod = self.make_sdk(root, "installed")
+            release = root / "target-game.d.lua"
+            release.write_text("return {}", encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "Platform v1"):
+                mod_sdk.compare_release(mod, release)
+            release.write_text(DECLARATIONS, encoding="utf-8")
+            (mod / ".ccb-sdk/ccb.lua").write_text("changed", encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "checksum"):
+                mod_sdk.compare_release(mod, release)
+
     def test_source_line_movement_does_not_change_signatures(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/tools/lua_api/test_mod_sdk.py
+++ b/tools/lua_api/test_mod_sdk.py
@@ -127,6 +127,43 @@ class ModSdkTest(unittest.TestCase):
             self.assertNotEqual(report["old"]["declarations_sha256"],
                                 report["new"]["declarations_sha256"])
 
+    def test_partial_diagnostics_cannot_hide_a_checker_signal_failure(self):
+        with tempfile.TemporaryDirectory() as directory:
+            mod = self.make_sdk(Path(directory), "example")
+
+            def crash(command, **kwargs):
+                log = next(x.split("=", 1)[1] for x in command
+                           if x.startswith("--logpath="))
+                report = {"file:///example.lua": [{
+                    "range": {"start": {"line": 0, "character": 0}},
+                    "message": "partial diagnostic",
+                }]}
+                (Path(log) / "check.json").write_text(json.dumps(report), encoding="utf-8")
+                return subprocess.CompletedProcess(command, -11, "", "crash")
+
+            with patch.object(mod_sdk.subprocess, "run", side_effect=crash):
+                with self.assertRaisesRegex(RuntimeError, "exited -11"):
+                    mod_sdk.check_mod(mod, "luals")
+
+    def test_malformed_diagnostic_has_a_report_error_instead_of_a_traceback(self):
+        cases = [None, [None], [{"message": "missing location"}],
+                 [{"message": "bad position", "range": {
+                     "start": {"line": True, "character": 0}}}]]
+        with tempfile.TemporaryDirectory() as directory:
+            mod = self.make_sdk(Path(directory), "example")
+            for entries in cases:
+                def malformed(command, **kwargs):
+                    log = next(x.split("=", 1)[1] for x in command
+                               if x.startswith("--logpath="))
+                    (Path(log) / "check.json").write_text(
+                        json.dumps({"file:///example.lua": entries}), encoding="utf-8")
+                    return subprocess.CompletedProcess(command, 0, "", "")
+
+                with self.subTest(entries=entries), patch.object(
+                        mod_sdk.subprocess, "run", side_effect=malformed):
+                    with self.assertRaisesRegex(ValueError, "LuaLS report for"):
+                        mod_sdk.check_mod(mod, "luals")
+
     def test_checker_crash_is_not_a_clean_report(self):
         with tempfile.TemporaryDirectory() as directory:
             mod = self.make_sdk(Path(directory), "example")

--- a/tools/lua_api/test_mod_sdk.py
+++ b/tools/lua_api/test_mod_sdk.py
@@ -117,6 +117,20 @@ class ModSdkTest(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "checksum"):
                 mod_sdk.compare_release(mod, release)
 
+    def test_sdk_metadata_must_identify_the_supported_platform_and_lua(self):
+        with tempfile.TemporaryDirectory() as directory:
+            mod = self.make_sdk(Path(directory), "example")
+            metadata_path = mod / ".ccb-sdk/version.json"
+            original = json.loads(metadata_path.read_text(encoding="utf-8"))
+            for key, value in (("schema_version", True), ("platform_version", True),
+                               ("platform_version", 5), ("lua_version", "5.3"),
+                               ("lua_version", None)):
+                with self.subTest(key=key, value=value):
+                    changed = dict(original, **{key: value})
+                    metadata_path.write_text(json.dumps(changed), encoding="utf-8")
+                    with self.assertRaisesRegex(ValueError, "unsupported"):
+                        mod_sdk.read_sdk(mod)
+
     def test_source_line_movement_does_not_change_signatures(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/tools/lua_api/test_mod_sdk.py
+++ b/tools/lua_api/test_mod_sdk.py
@@ -55,7 +55,9 @@ class ModSdkTest(unittest.TestCase):
             metadata = mod_sdk.initialize_sdk(mod, source)
             self.assertEqual(metadata, mod_sdk.read_sdk(mod)[0])
             self.assertEqual(main.read_bytes(), before)
-            self.assertEqual((mod / ".ccb-sdk/ccb.lua").read_bytes(), source.read_bytes())
+            self.assertEqual(
+                (mod / ".ccb-sdk/ccb.lua").read_bytes(),
+                source.read_bytes())
             with self.assertRaisesRegex(ValueError, "already exists"):
                 mod_sdk.initialize_sdk(mod, source)
 
@@ -77,7 +79,8 @@ class ModSdkTest(unittest.TestCase):
 
             def raced_config(path, mode="r", *args, **kwargs):
                 if path == config and mode == "xb":
-                    with original_open(config, "w", encoding="utf-8") as stream:
+                    with original_open(
+                            config, "w", encoding="utf-8") as stream:
                         stream.write("concurrent author settings")
                 return original_open(path, mode, *args, **kwargs)
 
@@ -149,15 +152,21 @@ class ModSdkTest(unittest.TestCase):
                 {path: path.read_bytes() for path in paths}, before)
             self.assertFalse((root / ".ccb-sdk").exists())
 
-    def test_compare_reports_multiline_alias_members_without_mixing_aliases(self):
+    def test_compare_reports_multiline_alias_members_without_mixing_aliases(
+            self):
         aliases = ("\n---@alias EquipmentError\n"
                    "---| 'stale_runtime'\n---| 'wrong_holder'\n"
                    "\n---@alias Operation\n---| 'wield'\n---| 'wear'\n")
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             before = self.make_sdk(root, "before", DECLARATIONS + aliases)
-            after = self.make_sdk(root, "after", DECLARATIONS + aliases.replace(
-                "---| 'wrong_holder'", "---| 'invalid_holder'"))
+            after = self.make_sdk(
+                root,
+                "after",
+                DECLARATIONS +
+                aliases.replace(
+                    "---| 'wrong_holder'",
+                    "---| 'invalid_holder'"))
             report = mod_sdk.compare_sdks(before, after)
             self.assertEqual(set(report["changed"]), {"alias EquipmentError"})
             difference = report["changed"]["alias EquipmentError"]
@@ -183,12 +192,14 @@ class ModSdkTest(unittest.TestCase):
             mod = self.make_sdk(Path(directory), "example")
             metadata_path = mod / ".ccb-sdk/version.json"
             original = json.loads(metadata_path.read_text(encoding="utf-8"))
-            for key, value in (("schema_version", True), ("platform_version", True),
+            for key, value in (("schema_version", True),
+                               ("platform_version", True),
                                ("platform_version", 5), ("lua_version", "5.3"),
                                ("lua_version", None)):
                 with self.subTest(key=key, value=value):
                     changed = dict(original, **{key: value})
-                    metadata_path.write_text(json.dumps(changed), encoding="utf-8")
+                    metadata_path.write_text(
+                        json.dumps(changed), encoding="utf-8")
                     with self.assertRaisesRegex(ValueError, "unsupported"):
                         mod_sdk.read_sdk(mod)
 
@@ -213,14 +224,16 @@ class ModSdkTest(unittest.TestCase):
                     "range": {"start": {"line": 0, "character": 0}},
                     "message": "partial diagnostic",
                 }]}
-                (Path(log) / "check.json").write_text(json.dumps(report), encoding="utf-8")
+                (Path(log) / "check.json").write_text(
+                    json.dumps(report), encoding="utf-8")
                 return subprocess.CompletedProcess(command, -11, "", "crash")
 
             with patch.object(mod_sdk.subprocess, "run", side_effect=crash):
                 with self.assertRaisesRegex(RuntimeError, "exited -11"):
                     mod_sdk.check_mod(mod, "luals")
 
-    def test_malformed_diagnostic_has_a_report_error_instead_of_a_traceback(self):
+    def test_malformed_diagnostic_has_a_report_error_instead_of_a_traceback(
+            self):
         cases = [None, [None], [{"message": "missing location"}],
                  [{"message": "bad position", "range": {
                      "start": {"line": True, "character": 0}}}]]
@@ -230,13 +243,14 @@ class ModSdkTest(unittest.TestCase):
                 def malformed(command, **kwargs):
                     log = next(x.split("=", 1)[1] for x in command
                                if x.startswith("--logpath="))
-                    (Path(log) / "check.json").write_text(
-                        json.dumps({"file:///example.lua": entries}), encoding="utf-8")
+                    (Path(log) / "check.json").write_text(json.dumps(
+                        {"file:///example.lua": entries}), encoding="utf-8")
                     return subprocess.CompletedProcess(command, 0, "", "")
 
                 with self.subTest(entries=entries), patch.object(
                         mod_sdk.subprocess, "run", side_effect=malformed):
-                    with self.assertRaisesRegex(ValueError, "LuaLS report for"):
+                    with self.assertRaisesRegex(
+                            ValueError, "LuaLS report for"):
                         mod_sdk.check_mod(mod, "luals")
 
     def test_checker_crash_is_not_a_clean_report(self):

--- a/tools/lua_api/test_mod_sdk.py
+++ b/tools/lua_api/test_mod_sdk.py
@@ -149,6 +149,22 @@ class ModSdkTest(unittest.TestCase):
                 {path: path.read_bytes() for path in paths}, before)
             self.assertFalse((root / ".ccb-sdk").exists())
 
+    def test_compare_reports_multiline_alias_members_without_mixing_aliases(self):
+        aliases = ("\n---@alias EquipmentError\n"
+                   "---| 'stale_runtime'\n---| 'wrong_holder'\n"
+                   "\n---@alias Operation\n---| 'wield'\n---| 'wear'\n")
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            before = self.make_sdk(root, "before", DECLARATIONS + aliases)
+            after = self.make_sdk(root, "after", DECLARATIONS + aliases.replace(
+                "---| 'wrong_holder'", "---| 'invalid_holder'"))
+            report = mod_sdk.compare_sdks(before, after)
+            self.assertEqual(set(report["changed"]), {"alias EquipmentError"})
+            difference = report["changed"]["alias EquipmentError"]
+            self.assertIn("---| 'wrong_holder'", difference["before"])
+            self.assertIn("---| 'invalid_holder'", difference["after"])
+            self.assertNotIn("---| 'wear'", difference["after"])
+
     def test_compare_release_rejects_invalid_target_and_tampered_sdk(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/tools/lua_api/test_mod_sdk.py
+++ b/tools/lua_api/test_mod_sdk.py
@@ -42,6 +42,51 @@ class ModSdkTest(unittest.TestCase):
         mod_sdk.write_editor_files(mod, source)
         return mod
 
+    def test_initialize_existing_mod_preserves_author_files(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "target.d.lua"
+            source.write_text(DECLARATIONS, encoding="utf-8")
+            mod = root / "existing"
+            mod.mkdir()
+            main = mod / "main.lua"
+            main.write_text('error("do not execute")', encoding="utf-8")
+            before = main.read_bytes()
+            metadata = mod_sdk.initialize_sdk(mod, source)
+            self.assertEqual(metadata, mod_sdk.read_sdk(mod)[0])
+            self.assertEqual(main.read_bytes(), before)
+            self.assertEqual((mod / ".ccb-sdk/ccb.lua").read_bytes(), source.read_bytes())
+            with self.assertRaisesRegex(ValueError, "already exists"):
+                mod_sdk.initialize_sdk(mod, source)
+
+    def test_initialize_refuses_existing_config_and_cleans_partial_sdk(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "target.d.lua"
+            source.write_text(DECLARATIONS, encoding="utf-8")
+            mod = root / "existing"
+            mod.mkdir()
+            config = mod / ".luarc.json"
+            config.write_text("author settings", encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "already exists"):
+                mod_sdk.initialize_sdk(mod, source)
+            self.assertFalse((mod / ".ccb-sdk").exists())
+            self.assertEqual(config.read_text(), "author settings")
+            config.unlink()
+            original_open = Path.open
+
+            def raced_config(path, mode="r", *args, **kwargs):
+                if path == config and mode == "xb":
+                    with original_open(config, "w", encoding="utf-8") as stream:
+                        stream.write("concurrent author settings")
+                return original_open(path, mode, *args, **kwargs)
+
+            with patch.object(Path, "open", raced_config):
+                with self.assertRaises(FileExistsError):
+                    mod_sdk.initialize_sdk(mod, source)
+            self.assertFalse((mod / ".ccb-sdk").exists())
+            self.assertEqual(config.read_text(), "concurrent author settings")
+
     def test_snapshot_survives_source_changes_and_project_move(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

Improves three parts of the existing Lua Mod SDK workflow:

- init adds a declaration snapshot and editor configuration to an existing Mod directory without replacing author Lua files or existing SDK/config paths. Staged writes roll back only files created by this operation, including when another writer races configuration creation.
- compare-release compares the pinned SDK against a chosen game's declarations without creating another Mod or updating the SDK. Comparison includes contiguous multiline alias members as well as normal declaration records.
- LuaLS report handling rejects signal failures even when partial diagnostics exist, validates diagnostic shapes, and reports actionable errors. SDK metadata requires exact schema/Platform integers, Lua 5.4 and a matching checksum.

Validation: 13 focused ModSdkTest tests passed (0.012 s), plus git diff --check. Mocked report tests do not represent a real LuaLS run. No native build, game or broad acceptance ran. Declaration comparison does not prove native or save compatibility.

#### Responsible human

@LYHGLYTX

#### Documentation impact

Updates the Lua-first contract or author tooling guidance for the behavior described above.

#### Related CCB-Docs PR

https://github.com/CrimsonCrossBunker/CCB-Docs/pull/47 (draft; publish only after source acceptance).

#### Affected documentation IDs

cpp.lua-bridge

#### Generated reference impact

Generated native references are deferred to batch acceptance; no generated inventories were hand-edited.


#### Additional context

Keep draft; do not merge before morning review.