### PR TITLE
Add Lua runtime and deferred content text translation

### DIFF
--- a/ai/lua-first-roadmap.yml
+++ b/ai/lua-first-roadmap.yml
@@ -663,14 +663,14 @@ capabilities:
   - id: platform-internationalization
     phase: internationalization
     status: in_progress
-    target_surface: "Draft runtime text helpers services.translate and services.translate_plural reuse native catalogs; literal gettext extraction is implemented separately from deferred content translation and catalog lifecycle work."
+    target_surface: "Draft runtime text helpers reuse native catalogs; Item names/descriptions also accept deferred content.text/plural_text values. Literal gettext extraction covers both routes; native/locale acceptance and wider content/catalog lifecycle work remain pending."
     legacy_dependency: none
-    evidence: [src/translation_manager.cpp, src/translations.h, src/lua_platform_world_content.cpp, tests/translation_system_test.cpp, data/lua/types/ccb_platform_v1.d.lua]
+    evidence: [src/translation_manager.cpp, src/lua_platform_runtime_services.cpp, src/lua_platform_content_items.cpp, tests/lua_platform_translation_test.cpp, tests/lua_platform_content_translation_test.cpp, tools/lua_api/extract_translations.py, data/lua/types/ccb_platform_v1.d.lua]
     verification: not_run
     next_actions:
       - Runtime helper and extraction source is an independent draft; focused Python extraction tests passed, but no native build or runtime acceptance was executed.
       - Review the draft API and refresh generated inventories at acceptance; verify real catalogs, context, plural rules, language changes and nonlocalized builds before claiming support.
-      - Deferred native content translations and catalog lifecycle remain outside this initial slice; do not make it a platform-capability-closure or final-acceptance dependency.
+      - Native regression source covers Item deferred text, inheritance, literal replacement and static fingerprints; other content builders, metadata translation and catalog lifecycle remain deferred. This slice is not a platform-capability-closure or final-acceptance dependency.
   - id: author-experience
     phase: tooling
     status: in_progress

--- a/ai/lua-first-roadmap.yml
+++ b/ai/lua-first-roadmap.yml
@@ -662,12 +662,15 @@ capabilities:
     next_actions: [Evaluate candidate shared helpers in an independent design and acceptance batch; add declarations, examples, and tests only after a public shape is chosen; do not make this capability a platform-capability-closure or final-acceptance dependency.]
   - id: platform-internationalization
     phase: internationalization
-    status: planned
-    target_surface: "Recommended future author-facing internationalization: a Lua translation surface and extraction/plural/context workflow aligned with native text operations; exact function names and public shape remain to be designed."
+    status: in_progress
+    target_surface: "Draft runtime text helpers services.translate and services.translate_plural reuse native catalogs; literal gettext extraction is implemented separately from deferred content translation and catalog lifecycle work."
     legacy_dependency: none
     evidence: [src/translation_manager.cpp, src/translations.h, src/lua_platform_world_content.cpp, tests/translation_system_test.cpp, data/lua/types/ccb_platform_v1.d.lua]
     verification: not_run
-    next_actions: [Design and implement internationalization in an independent follow-on batch with its own extraction, declaration, example, test, and acceptance evidence; do not make it a platform-capability-closure or final-acceptance dependency.]
+    next_actions:
+      - Runtime helper and extraction source is an independent draft; focused Python extraction tests passed, but no native build or runtime acceptance was executed.
+      - Review the draft API and refresh generated inventories at acceptance; verify real catalogs, context, plural rules, language changes and nonlocalized builds before claiming support.
+      - Deferred native content translations and catalog lifecycle remain outside this initial slice; do not make it a platform-capability-closure or final-acceptance dependency.
   - id: author-experience
     phase: tooling
     status: in_progress

--- a/ai/lua-first-roadmap.yml
+++ b/ai/lua-first-roadmap.yml
@@ -663,7 +663,7 @@ capabilities:
   - id: platform-internationalization
     phase: internationalization
     status: in_progress
-    target_surface: "Draft runtime text helpers reuse native catalogs; Item names/descriptions also accept deferred content.text/plural_text values. Literal gettext extraction covers both routes; native/locale acceptance and wider content/catalog lifecycle work remain pending."
+    target_surface: "Draft runtime text helpers reuse native catalogs; Item names/descriptions and singular Skill/SkillDisplay texts also accept deferred text values. Literal gettext extraction covers both routes; native/locale acceptance and wider content/catalog lifecycle work remain pending."
     legacy_dependency: none
     evidence: [src/translation_manager.cpp, src/lua_platform_runtime_services.cpp, src/lua_platform_content_items.cpp, tests/lua_platform_translation_test.cpp, tests/lua_platform_content_translation_test.cpp, tools/lua_api/extract_translations.py, data/lua/types/ccb_platform_v1.d.lua]
     verification: not_run

--- a/data/lua/LUA_FIRST_PLATFORM.md
+++ b/data/lua/LUA_FIRST_PLATFORM.md
@@ -461,12 +461,29 @@ The independent draft exposes `ccb.services.translate(text, context?)` and
 `world_ready`. Both return strings using the current native catalog. Literal
 calls can be extracted by `tools/lua_api/extract_translations.py`; its README
 contains the author example and catalog limitations. This is source-level work,
-not completed native acceptance. Deferred content-name translations, metadata
-translations and live catalog reload are outside this initial slice.
+not completed native acceptance. Metadata translations, other content builders
+and live catalog reload remain outside this slice.
+
+For Item names/descriptions, the draft also accepts immutable `LocalizedText`
+values from `ccb.content.text(text, context?)` and
+`ccb.content.plural_text(singular, plural, context?)`. These retain source text
+for native deferred translation; ordinary strings keep their untranslated
+behavior. Item descriptions reject plural values. A singular marked name uses
+the same source for plural fallback; use `plural_text` to supply a distinct
+plural. Source forms must be nonempty and all inputs must exclude NUL. Inherited
+fields retain the parent's translation object; explicit strings replace it.
+Context, plural form and literal/translated status enter the static fingerprint.
 
 独立草稿提供上述运行时文本接口，复用原生翻译目录、上下文与复数规则。这里只完成实现、
 声明、提取工具与测试源码；原生编译、真实语言目录及切换验收尚未执行。不能据此宣称
 完整国际化已经完成，也不将它加入核心 Platform 或 EOC 全量验收的前置条件。
+
+物品名称与说明还可接收 `ccb.content.text(text, context?)` 或
+`ccb.content.plural_text(singular, plural, context?)` 构造的不可变 `LocalizedText`。
+它保留源文本供原生层延迟翻译；普通字符串仍不翻译，说明字段不接受复数值。
+仅标记单数的名称以相同源文本作为复数回退；需要不同复数时使用 `plural_text`。
+源文本不能为空，所有输入均不允许 NUL。继承字段保留父定义的翻译对象，显式字符串替换它；
+上下文、复数和是否翻译均计入静态指纹。其他内容 builder、Mod 元数据及目录热重载仍待推进。
 
 ## Templates, examples, and maintenance / 模板、样例与维护
 

--- a/data/lua/LUA_FIRST_PLATFORM.md
+++ b/data/lua/LUA_FIRST_PLATFORM.md
@@ -461,8 +461,8 @@ The independent draft exposes `ccb.services.translate(text, context?)` and
 `world_ready`. Both return strings using the current native catalog. Literal
 calls can be extracted by `tools/lua_api/extract_translations.py`; its README
 contains the author example and catalog limitations. This is source-level work,
-not completed native acceptance. Metadata translations, other content builders
-and live catalog reload remain outside this slice.
+not completed native acceptance. Metadata translations, content builders beyond
+Item/Skill/SkillDisplay, and live catalog reload remain outside this slice.
 
 For Item names/descriptions, the draft also accepts immutable `LocalizedText`
 values from `ccb.content.text(text, context?)` and
@@ -483,7 +483,21 @@ Context, plural form and literal/translated status enter the static fingerprint.
 它保留源文本供原生层延迟翻译；普通字符串仍不翻译，说明字段不接受复数值。
 仅标记单数的名称以相同源文本作为复数回退；需要不同复数时使用 `plural_text`。
 源文本不能为空，所有输入均不允许 NUL。继承字段保留父定义的翻译对象，显式字符串替换它；
-上下文、复数和是否翻译均计入静态指纹。其他内容 builder、Mod 元数据及目录热重载仍待推进。
+上下文、复数和是否翻译均计入静态指纹。除下述 Skill／SkillDisplay 外的其他内容 builder、
+Mod 元数据及目录热重载仍待推进。
+
+The same `content.text` marker now also covers Skill names/descriptions,
+SkillDisplay labels, and theory/practice level descriptions. All of these fields
+are singular-only and reject `content.plural_text`. Plain strings remain literal;
+omitting a practice description still leaves the independent practice map alone.
+Translation context participates in static fingerprints. Native source tests cover
+fallback display, invalid plural input, atomic method failure and rollback;
+locale/catalog execution remains unverified.
+
+同一个 `content.text` 也可用于 Skill 名称、说明、SkillDisplay 分类名称以及理论／实践
+等级说明。这些字段只接收单数文本，拒绝 `content.plural_text`；普通字符串仍保持字面值，
+省略实践说明时仍不改动独立的实践映射。翻译上下文参与静态指纹。原生测试源码覆盖源文本
+显示、拒绝复数、方法失败时不部分改写以及回滚；语言／目录运行验收仍未执行。
 
 ## Templates, examples, and maintenance / 模板、样例与维护
 

--- a/data/lua/LUA_FIRST_PLATFORM.md
+++ b/data/lua/LUA_FIRST_PLATFORM.md
@@ -454,6 +454,20 @@ PR 664 的基础设施范围和后续能力证据保留在 roadmap，不作为�
 可选标准 helper、国际化与作者工具按需求独立推进；候选 `ccb.std` 名称不是冻结公开契约，
 未来实现仍使用唯一 `require("ccb")` 入口。
 
+### Runtime text internationalization / 运行时文本国际化（草稿实现）
+
+The independent draft exposes `ccb.services.translate(text, context?)` and
+`ccb.services.translate_plural(singular, plural, count, context?)` after
+`world_ready`. Both return strings using the current native catalog. Literal
+calls can be extracted by `tools/lua_api/extract_translations.py`; its README
+contains the author example and catalog limitations. This is source-level work,
+not completed native acceptance. Deferred content-name translations, metadata
+translations and live catalog reload are outside this initial slice.
+
+独立草稿提供上述运行时文本接口，复用原生翻译目录、上下文与复数规则。这里只完成实现、
+声明、提取工具与测试源码；原生编译、真实语言目录及切换验收尚未执行。不能据此宣称
+完整国际化已经完成，也不将它加入核心 Platform 或 EOC 全量验收的前置条件。
+
 ## Templates, examples, and maintenance / 模板、样例与维护
 
 `data/lua/templates/minimal/` and `complete/` are authoring scaffolds. The

--- a/data/lua/types/ccb_platform_v1.d.lua
+++ b/data/lua/types/ccb_platform_v1.d.lua
@@ -356,7 +356,7 @@ local ModDefinition = {}
 ---@field y integer Absolute map-square y coordinate.
 ---@field z integer Absolute map-square z coordinate.
 
----Immutable deferred translation value. Currently accepted by Item name and description.
+---Immutable deferred translation value for Item text and Skill/SkillDisplay text.
 ---Create with content.text or content.plural_text; ordinary strings remain untranslated.
 ---@class LocalizedText
 
@@ -3993,7 +3993,7 @@ function ToolQualityDefinition:usage(level, text) end
 
 ---@class SkillDisplayDefinitionOptions
 ---@field id string Stable skill display-category id.
----@field label? string Player-facing category label; defaults to id.
+---@field label? string|LocalizedText Player-facing category label; defaults to id. Plural text is rejected.
 
 ---@class SkillDisplayDefinition
 ---@field id string
@@ -4001,8 +4001,8 @@ local SkillDisplayDefinition = {}
 
 ---@class SkillDefinitionOptions
 ---@field id string Stable skill id.
----@field name? string Display name; defaults to id.
----@field description string Player-facing description.
+---@field name? string|LocalizedText Display name; defaults to id. Plural text is rejected.
+---@field description string|LocalizedText Player-facing description; plural text is rejected.
 ---@field display_category? string SkillDisplay id; defaults to `none`.
 ---@field sort_rank? integer Native display ordering rank.
 ---@field teachable? boolean Whether NPCs may teach the skill.
@@ -4023,14 +4023,14 @@ function SkillDefinition:tag(tag) end
 function SkillDefinition:companion_practice(practice_id, weight) end
 
 ---@param level integer Level from zero through the native skill maximum.
----@param theory string Theory-level description.
----@param practice? string Practical-level description; omitted means theory-only,
+---@param theory string|LocalizedText Theory-level description; plural text is rejected.
+---@param practice? string|LocalizedText Practical-level description; plural text is rejected. Omitted means theory-only,
 --- matching the legacy independent theory/practice maps.
 ---@return SkillDefinition self
 function SkillDefinition:level_description(level, theory, practice) end
 
 ---@param level integer Level from zero through the native skill maximum.
----@param practice string Practical-level description for a practice-only level.
+---@param practice string|LocalizedText Practical-level description for a practice-only level; plural text is rejected.
 ---@return SkillDefinition self
 function SkillDefinition:level_description_practice(level, practice) end
 

--- a/data/lua/types/ccb_platform_v1.d.lua
+++ b/data/lua/types/ccb_platform_v1.d.lua
@@ -10371,6 +10371,23 @@ function CcbCreaturesApi.visible_monsters(observer, direction) end
 
 function CcbPlatformServices.message(text) end
 
+---Translate runtime text using the current game language. Available after world_ready.
+---Missing translations return the source text. Text/context must not contain NUL.
+---@param text string Literal source text for extraction.
+---@param context? string Literal disambiguation context.
+---@return string
+function CcbPlatformServices.translate(text, context) end
+
+---Translate runtime plural text using the native catalog's plural rules.
+---Without a translation, count 1 selects singular; other counts select plural.
+---Available after world_ready. Text/context must not contain NUL.
+---@param singular string Literal singular source text.
+---@param plural string Literal plural source text.
+---@param count integer Nonnegative and representable by the target's native size_t.
+---@param context? string Literal disambiguation context.
+---@return string
+function CcbPlatformServices.translate_plural(singular, plural, count, context) end
+
 ---@return integer
 function CcbPlatformServices.turn() end
 

--- a/data/lua/types/ccb_platform_v1.d.lua
+++ b/data/lua/types/ccb_platform_v1.d.lua
@@ -356,11 +356,15 @@ local ModDefinition = {}
 ---@field y integer Absolute map-square y coordinate.
 ---@field z integer Absolute map-square z coordinate.
 
+---Immutable deferred translation value. Currently accepted by Item name and description.
+---Create with content.text or content.plural_text; ordinary strings remain untranslated.
+---@class LocalizedText
+
 ---@class ItemDefinitionOptions
 ---@field id string Stable item type id.
 ---@field copy_from? string Existing item id used as the patch base.
----@field name? string Display name; defaults to id.
----@field description? string Player-facing description.
+---@field name? string|LocalizedText Display name; defaults to id. Explicit plural text supplies counted names.
+---@field description? string|LocalizedText Player-facing description; plural text is rejected.
 ---@field symbol? string Map symbol; defaults to `?`.
 ---@field color? string Native color id.
 ---@field category? string Native item-category id.
@@ -4993,6 +4997,19 @@ function CcbPlatformTilesetApi.limits() end
 function CcbPlatformTilesetApi.register(descriptor) end
 ---@class CcbPlatformContent
 local CcbPlatformContent = {}
+
+---Mark static content text for deferred translation, including after language changes.
+---@param text string Nonempty source text without NUL.
+---@param context? string Translation context without NUL.
+---@return LocalizedText
+function CcbPlatformContent.text(text, context) end
+
+---Mark singular/plural static content text. Translation is deferred until native display.
+---@param singular string Nonempty source text without NUL.
+---@param plural string Nonempty plural source text without NUL.
+---@param context? string Translation context without NUL.
+---@return LocalizedText
+function CcbPlatformContent.plural_text(singular, plural, context) end
 
 ---@param options ItemDefinitionOptions
 ---@return ItemDefinition

--- a/src/lua_platform_content_items.cpp
+++ b/src/lua_platform_content_items.cpp
@@ -6404,17 +6404,21 @@ void items_content_transaction::append_fingerprint( const items_content_fingerpr
                 hash_part( state, std::to_string( v.companion_combat_rank_factor ) );
                 hash_part( state, std::to_string( v.companion_survival_rank_factor ) );
                 hash_part( state, std::to_string( v.companion_industry_rank_factor ) );
+                hash_part( state, "tags" );
                 for( const auto &tag : v.tags ) {
                     hash_part( state, tag );
                 }
+                hash_part( state, "companion_practice" );
                 for( const auto &[id, weight] : v.companion_practice ) {
                     hash_part( state, id );
                     hash_part( state, std::to_string( weight ) );
                 }
+                hash_part( state, "theory_descriptions" );
                 for( const auto &[level, description] : v.theory_descriptions ) {
                     hash_part( state, std::to_string( level ) );
                     hash_part( state, description );
                 }
+                hash_part( state, "practice_descriptions" );
                 for( const auto &[level, description] : v.practice_descriptions ) {
                     hash_part( state, std::to_string( level ) );
                     hash_part( state, description );

--- a/src/lua_platform_content_items.cpp
+++ b/src/lua_platform_content_items.cpp
@@ -39,6 +39,7 @@
 #include <initializer_list>
 #include <iterator>
 #include <list>
+#include <optional>
 
 namespace cata::lua_platform::detail
 {
@@ -334,6 +335,33 @@ struct quality_level {
     std::int64_t level = 1;
 };
 
+struct localized_text {
+    std::string singular;
+    std::optional<std::string> plural;
+    std::optional<std::string> context;
+
+    translation native() const {
+        if( plural ) {
+            return context ? translation::pl_translation( *context, singular, *plural ) :
+                   translation::pl_translation( singular, *plural );
+        }
+        return context ? translation::to_translation( *context, singular ) :
+               translation::to_translation( singular );
+    }
+};
+
+localized_text make_localized_text( const std::string &singular,
+                                   const std::optional<std::string> &plural,
+                                   const sol::optional<std::string> &context )
+{
+    if( singular.empty() || singular.find( '\0' ) != std::string::npos ||
+        ( plural && ( plural->empty() || plural->find( '\0' ) != std::string::npos ) ) ||
+        ( context && context->find( '\0' ) != std::string::npos ) ) {
+        throw std::runtime_error( "localized content text requires nonempty source forms without NUL" );
+    }
+    return { singular, plural, context ? std::optional<std::string>( *context ) : std::nullopt };
+}
+
 struct item_definition_data {
     struct comestible_data {
         std::string type;
@@ -358,6 +386,8 @@ struct item_definition_data {
     std::string copy_from;
     std::string name;
     std::string description;
+    std::optional<localized_text> translated_name;
+    std::optional<localized_text> translated_description;
     std::string symbol = "?";
     std::int64_t mass_grams = 0;
     std::int64_t volume_ml = 0;
@@ -2430,6 +2460,15 @@ items_content_transaction::~items_content_transaction() = default;
 void items_content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         sol::table &content )
 {
+    ccb.new_usertype<localized_text>( "LocalizedText", sol::no_constructor );
+    content.set_function( "text", []( const std::string &text,
+    const sol::optional<std::string> &context ) {
+        return make_localized_text( text, std::nullopt, context );
+    } );
+    content.set_function( "plural_text", []( const std::string &singular, const std::string &plural,
+    const sol::optional<std::string> &context ) {
+        return make_localized_text( singular, plural, context );
+    } );
     ccb.new_usertype<tool_quality_definition_handle>(
         "ToolQualityDefinition", sol::no_constructor,
         "id", sol::property( &tool_quality_definition_handle::id ),
@@ -2816,8 +2855,23 @@ void items_content_transaction::install_lua_api( sol::state &lua, sol::table &cc
                 present = true;
             }
         };
-        read_string( "name", definition->name, definition->has_name );
-        read_string( "description", definition->description, definition->has_description );
+        const auto read_text = [&options, &read_string]( const char *key, std::string &raw,
+        bool &present, std::optional<localized_text> &translated, const bool allow_plural ) {
+            const sol::object value = options[key];
+            if( value.is<localized_text>() ) {
+                translated = value.as<localized_text>();
+                if( translated->plural && !allow_plural ) {
+                    throw std::runtime_error( "item description does not accept plural text" );
+                }
+                raw = translated->singular;
+                present = true;
+            } else {
+                read_string( key, raw, present );
+            }
+        };
+        read_text( "name", definition->name, definition->has_name, definition->translated_name, true );
+        read_text( "description", definition->description, definition->has_description,
+                   definition->translated_description, false );
         read_string( "symbol", definition->symbol, definition->has_symbol );
         read_string( "color", definition->color, definition->has_color );
         read_string( "category", definition->category, definition->has_category );
@@ -5414,10 +5468,15 @@ bool items_content_transaction::apply_phase( const items_content_apply_phase pha
                     }
                     native->id = id;
                     if( definition.has_name ) {
-                        native->name = no_translation( definition.name );
+                        native->name = definition.translated_name ? definition.translated_name->native() :
+                                       no_translation( definition.name );
+                        if( definition.translated_name ) {
+                            native->name.make_plural();
+                        }
                     }
                     if( definition.has_description ) {
-                        native->description = no_translation( definition.description );
+                        native->description = definition.translated_description ?
+                                              definition.translated_description->native() : no_translation( definition.description );
                     }
                     if( definition.has_symbol ) {
                         native->sym = definition.symbol;
@@ -6687,6 +6746,17 @@ void items_content_transaction::append_fingerprint( const items_content_fingerpr
                 hash_part( state, v.copy_from );
                 hash_part( state, v.name );
                 hash_part( state, v.description );
+                const auto hash_text = [&state]( const std::optional<localized_text> &text ) {
+                    hash_part( state, text ? "localized" : "literal" );
+                    if( text ) {
+                        hash_part( state, text->context ? "context" : "no_context" );
+                        hash_part( state, text->context.value_or( "" ) );
+                        hash_part( state, text->plural ? "plural" : "no_plural" );
+                        hash_part( state, text->plural.value_or( "" ) );
+                    }
+                };
+                hash_text( v.translated_name );
+                hash_text( v.translated_description );
                 hash_part( state, v.symbol );
                 hash_part( state, std::to_string( v.mass_grams ) );
                 hash_part( state, std::to_string( v.volume_ml ) );

--- a/src/lua_platform_content_items.cpp
+++ b/src/lua_platform_content_items.cpp
@@ -362,6 +362,36 @@ localized_text make_localized_text( const std::string &singular,
     return { singular, plural, context ? std::optional<std::string>( *context ) : std::nullopt };
 }
 
+// Native text fields can retain either a literal or explicit translation data.
+struct authored_text {
+    std::string raw;
+    std::optional<localized_text> translated;
+
+    bool empty() const {
+        return raw.empty();
+    }
+
+    translation native() const {
+        return translated ? translated->native() : no_translation( raw );
+    }
+};
+
+authored_text read_singular_text( const sol::object &value, const std::string &fallback,
+                                  const std::string &field )
+{
+    if( !value.valid() || value.get_type() == sol::type::nil ) {
+        return { fallback, std::nullopt };
+    }
+    if( value.is<localized_text>() ) {
+        const localized_text text = value.as<localized_text>();
+        if( text.plural ) {
+            throw std::runtime_error( field + " does not accept plural text" );
+        }
+        return { text.singular, text };
+    }
+    return { value.as<std::string>(), std::nullopt };
+}
+
 struct item_definition_data {
     struct comestible_data {
         std::string type;
@@ -613,20 +643,20 @@ struct tool_quality_definition_data {
 
 struct skill_display_definition_data {
     std::string id;
-    std::string label;
+    authored_text label;
     bool registered = false;
 };
 
 struct skill_definition_data {
     std::string id;
-    std::string name;
-    std::string description;
+    authored_text name;
+    authored_text description;
     std::string display_category = "none";
     std::int64_t sort_rank = 1000000;
     std::set<std::string> tags;
     std::map<std::string, std::int64_t> companion_practice;
-    std::map<std::int64_t, std::string> theory_descriptions;
-    std::map<std::int64_t, std::string> practice_descriptions;
+    std::map<std::int64_t, authored_text> theory_descriptions;
+    std::map<std::int64_t, authored_text> practice_descriptions;
     std::set<std::string> requires_all_traits;
     std::set<std::string> requires_any_traits;
     std::int64_t attack_min_time = 50;
@@ -1435,27 +1465,32 @@ struct skill_definition_handle {
     }
 
     skill_definition_handle &level_description( std::int64_t level,
-            const std::string &theory, const sol::optional<std::string> &practice ) {
+            const sol::object &theory_value, const sol::optional<sol::object> &practice_value ) {
         require_building_handle( token, *definition, "skill" );
+        authored_text theory = read_singular_text( theory_value, "", "skill theory description" );
+        std::optional<authored_text> practice;
+        if( practice_value ) {
+            practice = read_singular_text( *practice_value, "", "skill practice description" );
+        }
         if( level < 0 || level > MAX_SKILL || theory.empty() ) {
             throw std::runtime_error( "skill level description is invalid" );
         }
-        definition->theory_descriptions[level] = theory;
-        // Legacy stores the theory and practice maps independently; only an
-        // explicit practice argument fills the practice side.
+        // Parse both texts before changing either independent description map.
+        definition->theory_descriptions[level] = std::move( theory );
         if( practice ) {
-            definition->practice_descriptions[level] = *practice;
+            definition->practice_descriptions[level] = std::move( *practice );
         }
         return *this;
     }
 
     skill_definition_handle &level_description_practice( std::int64_t level,
-            const std::string &practice ) {
+            const sol::object &practice_value ) {
         require_building_handle( token, *definition, "skill" );
+        authored_text practice = read_singular_text( practice_value, "", "skill practice description" );
         if( level < 0 || level > MAX_SKILL || practice.empty() ) {
             throw std::runtime_error( "skill level description is invalid" );
         }
-        definition->practice_descriptions[level] = practice;
+        definition->practice_descriptions[level] = std::move( practice );
         return *this;
     }
 
@@ -2362,6 +2397,18 @@ void hash_part( std::uint64_t &state, const std::string_view value )
     append( ";" );
 }
 
+void hash_part( std::uint64_t &state, const authored_text &text )
+{
+    hash_part( state, text.raw );
+    hash_part( state, text.translated ? "localized" : "literal" );
+    if( text.translated ) {
+        hash_part( state, text.translated->context ? "context" : "no_context" );
+        if( text.translated->context ) {
+            hash_part( state, *text.translated->context );
+        }
+    }
+}
+
 template<typename Registration>
 bool defines_registration(
     const std::vector<Registration> &entries, const std::string_view id )
@@ -2650,7 +2697,8 @@ void items_content_transaction::install_lua_api( sol::state &lua, sol::table &cc
         }
         auto definition = std::make_shared<skill_display_definition_data>();
         definition->id = options.get_or( "id", std::string() );
-        definition->label = options.get_or( "label", definition->id );
+        definition->label = read_singular_text( options.get<sol::object>( "label" ),
+                                                definition->id, "skill display label" );
         return skill_display_definition_handle{ std::move( definition ), transaction->token };
     } );
     content.set_function( "Skill", [transaction]( const sol::table & options ) {
@@ -2659,8 +2707,10 @@ void items_content_transaction::install_lua_api( sol::state &lua, sol::table &cc
         }
         auto definition = std::make_shared<skill_definition_data>();
         definition->id = options.get_or( "id", std::string() );
-        definition->name = options.get_or( "name", definition->id );
-        definition->description = options.get_or( "description", std::string() );
+        definition->name = read_singular_text( options.get<sol::object>( "name" ),
+                                               definition->id, "skill name" );
+        definition->description = read_singular_text( options.get<sol::object>( "description" ),
+            "", "skill description" );
         definition->display_category = options.get_or( "display_category", std::string( "none" ) );
         definition->sort_rank = options.get_or<std::int64_t>( "sort_rank", 1000000 );
         definition->teachable = options.get_or( "teachable", true );
@@ -4802,7 +4852,7 @@ bool items_content_transaction::apply_phase( const items_content_apply_phase pha
                     } ),
                     SkillDisplayType::skillTypes.end() );
                     SkillDisplayType::skillTypes.emplace_back(
-                        id, no_translation( entry.definition->label ) );
+                        id, entry.definition->label.native() );
                 }
 
                 for( const skill_registration &entry : pimpl_->skills ) {
@@ -4815,7 +4865,7 @@ bool items_content_transaction::apply_phase( const items_content_apply_phase pha
                     } ), Skill::skills.end() );
                     Skill::contextual_skills.erase( id );
                     const skill_definition_data &source = *entry.definition;
-                    Skill native( id, no_translation( source.name ), no_translation( source.description ),
+                    Skill native( id, source.name.native(), source.description.native(),
                                   source.tags, skill_displayType_id( source.display_category ) );
                     native._sort_rank = static_cast<int>( source.sort_rank );
                     native.consumes_focus = source.consumes_focus;
@@ -4837,11 +4887,11 @@ bool items_content_transaction::apply_phase( const items_content_apply_phase pha
                     }
                     for( const auto &[level, description] : source.theory_descriptions ) {
                         native._level_descriptions_theory[static_cast<int>( level )] =
-                            no_translation( description );
+                            description.native();
                     }
                     for( const auto &[level, description] : source.practice_descriptions ) {
                         native._level_descriptions_practice[static_cast<int>( level )] =
-                            no_translation( description );
+                            description.native();
                     }
                     native._requires_all_traits = source.requires_all_traits;
                     native._requires_any_traits = source.requires_any_traits;

--- a/src/lua_platform_content_items.cpp
+++ b/src/lua_platform_content_items.cpp
@@ -351,8 +351,8 @@ struct localized_text {
 };
 
 localized_text make_localized_text( const std::string &singular,
-                                   const std::optional<std::string> &plural,
-                                   const sol::optional<std::string> &context )
+                                    const std::optional<std::string> &plural,
+                                    const sol::optional<std::string> &context )
 {
     if( singular.empty() || singular.find( '\0' ) != std::string::npos ||
         ( plural && ( plural->empty() || plural->find( '\0' ) != std::string::npos ) ) ||
@@ -2461,11 +2461,11 @@ void items_content_transaction::install_lua_api( sol::state &lua, sol::table &cc
         sol::table &content )
 {
     ccb.new_usertype<localized_text>( "LocalizedText", sol::no_constructor );
-    content.set_function( "text", []( const std::string &text,
+    content.set_function( "text", []( const std::string & text,
     const sol::optional<std::string> &context ) {
         return make_localized_text( text, std::nullopt, context );
     } );
-    content.set_function( "plural_text", []( const std::string &singular, const std::string &plural,
+    content.set_function( "plural_text", []( const std::string & singular, const std::string & plural,
     const sol::optional<std::string> &context ) {
         return make_localized_text( singular, plural, context );
     } );
@@ -2855,8 +2855,8 @@ void items_content_transaction::install_lua_api( sol::state &lua, sol::table &cc
                 present = true;
             }
         };
-        const auto read_text = [&options, &read_string]( const char *key, std::string &raw,
-        bool &present, std::optional<localized_text> &translated, const bool allow_plural ) {
+        const auto read_text = [&options, &read_string]( const char *key, std::string & raw,
+        bool & present, std::optional<localized_text> &translated, const bool allow_plural ) {
             const sol::object value = options[key];
             if( value.is<localized_text>() ) {
                 translated = value.as<localized_text>();

--- a/src/lua_platform_runtime_services.cpp
+++ b/src/lua_platform_runtime_services.cpp
@@ -1731,13 +1731,13 @@ void install_runtime_api( const std::shared_ptr<runtime> &value,
         if( context ) {
             require_translation_text( *context );
         }
-        if( count < 0 || static_cast<std::uint64_t>( count ) >
-            std::numeric_limits<std::size_t>::max() ) {
+        const std::size_t native_count = static_cast<std::size_t>( count );
+        if( count < 0 || static_cast<std::uint64_t>( native_count ) !=
+            static_cast<std::uint64_t>( count ) ) {
             throw std::runtime_error( "translation count is outside the native nonnegative range" );
         }
 #if defined(LOCALIZE)
         TranslationManager &manager = TranslationManager::GetInstance();
-        const std::size_t native_count = static_cast<std::size_t>( count );
         return context ? manager.TranslatePluralWithContext( context->c_str(), singular.c_str(),
                plural.c_str(), native_count ) : manager.TranslatePlural( singular.c_str(),
                        plural.c_str(), native_count );

--- a/src/lua_platform_runtime_services.cpp
+++ b/src/lua_platform_runtime_services.cpp
@@ -1707,40 +1707,43 @@ void install_runtime_api( const std::shared_ptr<runtime> &value,
 
 
     sol::table services = lua.create_table();
-    services.set_function( "translate", [weak]( const std::string &text,
+    services.set_function( "translate", [weak]( const std::string & text,
     const sol::optional<std::string> &context ) -> std::string {
         require_live_runtime( weak, "services.translate" );
         require_translation_text( text );
-        if( context ) {
-            require_translation_text( *context );
+        if( context )
+    {
+        require_translation_text( *context );
         }
 #if defined(LOCALIZE)
         TranslationManager &manager = TranslationManager::GetInstance();
         return context ? manager.TranslateWithContext( context->c_str(), text.c_str() ) :
-               manager.Translate( text );
+                                manager.Translate( text );
 #else
         return text;
 #endif
     } );
-    services.set_function( "translate_plural", [weak]( const std::string &singular,
-    const std::string &plural, const std::int64_t count,
+    services.set_function( "translate_plural", [weak]( const std::string & singular,
+            const std::string & plural, const std::int64_t count,
     const sol::optional<std::string> &context ) -> std::string {
         require_live_runtime( weak, "services.translate_plural" );
         require_translation_text( singular );
         require_translation_text( plural );
-        if( context ) {
-            require_translation_text( *context );
+        if( context )
+    {
+        require_translation_text( *context );
         }
         const std::size_t native_count = static_cast<std::size_t>( count );
         if( count < 0 || static_cast<std::uint64_t>( native_count ) !=
-            static_cast<std::uint64_t>( count ) ) {
-            throw std::runtime_error( "translation count is outside the native nonnegative range" );
+            static_cast<std::uint64_t>( count ) )
+    {
+        throw std::runtime_error( "translation count is outside the native nonnegative range" );
         }
 #if defined(LOCALIZE)
         TranslationManager &manager = TranslationManager::GetInstance();
         return context ? manager.TranslatePluralWithContext( context->c_str(), singular.c_str(),
-               plural.c_str(), native_count ) : manager.TranslatePlural( singular.c_str(),
-                       plural.c_str(), native_count );
+            plural.c_str(), native_count ) : manager.TranslatePlural( singular.c_str(),
+                plural.c_str(), native_count );
 #else
         return count == 1 ? singular : plural;
 #endif

--- a/src/lua_platform_runtime_services.cpp
+++ b/src/lua_platform_runtime_services.cpp
@@ -227,6 +227,7 @@ extern "C" {
 #include "talker.h"
 #include "text_snippets.h"
 #include "translation.h"
+#include "translation_manager.h"
 #include "trap.h"
 #include "type_id.h"
 #include "uilist.h"
@@ -257,6 +258,13 @@ using detail::runtime_callback_is_active;
 
 namespace
 {
+
+void require_translation_text( const std::string &text )
+{
+    if( text.find( '\0' ) != std::string::npos ) {
+        throw std::runtime_error( "translation text and context must not contain NUL" );
+    }
+}
 
 std::size_t require_dense_array( const sol::table &values,
                                  const std::string_view description,
@@ -1699,6 +1707,44 @@ void install_runtime_api( const std::shared_ptr<runtime> &value,
 
 
     sol::table services = lua.create_table();
+    services.set_function( "translate", [weak]( const std::string &text,
+    const sol::optional<std::string> &context ) -> std::string {
+        require_live_runtime( weak, "services.translate" );
+        require_translation_text( text );
+        if( context ) {
+            require_translation_text( *context );
+        }
+#if defined(LOCALIZE)
+        TranslationManager &manager = TranslationManager::GetInstance();
+        return context ? manager.TranslateWithContext( context->c_str(), text.c_str() ) :
+               manager.Translate( text );
+#else
+        return text;
+#endif
+    } );
+    services.set_function( "translate_plural", [weak]( const std::string &singular,
+    const std::string &plural, const std::int64_t count,
+    const sol::optional<std::string> &context ) -> std::string {
+        require_live_runtime( weak, "services.translate_plural" );
+        require_translation_text( singular );
+        require_translation_text( plural );
+        if( context ) {
+            require_translation_text( *context );
+        }
+        if( count < 0 || static_cast<std::uint64_t>( count ) >
+            std::numeric_limits<std::size_t>::max() ) {
+            throw std::runtime_error( "translation count is outside the native nonnegative range" );
+        }
+#if defined(LOCALIZE)
+        TranslationManager &manager = TranslationManager::GetInstance();
+        const std::size_t native_count = static_cast<std::size_t>( count );
+        return context ? manager.TranslatePluralWithContext( context->c_str(), singular.c_str(),
+               plural.c_str(), native_count ) : manager.TranslatePlural( singular.c_str(),
+                       plural.c_str(), native_count );
+#else
+        return count == 1 ? singular : plural;
+#endif
+    } );
     services.set_function( "message", [weak]( const std::string & message ) {
         const std::shared_ptr<runtime> owner = weak.lock();
         if( !owner || !owner->world_is_ready ) {

--- a/tests/lua_platform_content_translation_test.cpp
+++ b/tests/lua_platform_content_translation_test.cpp
@@ -1,6 +1,7 @@
 #if defined(CATA_ENABLE_LUA_PLATFORM) && CATA_ENABLE_LUA_PLATFORM
 #include "lua_platform_test_support.h"
 #include "itype.h"
+#include "skill.h"
 #include "translation.h"
 
 TEST_CASE( "lua_platform_item_text_preserves_deferred_native_translations",
@@ -98,5 +99,90 @@ TEST_CASE( "lua_platform_item_text_fingerprints_translation_semantics",
            fingerprint( "ccb.content.text('stone', 'material')" ) );
     CHECK( fingerprint( "ccb.content.plural_text('stone', 'stones')" ) !=
            fingerprint( "ccb.content.plural_text('stone', 'stone pieces')" ) );
+}
+
+TEST_CASE( "lua_platform_skill_text_accepts_deferred_markers_and_rolls_back",
+           "[lua][platform][content][translations]" )
+{
+    namespace platform = cata::lua_platform;
+    platform::shutdown();
+    const platform_lua_test_directory files;
+    const on_out_of_scope cleanup( []() {
+        platform::shutdown();
+    } );
+    files.write( "main.lua", R"lua(
+local ccb = require("ccb")
+local plural = ccb.content.plural_text("one", "many")
+assert(not pcall(ccb.content.SkillDisplay, {id="bad_label", label=plural}))
+assert(not pcall(ccb.content.Skill, {id="bad_name", name=plural, description="text"}))
+assert(not pcall(ccb.content.Skill, {id="bad_description", description=plural}))
+ccb.content.add(ccb.content.SkillDisplay {
+    id = "lua_translated_skill_display", label = ccb.content.text("ccb skill category", "skill category")
+})
+local skill = ccb.content.Skill {
+    id = "lua_translated_skill", name = ccb.content.text("ccb skill name", "skill name"),
+    description = ccb.content.text("ccb skill description", "skill description"),
+    display_category = "lua_translated_skill_display"
+}
+skill:level_description(1, ccb.content.text("ccb skill theory", "skill theory"),
+                          ccb.content.text("ccb skill practice", "skill practice"))
+assert(not pcall(function() skill:level_description(1, "must not replace", plural) end))
+assert(not pcall(function() skill:level_description_practice(2, plural) end))
+skill:level_description_practice(2, ccb.content.text("ccb advanced practice", "skill practice"))
+skill:level_description(3, ccb.content.text("marked then replaced"))
+skill:level_description(3, "literal theory")
+ccb.content.add(skill)
+)lua" );
+    std::string error;
+    const bool prepared = platform::prepare_mods( {
+        { "skill-text", files.root, files.root / "main.lua" }
+    }, error );
+    INFO( error );
+    REQUIRE( prepared );
+    REQUIRE( platform::apply_prepared_content( error ) );
+    const skill_id id( "lua_translated_skill" );
+    REQUIRE( id.is_valid() );
+    CHECK( id.obj().name() == "ccb skill name" );
+    CHECK( id.obj().description() == "ccb skill description" );
+    CHECK( skill_displayType_id( "lua_translated_skill_display" ).obj().display_string() ==
+           "ccb skill category" );
+    CHECK( id.obj().get_level_description( 1, false ) == "ccb skill theory" );
+    CHECK( id.obj().get_level_description( 1, true ) == "ccb skill practice" );
+    CHECK( id.obj().get_level_description( 2, true ) == "ccb advanced practice" );
+    CHECK( id.obj().get_level_description( 3, false ) == "literal theory" );
+    platform::discard_prepared_mods();
+    CHECK_FALSE( id.is_valid() );
+    CHECK_FALSE( skill_displayType_id( "lua_translated_skill_display" ).is_valid() );
+}
+
+TEST_CASE( "lua_platform_skill_text_context_changes_static_fingerprints",
+           "[lua][platform][content][translations][reload]" )
+{
+    namespace platform = cata::lua_platform;
+    platform::shutdown();
+    const platform_lua_test_directory files;
+    const on_out_of_scope cleanup( []() {
+        platform::shutdown();
+    } );
+    const auto fingerprint = [&]( const std::string & text ) {
+        files.write( "main.lua", "local ccb = require('ccb')\n"
+                     "ccb.content.add(ccb.content.Skill {id='lua_skill_text_hash', "
+                     "name=" + text + ", description='description'})\n" );
+        std::string error;
+        const bool prepared = platform::prepare_mods( {
+            { "skill-text-hash", files.root, files.root / "main.lua" }
+        }, error );
+        INFO( error );
+        REQUIRE( prepared );
+        const std::string result = platform::prepared_content_fingerprint();
+        platform::discard_prepared_mods();
+        return result;
+    };
+    const std::string marked = fingerprint( "ccb.content.text('same source')" );
+    CHECK( fingerprint( "ccb.content.text('same source')" ) == marked );
+    CHECK( fingerprint( "'same source'" ) != marked );
+    CHECK( fingerprint( "ccb.content.text('same source', '')" ) != marked );
+    CHECK( fingerprint( "ccb.content.text('same source', 'skill name')" ) !=
+           fingerprint( "ccb.content.text('same source', 'other context')" ) );
 }
 #endif

--- a/tests/lua_platform_content_translation_test.cpp
+++ b/tests/lua_platform_content_translation_test.cpp
@@ -1,0 +1,102 @@
+#if defined(CATA_ENABLE_LUA_PLATFORM) && CATA_ENABLE_LUA_PLATFORM
+#include "lua_platform_test_support.h"
+#include "itype.h"
+#include "translation.h"
+
+TEST_CASE( "lua_platform_item_text_preserves_deferred_native_translations",
+           "[lua][platform][content][translations]" )
+{
+    namespace platform = cata::lua_platform;
+    platform::shutdown();
+    const platform_lua_test_directory files;
+    const on_out_of_scope cleanup( []() {
+        platform::shutdown();
+    } );
+    files.write( "main.lua", R"lua(
+local ccb = require("ccb")
+assert(not pcall(ccb.content.text, ""))
+assert(not pcall(ccb.content.text, "a\0b"))
+assert(not pcall(ccb.content.text, "source", "a\0b"))
+assert(not pcall(ccb.content.plural_text, "source", ""))
+assert(not pcall(ccb.content.plural_text, "source", "a\0b"))
+assert(not pcall(ccb.content.Item, {
+    id = "lua_text_invalid_description",
+    description = ccb.content.plural_text("one", "many")
+}))
+ccb.content.add(ccb.content.Item {
+    id = "lua_text_translated_parent", mass_grams = 1, volume_ml = 1,
+    name = ccb.content.plural_text("ccb text pebble", "ccb text pebbles", "item name"),
+    description = ccb.content.text("ccb text description", "item description")
+})
+ccb.content.add(ccb.content.Item {
+    id = "lua_text_translated_child", copy_from = "lua_text_translated_parent"
+})
+ccb.content.add(ccb.content.Item {
+    id = "lua_text_literal_child", copy_from = "lua_text_translated_parent", name = "literal name"
+})
+ccb.content.add(ccb.content.Item {
+    id = "lua_text_same_plural", copy_from = "lua_text_translated_parent",
+    name = ccb.content.text("ccb text water")
+})
+)lua" );
+    const platform::mod_source source { "item-text", files.root, files.root / "main.lua" };
+    std::string error;
+    const bool prepared = platform::prepare_mods( { source }, error );
+    INFO( error );
+    REQUIRE( prepared );
+    REQUIRE( platform::apply_prepared_content( error ) );
+    const translation expected_name = translation::pl_translation(
+                                         "item name", "ccb text pebble", "ccb text pebbles" );
+    const translation expected_description = translation::to_translation(
+            "item description", "ccb text description" );
+    const itype &parent = itype_id( "lua_text_translated_parent" ).obj();
+    CHECK( parent.name == expected_name );
+    CHECK( parent.description == expected_description );
+    const itype &child = itype_id( "lua_text_translated_child" ).obj();
+    CHECK( child.name == expected_name );
+    CHECK( child.description == expected_description );
+    const itype &literal = itype_id( "lua_text_literal_child" ).obj();
+    CHECK( literal.name == translation::no_translation( "literal name" ) );
+    CHECK( literal.description == expected_description );
+    translation uncounted = translation::to_translation( "ccb text water" );
+    uncounted.make_plural();
+    CHECK( itype_id( "lua_text_same_plural" ).obj().name == uncounted );
+    // Candidate application remains reversible, including translation objects.
+    platform::discard_prepared_mods();
+    CHECK_FALSE( itype_id( "lua_text_translated_parent" ).is_valid() );
+    CHECK_FALSE( itype_id( "lua_text_translated_child" ).is_valid() );
+}
+
+TEST_CASE( "lua_platform_item_text_fingerprints_translation_semantics",
+           "[lua][platform][content][translations][reload]" )
+{
+    namespace platform = cata::lua_platform;
+    platform::shutdown();
+    const platform_lua_test_directory files;
+    const on_out_of_scope cleanup( []() {
+        platform::shutdown();
+    } );
+    const platform::mod_source source { "item-text-hash", files.root, files.root / "main.lua" };
+    const auto fingerprint = [&]( const std::string &name ) {
+        files.write( "main.lua", "local ccb = require('ccb')\n"
+                     "ccb.content.add(ccb.content.Item { id = 'lua_text_hash', "
+                     "copy_from = 'rock', name = " + name + " })\n" );
+        std::string error;
+        const bool prepared = platform::prepare_mods( { source }, error );
+        INFO( error );
+        REQUIRE( prepared );
+        const std::string value = platform::prepared_content_fingerprint();
+        platform::discard_prepared_mods();
+        return value;
+    };
+    const std::string literal = fingerprint( "'stone'" );
+    const std::string marked = fingerprint( "ccb.content.text('stone')" );
+    CHECK( marked != literal );
+    CHECK( fingerprint( "ccb.content.text('stone')" ) == marked );
+    CHECK( fingerprint( "ccb.content.text('stone', '')" ) != marked );
+    CHECK( fingerprint( "ccb.content.text('stone', 'name')" ) !=
+           fingerprint( "ccb.content.text('stone', 'material')" ) );
+    CHECK( fingerprint( "ccb.content.plural_text('stone', 'stones')" ) !=
+           fingerprint( "ccb.content.plural_text('stone', 'stone pieces')" ) );
+}
+#endif

--- a/tests/lua_platform_content_translation_test.cpp
+++ b/tests/lua_platform_content_translation_test.cpp
@@ -164,10 +164,11 @@ TEST_CASE( "lua_platform_skill_text_context_changes_static_fingerprints",
     const on_out_of_scope cleanup( []() {
         platform::shutdown();
     } );
-    const auto fingerprint = [&]( const std::string & text ) {
+    const auto fingerprint = [&]( const std::string & text, const std::string &configure = "" ) {
         files.write( "main.lua", "local ccb = require('ccb')\n"
-                     "ccb.content.add(ccb.content.Skill {id='lua_skill_text_hash', "
-                     "name=" + text + ", description='description'})\n" );
+                     "local skill = ccb.content.Skill {id='lua_skill_text_hash', "
+                     "name=" + text + ", description='description'}\n" +
+                     configure + "\nccb.content.add(skill)\n" );
         std::string error;
         const bool prepared = platform::prepare_mods( {
             { "skill-text-hash", files.root, files.root / "main.lua" }
@@ -178,6 +179,8 @@ TEST_CASE( "lua_platform_skill_text_context_changes_static_fingerprints",
         platform::discard_prepared_mods();
         return result;
     };
+    CHECK( fingerprint( "'same source'", "skill:level_description(1, 'same text')" ) !=
+           fingerprint( "'same source'", "skill:level_description_practice(1, 'same text')" ) );
     const std::string marked = fingerprint( "ccb.content.text('same source')" );
     CHECK( fingerprint( "ccb.content.text('same source')" ) == marked );
     CHECK( fingerprint( "'same source'" ) != marked );

--- a/tests/lua_platform_content_translation_test.cpp
+++ b/tests/lua_platform_content_translation_test.cpp
@@ -46,7 +46,7 @@ ccb.content.add(ccb.content.Item {
     REQUIRE( prepared );
     REQUIRE( platform::apply_prepared_content( error ) );
     const translation expected_name = translation::pl_translation(
-                                         "item name", "ccb text pebble", "ccb text pebbles" );
+                                          "item name", "ccb text pebble", "ccb text pebbles" );
     const translation expected_description = translation::to_translation(
             "item description", "ccb text description" );
     const itype &parent = itype_id( "lua_text_translated_parent" ).obj();
@@ -77,7 +77,7 @@ TEST_CASE( "lua_platform_item_text_fingerprints_translation_semantics",
         platform::shutdown();
     } );
     const platform::mod_source source { "item-text-hash", files.root, files.root / "main.lua" };
-    const auto fingerprint = [&]( const std::string &name ) {
+    const auto fingerprint = [&]( const std::string & name ) {
         files.write( "main.lua", "local ccb = require('ccb')\n"
                      "ccb.content.add(ccb.content.Item { id = 'lua_text_hash', "
                      "copy_from = 'rock', name = " + name + " })\n" );

--- a/tests/lua_platform_translation_test.cpp
+++ b/tests/lua_platform_translation_test.cpp
@@ -1,0 +1,55 @@
+#if defined(CATA_ENABLE_LUA_PLATFORM) && CATA_ENABLE_LUA_PLATFORM
+#include "lua_platform_test_support.h"
+
+TEST_CASE( "lua_platform_translation_fallback_and_lifetime",
+           "[lua][platform][runtime][translations]" )
+{
+    cata::lua_platform::clear_active_runtimes();
+    sol::state lua;
+    lua.open_libraries( sol::lib::base );
+    sol::table ccb = lua.create_table();
+    const std::shared_ptr<cata::lua_platform::runtime> runtime =
+        cata::lua_platform::make_runtime( "lua_platform_translation_test", 1901, lua );
+    on_out_of_scope cleanup( []() {
+        cata::lua_platform::clear_active_runtimes();
+    } );
+    cata::lua_platform::install_runtime_api( runtime, lua, ccb );
+    cata::lua_platform::set_active_runtimes( { runtime } );
+    lua["ccb"] = ccb;
+
+    const auto run = [&lua]( const std::string &source ) {
+        const sol::protected_function_result result = lua.safe_script(
+                    source, sol::script_pass_on_error );
+        if( !result.valid() ) {
+            const sol::error error = result;
+            INFO( error.what() );
+            REQUIRE( result.valid() );
+        }
+    };
+    run( R"(
+        assert(not pcall(ccb.services.translate, "before world ready"))
+        assert(not pcall(ccb.services.translate_plural, "one", "many", 1))
+    )" );
+    cata::lua_platform::runtime_world_ready( true );
+    // Unique source strings deliberately have no entries in installed catalogs.
+    run( R"(
+        local one = "ccb translation regression singular 1901"
+        local many = "ccb translation regression plural 1901"
+        assert(ccb.services.translate(one) == one)
+        assert(ccb.services.translate(one, "ccb regression context") == one)
+        assert(ccb.services.translate_plural(one, many, 1) == one)
+        assert(ccb.services.translate_plural(one, many, 0) == many)
+        assert(ccb.services.translate_plural(one, many, 2, "ccb regression context") == many)
+        assert(not pcall(ccb.services.translate_plural, one, many, -1))
+        assert(not pcall(ccb.services.translate, "a\0b"))
+        assert(not pcall(ccb.services.translate, one, "a\0b"))
+        assert(not pcall(ccb.services.translate_plural, one, "a\0b", 2))
+        assert(not pcall(ccb.services.translate_plural, one, many, 2, "a\0b"))
+    )" );
+    cata::lua_platform::clear_active_runtimes();
+    run( R"(
+        assert(not pcall(ccb.services.translate, "after world unload"))
+        assert(not pcall(ccb.services.translate_plural, "one", "many", 2))
+    )" );
+}
+#endif

--- a/tests/lua_platform_translation_test.cpp
+++ b/tests/lua_platform_translation_test.cpp
@@ -46,6 +46,13 @@ TEST_CASE( "lua_platform_translation_fallback_and_lifetime",
         assert(not pcall(ccb.services.translate_plural, one, "a\0b", 2))
         assert(not pcall(ccb.services.translate_plural, one, many, 2, "a\0b"))
     )" );
+    lua["native_count_accepts_2_to_32"] = sizeof( std::size_t ) > 4;
+    run( R"(
+        local success = pcall(ccb.services.translate_plural,
+            "ccb translation regression singular 1901", "ccb translation regression plural 1901",
+            4294967296)
+        assert(success == native_count_accepts_2_to_32)
+    )" );
     cata::lua_platform::clear_active_runtimes();
     run( R"(
         assert(not pcall(ccb.services.translate, "after world unload"))

--- a/tests/lua_platform_translation_test.cpp
+++ b/tests/lua_platform_translation_test.cpp
@@ -17,9 +17,9 @@ TEST_CASE( "lua_platform_translation_fallback_and_lifetime",
     cata::lua_platform::set_active_runtimes( { runtime } );
     lua["ccb"] = ccb;
 
-    const auto run = [&lua]( const std::string &source ) {
+    const auto run = [&lua]( const std::string & source ) {
         const sol::protected_function_result result = lua.safe_script(
-                    source, sol::script_pass_on_error );
+                source, sol::script_pass_on_error );
         if( !result.valid() ) {
             const sol::error error = result;
             INFO( error.what() );

--- a/tools/lua_api/README.md
+++ b/tools/lua_api/README.md
@@ -116,3 +116,53 @@ python3 tools/test_create_lua_mod.py
 The editor gate checks both real templates and deliberately invalid author code
 for unknown APIs, missing arguments and wrong argument types. It is a static
 acceptance gate and does not trigger a C++ build or a full content audit.
+
+## Extract runtime translations (draft API)
+
+The independent localization implementation adds `ccb.services.translate(text,
+context?)` and `ccb.services.translate_plural(singular, plural, count, context?)`.
+These calls use the current native game catalog after `world_ready`. They return
+plain strings; they do not create deferred translation objects for content names
+or Mod metadata. Missing entries return source text (singular for count 1,
+plural otherwise). Negative counts, counts outside native `size_t`, and embedded
+NUL in text/context are rejected. No new catalog registry or Lua interpreter is
+introduced. Native loading, locale switching and plural-rule acceptance remain
+pending; source implementation is not a shipped-compatibility claim.
+
+Write full calls with literal messages and optional literal context:
+
+```lua
+local ccb = require("ccb")
+ccb.runtime.handler("translated_ready", function()
+    ccb.services.message(ccb.services.translate("Ready", "MyMod status"))
+    local count = 2
+    local message = ccb.services.translate_plural(
+        "%d item is ready", "%d items are ready", count, "MyMod status")
+    ccb.services.message(string.format(message, count))
+end)
+ccb.runtime.on("world_ready", "translated_ready")
+```
+
+Use GNU `xgettext` to extract explicitly named source files without executing
+Lua. Run from the Mod root for stable relative references:
+
+```sh
+python3 /path/CCB/tools/lua_api/extract_translations.py main.lua runtime/status.lua --output messages.pot
+python3 /path/CCB/tools/lua_api/extract_translations.py main.lua runtime/status.lua --output messages.pot --check
+```
+
+The tool does not traverse directories. `--check` does not write; exit 1 means a
+missing/stale POT and exit 2 means extraction/setup failure. Output is stable for
+unchanged inputs and the same xgettext version. Calls through renamed aliases,
+computed messages, and dynamic contexts cannot be extracted reliably: keep the
+full `ccb.services` spelling and literals. Review the POT after extraction.
+Formatting is a separate Lua operation; translators must preserve placeholders.
+
+Translate the POT into PO catalogs with normal gettext tooling. For an external
+Mod under the game's configured user Mod directory, the existing native scanner
+accepts `MyMod/lang/mo/<language>/LC_MESSAGES/MyMod.mo`; language is taken from
+the parent of `LC_MESSAGES`. Catalog compilation/installation is a separate
+release step. Bundled Mod catalogs are not automatically discovered by that
+user-directory scan. The native registry is shared: use a distinctive context
+for ambiguous/common messages. This batch does not change catalog precedence or
+add live catalog reload. Restart the game after installing changed catalogs.

--- a/tools/lua_api/README.md
+++ b/tools/lua_api/README.md
@@ -196,3 +196,9 @@ release step. Bundled Mod catalogs are not automatically discovered by that
 user-directory scan. The native registry is shared: use a distinctive context
 for ambiguous/common messages. This batch does not change catalog precedence or
 add live catalog reload. Restart the game after installing changed catalogs.
+
+The same `ccb.content.text` marker is accepted by Skill names/descriptions,
+SkillDisplay labels and Skill theory/practice level descriptions. These fields
+reject plural markers and keep ordinary strings literal. Use the full helper
+name with literal source/context arguments so the existing extractor can find
+these strings; no separate Skill extraction command is required.

--- a/tools/lua_api/README.md
+++ b/tools/lua_api/README.md
@@ -180,6 +180,8 @@ unchanged inputs and the same xgettext version. Calls through renamed aliases,
 computed messages, and dynamic contexts cannot be extracted reliably: keep the
 full `ccb.services.translate`/`translate_plural` or `ccb.content.text`/`plural_text`
 spelling and literals. Review the POT after extraction.
+An immediately preceding `-- TRANSLATORS: ...` comment is retained for translators;
+ordinary implementation comments are not added to the template.
 Formatting is a separate Lua operation; translators must preserve placeholders.
 For automatic gettext format flags, nest the translation call directly inside
 `string.format(ccb.services.translate("%d items", "MyMod status"), count)`.

--- a/tools/lua_api/README.md
+++ b/tools/lua_api/README.md
@@ -151,7 +151,9 @@ python3 /path/CCB/tools/lua_api/extract_translations.py main.lua runtime/status.
 python3 /path/CCB/tools/lua_api/extract_translations.py main.lua runtime/status.lua --output messages.pot --check
 ```
 
-The tool does not traverse directories. `--check` does not write; exit 1 means a
+The tool does not traverse directories. It stages output before replacing the
+POT so write failures preserve the previous template; output cannot alias an
+input source. `--check` does not write; exit 1 means a
 missing/stale POT and exit 2 means extraction/setup failure. Output is stable for
 unchanged inputs and the same xgettext version. Calls through renamed aliases,
 computed messages, and dynamic contexts cannot be extracted reliably: keep the

--- a/tools/lua_api/README.md
+++ b/tools/lua_api/README.md
@@ -117,7 +117,7 @@ The editor gate checks both real templates and deliberately invalid author code
 for unknown APIs, missing arguments and wrong argument types. It is a static
 acceptance gate and does not trigger a C++ build or a full content audit.
 
-## Extract runtime translations (draft API)
+## Extract translations (draft API)
 
 The independent localization implementation adds `ccb.services.translate(text,
 context?)` and `ccb.services.translate_plural(singular, plural, count, context?)`.
@@ -143,6 +143,27 @@ end)
 ccb.runtime.on("world_ready", "translated_ready")
 ```
 
+Static Item names and descriptions instead accept deferred values. Plain strings
+remain untranslated; other content builders and Mod metadata do not yet accept
+these values. Source forms must be nonempty and all arguments must exclude NUL:
+
+```lua
+local ccb = require("ccb")
+ccb.content.add(ccb.content.Item {
+    id = "MyMod_water_bottle", mass_grams = 500, volume_ml = 500,
+    name = ccb.content.plural_text("bottle of water", "bottles of water", "MyMod item"),
+    description = ccb.content.text("A sealed bottle.", "MyMod description")
+})
+```
+
+These immutable values preserve source text for native translation when displayed,
+including after a language change. Descriptions reject plural values. A name
+marked with `text` uses the same source as its plural fallback; use `plural_text`
+for distinct forms. Inheritance preserves an omitted translated field, while an
+explicit plain string replaces it. Changes to text context, plural forms or
+translation status require static content reload. Native/locale acceptance remains
+pending; the extractor's passing checks alone do not prove game integration.
+
 Use GNU `xgettext` to extract explicitly named source files without executing
 Lua. Run from the Mod root for stable relative references:
 
@@ -157,7 +178,8 @@ input source. `--check` does not write; exit 1 means a
 missing/stale POT and exit 2 means extraction/setup failure. Output is stable for
 unchanged inputs and the same xgettext version. Calls through renamed aliases,
 computed messages, and dynamic contexts cannot be extracted reliably: keep the
-full `ccb.services` spelling and literals. Review the POT after extraction.
+full `ccb.services.translate`/`translate_plural` or `ccb.content.text`/`plural_text`
+spelling and literals. Review the POT after extraction.
 Formatting is a separate Lua operation; translators must preserve placeholders.
 For automatic gettext format flags, nest the translation call directly inside
 `string.format(ccb.services.translate("%d items", "MyMod status"), count)`.

--- a/tools/lua_api/README.md
+++ b/tools/lua_api/README.md
@@ -157,6 +157,10 @@ unchanged inputs and the same xgettext version. Calls through renamed aliases,
 computed messages, and dynamic contexts cannot be extracted reliably: keep the
 full `ccb.services` spelling and literals. Review the POT after extraction.
 Formatting is a separate Lua operation; translators must preserve placeholders.
+For automatic gettext format flags, nest the translation call directly inside
+`string.format(ccb.services.translate("%d items", "MyMod status"), count)`.
+A translation stored in an intermediate variable cannot inherit that static
+format-use information.
 
 Translate the POT into PO catalogs with normal gettext tooling. For an external
 Mod under the game's configured user Mod directory, the existing native scanner

--- a/tools/lua_api/extract_translations.py
+++ b/tools/lua_api/extract_translations.py
@@ -30,6 +30,9 @@ def extract(files: list[Path], executable: str = "xgettext") -> str:
     command = [executable, "--language=Lua", "--from-code=UTF-8", "--keyword=",
                "--force-po", "--no-wrap", "--output=-"]
     command.extend(f"--keyword={keyword}" for keyword in KEYWORDS)
+    command.extend(("--flag=ccb.services.translate:1:pass-lua-format",
+                    "--flag=ccb.services.translate_plural:1:pass-lua-format",
+                    "--flag=ccb.services.translate_plural:2:pass-lua-format"))
     command.append("--")
     command.extend(sorted({str(path) for path in files}))
     try:
@@ -43,9 +46,10 @@ def extract(files: list[Path], executable: str = "xgettext") -> str:
         print(result.stderr.rstrip(), file=sys.stderr)
     # Keep xgettext's UTF-8 header during extraction: --omit-header can lose
     # non-ASCII strings in some gettext versions. Replace only after extraction.
-    _, separator, messages = result.stdout.partition("\n\n")
-    if not separator:
+    header, _, messages = result.stdout.partition("\n\n")
+    if 'msgid ""\nmsgstr ""' not in header or '"Content-Type:' not in header:
         raise ValueError("xgettext returned an invalid translation template")
+    # A header-only output is valid when none of the inputs contains messages.
     return HEADER + messages
 
 

--- a/tools/lua_api/extract_translations.py
+++ b/tools/lua_api/extract_translations.py
@@ -13,6 +13,10 @@ KEYWORDS = (
     "ccb.services.translate:1,2c,2t",
     "ccb.services.translate_plural:1,2,3t",
     "ccb.services.translate_plural:1,2,4c,4t",
+    "ccb.content.text:1,1t",
+    "ccb.content.text:1,2c,2t",
+    "ccb.content.plural_text:1,2,2t",
+    "ccb.content.plural_text:1,2,3c,3t",
 )
 HEADER = (
     'msgid ""\nmsgstr ""\n'

--- a/tools/lua_api/extract_translations.py
+++ b/tools/lua_api/extract_translations.py
@@ -26,14 +26,15 @@ HEADER = (
 
 
 def extract(files: list[Path], executable: str = "xgettext") -> str:
-    """Keep the caller's relative source references; stable input order is sorted."""
+    """Keep relative source references and sort the input order."""
     for path in files:
         if path.suffix != ".lua" or not path.is_file():
             raise ValueError(f"expected an existing Lua source file: {path}")
     if not files:
         raise ValueError("at least one Lua source file is required")
     command = [executable, "--language=Lua", "--from-code=UTF-8", "--keyword=",
-               "--force-po", "--no-wrap", "--add-comments=TRANSLATORS:", "--output=-"]
+               "--force-po", "--no-wrap", "--add-comments=TRANSLATORS:",
+               "--output=-"]
     command.extend(f"--keyword={keyword}" for keyword in KEYWORDS)
     command.extend(("--flag=ccb.services.translate:1:pass-lua-format",
                     "--flag=ccb.services.translate_plural:1:pass-lua-format",
@@ -46,11 +47,13 @@ def extract(files: list[Path], executable: str = "xgettext") -> str:
     except (OSError, UnicodeError) as error:
         raise ValueError(f"cannot run GNU xgettext: {error}") from error
     if result.returncode:
-        raise ValueError(f"xgettext failed ({result.returncode}): {result.stderr.strip()}")
+        raise ValueError(
+            f"xgettext failed ({result.returncode}): {result.stderr.strip()}")
     if result.stderr:
         print(result.stderr.rstrip(), file=sys.stderr)
     # Keep xgettext's UTF-8 header during extraction: --omit-header can lose
-    # non-ASCII strings in some gettext versions. Replace only after extraction.
+    # non-ASCII strings in some gettext versions. Replace only after
+    # extraction.
     header, _, messages = result.stdout.partition("\n\n")
     if 'msgid ""\nmsgstr ""' not in header or '"Content-Type:' not in header:
         raise ValueError("xgettext returned an invalid translation template")
@@ -58,13 +61,13 @@ def extract(files: list[Path], executable: str = "xgettext") -> str:
     return HEADER + messages
 
 
-
 def write_template(path: Path, content: str) -> None:
-    """Stage beside the destination so a failed write leaves its old file intact."""
+    """Stage output so a failed write preserves the old file."""
     temporary = None
     try:
-        with tempfile.NamedTemporaryFile(dir=path.parent, prefix=f".{path.name}.",
-                                         suffix=".tmp", delete=False) as stream:
+        with tempfile.NamedTemporaryFile(
+                dir=path.parent, prefix=f".{path.name}.",
+                suffix=".tmp", delete=False) as stream:
             temporary = Path(stream.name)
             stream.write(content.encode("utf-8"))
         if path.is_file():
@@ -77,23 +80,32 @@ def write_template(path: Path, content: str) -> None:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("files", nargs="+", type=Path, help="explicit Lua source files")
-    parser.add_argument("--output", type=Path, help="POT destination; default is stdout")
-    parser.add_argument("--check", action="store_true", help="compare --output without writing")
-    parser.add_argument("--xgettext", default="xgettext", help="GNU xgettext executable")
+    parser.add_argument("files", nargs="+", type=Path,
+                        help="explicit Lua source files")
+    parser.add_argument("--output", type=Path,
+                        help="POT destination; default is stdout")
+    parser.add_argument("--check", action="store_true",
+                        help="compare --output without writing")
+    parser.add_argument("--xgettext", default="xgettext",
+                        help="GNU xgettext executable")
     args = parser.parse_args(argv)
     if args.check and args.output is None:
         parser.error("--check requires --output")
     try:
         if args.output:
             for path in args.files:
-                if (args.output.resolve() == path.resolve()
-                        or (args.output.exists() and path.exists() and args.output.samefile(path))):
-                    raise ValueError("output must not overwrite an input source")
+                if (args.output.resolve() == path.resolve() or
+                        (args.output.exists() and path.exists() and
+                         args.output.samefile(path))):
+                    raise ValueError(
+                        "output must not overwrite an input source")
         content = extract(args.files, args.xgettext)
         if args.check:
-            if not args.output.is_file() or args.output.read_bytes() != content.encode("utf-8"):
-                print(f"translation template is out of date: {args.output}", file=sys.stderr)
+            if (not args.output.is_file() or
+                    args.output.read_bytes() != content.encode("utf-8")):
+                print(
+                    f"translation template is out of date: {args.output}",
+                    file=sys.stderr)
                 return 1
         elif args.output:
             write_template(args.output, content)

--- a/tools/lua_api/extract_translations.py
+++ b/tools/lua_api/extract_translations.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Extract literal Platform text with GNU xgettext; never execute Lua."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import subprocess
+import sys
+
+KEYWORDS = (
+    "ccb.services.translate:1,1t",
+    "ccb.services.translate:1,2c,2t",
+    "ccb.services.translate_plural:1,2,3t",
+    "ccb.services.translate_plural:1,2,4c,4t",
+)
+HEADER = (
+    'msgid ""\nmsgstr ""\n'
+    '"Content-Type: text/plain; charset=UTF-8\\n"\n'
+    '"Content-Transfer-Encoding: 8bit\\n"\n\n'
+)
+
+
+def extract(files: list[Path], executable: str = "xgettext") -> str:
+    """Keep the caller's relative source references; stable input order is sorted."""
+    for path in files:
+        if path.suffix != ".lua" or not path.is_file():
+            raise ValueError(f"expected an existing Lua source file: {path}")
+    if not files:
+        raise ValueError("at least one Lua source file is required")
+    command = [executable, "--language=Lua", "--from-code=UTF-8", "--keyword=",
+               "--force-po", "--no-wrap", "--output=-"]
+    command.extend(f"--keyword={keyword}" for keyword in KEYWORDS)
+    command.append("--")
+    command.extend(sorted({str(path) for path in files}))
+    try:
+        result = subprocess.run(command, capture_output=True, text=True,
+                                encoding="utf-8", check=False)
+    except (OSError, UnicodeError) as error:
+        raise ValueError(f"cannot run GNU xgettext: {error}") from error
+    if result.returncode:
+        raise ValueError(f"xgettext failed ({result.returncode}): {result.stderr.strip()}")
+    if result.stderr:
+        print(result.stderr.rstrip(), file=sys.stderr)
+    # Keep xgettext's UTF-8 header during extraction: --omit-header can lose
+    # non-ASCII strings in some gettext versions. Replace only after extraction.
+    _, separator, messages = result.stdout.partition("\n\n")
+    if not separator:
+        raise ValueError("xgettext returned an invalid translation template")
+    return HEADER + messages
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("files", nargs="+", type=Path, help="explicit Lua source files")
+    parser.add_argument("--output", type=Path, help="POT destination; default is stdout")
+    parser.add_argument("--check", action="store_true", help="compare --output without writing")
+    parser.add_argument("--xgettext", default="xgettext", help="GNU xgettext executable")
+    args = parser.parse_args(argv)
+    if args.check and args.output is None:
+        parser.error("--check requires --output")
+    try:
+        if args.output and args.output.resolve() in {path.resolve() for path in args.files}:
+            raise ValueError("output must not overwrite an input source")
+        content = extract(args.files, args.xgettext)
+        if args.check:
+            if not args.output.is_file() or args.output.read_bytes() != content.encode("utf-8"):
+                print(f"translation template is out of date: {args.output}", file=sys.stderr)
+                return 1
+        elif args.output:
+            args.output.write_bytes(content.encode("utf-8"))
+        else:
+            sys.stdout.write(content)
+        return 0
+    except (OSError, UnicodeError, ValueError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lua_api/extract_translations.py
+++ b/tools/lua_api/extract_translations.py
@@ -6,6 +6,7 @@ import argparse
 from pathlib import Path
 import subprocess
 import sys
+import tempfile
 
 KEYWORDS = (
     "ccb.services.translate:1,1t",
@@ -53,6 +54,23 @@ def extract(files: list[Path], executable: str = "xgettext") -> str:
     return HEADER + messages
 
 
+
+def write_template(path: Path, content: str) -> None:
+    """Stage beside the destination so a failed write leaves its old file intact."""
+    temporary = None
+    try:
+        with tempfile.NamedTemporaryFile(dir=path.parent, prefix=f".{path.name}.",
+                                         suffix=".tmp", delete=False) as stream:
+            temporary = Path(stream.name)
+            stream.write(content.encode("utf-8"))
+        if path.is_file():
+            temporary.chmod(path.stat().st_mode & 0o777)
+        temporary.replace(path)
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("files", nargs="+", type=Path, help="explicit Lua source files")
@@ -63,15 +81,18 @@ def main(argv: list[str] | None = None) -> int:
     if args.check and args.output is None:
         parser.error("--check requires --output")
     try:
-        if args.output and args.output.resolve() in {path.resolve() for path in args.files}:
-            raise ValueError("output must not overwrite an input source")
+        if args.output:
+            for path in args.files:
+                if (args.output.resolve() == path.resolve()
+                        or (args.output.exists() and path.exists() and args.output.samefile(path))):
+                    raise ValueError("output must not overwrite an input source")
         content = extract(args.files, args.xgettext)
         if args.check:
             if not args.output.is_file() or args.output.read_bytes() != content.encode("utf-8"):
                 print(f"translation template is out of date: {args.output}", file=sys.stderr)
                 return 1
         elif args.output:
-            args.output.write_bytes(content.encode("utf-8"))
+            write_template(args.output, content)
         else:
             sys.stdout.write(content)
         return 0

--- a/tools/lua_api/extract_translations.py
+++ b/tools/lua_api/extract_translations.py
@@ -33,7 +33,7 @@ def extract(files: list[Path], executable: str = "xgettext") -> str:
     if not files:
         raise ValueError("at least one Lua source file is required")
     command = [executable, "--language=Lua", "--from-code=UTF-8", "--keyword=",
-               "--force-po", "--no-wrap", "--output=-"]
+               "--force-po", "--no-wrap", "--add-comments=TRANSLATORS:", "--output=-"]
     command.extend(f"--keyword={keyword}" for keyword in KEYWORDS)
     command.extend(("--flag=ccb.services.translate:1:pass-lua-format",
                     "--flag=ccb.services.translate_plural:1:pass-lua-format",

--- a/tools/lua_api/test_extract_translations.py
+++ b/tools/lua_api/test_extract_translations.py
@@ -16,9 +16,11 @@ class ExtractTranslationsTest(unittest.TestCase):
         self.addCleanup(self.directory.cleanup)
         self.root = Path(self.directory.name)
         self.source = self.root / "main.lua"
-        self.source.write_text('ccb.services.translate("hello")\n', encoding="utf-8")
+        self.source.write_text(
+            'ccb.services.translate("hello")\n', encoding="utf-8")
 
-    @unittest.skipUnless(shutil.which("xgettext"), "GNU xgettext is not installed")
+    @unittest.skipUnless(shutil.which("xgettext"),
+                         "GNU xgettext is not installed")
     def test_no_messages_produces_a_valid_empty_template(self):
         self.source.write_text("local value = 42\n", encoding="utf-8")
         output = extract([self.source])
@@ -26,10 +28,12 @@ class ExtractTranslationsTest(unittest.TestCase):
         self.assertEqual(output.count('msgid '), 1)
         self.assertNotIn("POT-Creation-Date", output)
 
-    @unittest.skipUnless(shutil.which("xgettext"), "GNU xgettext is not installed")
+    @unittest.skipUnless(shutil.which("xgettext"),
+                         "GNU xgettext is not installed")
     def test_format_flags_follow_enclosing_string_format(self):
         self.source.write_text('string.format(ccb.services.translate_plural('
-                               '"%d apple", "%d apples", n, "fruit"), n)', encoding="utf-8")
+                               '"%d apple", "%d apples", n, "fruit"), n)',
+                               encoding="utf-8")
         output = extract([self.source])
         self.assertIn("#, lua-format", output)
         self.assertIn('msgctxt "fruit"', output)
@@ -37,7 +41,8 @@ class ExtractTranslationsTest(unittest.TestCase):
     def test_failed_replacement_preserves_the_previous_template(self):
         destination = self.root / "messages.pot"
         destination.write_text("existing template", encoding="utf-8")
-        with patch.object(Path, "replace", side_effect=OSError("replacement failed")):
+        with patch.object(
+                Path, "replace", side_effect=OSError("replacement failed")):
             with self.assertRaisesRegex(OSError, "replacement failed"):
                 write_template(destination, "new template")
         self.assertEqual(destination.read_text(), "existing template")
@@ -52,19 +57,23 @@ class ExtractTranslationsTest(unittest.TestCase):
         except OSError as error:
             self.skipTest(f"hard links unavailable: {error}")
         before = self.source.read_bytes()
-        with contextlib.redirect_stderr(io.StringIO()), patch("extract_translations.extract") as run:
-            self.assertEqual(main([str(self.source), "--output", str(destination)]), 2)
+        with (contextlib.redirect_stderr(io.StringIO()),
+              patch("extract_translations.extract") as run):
+            self.assertEqual(
+                main([str(self.source), "--output", str(destination)]), 2)
             run.assert_not_called()
         self.assertEqual(self.source.read_bytes(), before)
 
     def test_failed_extractor_is_not_success(self):
-        with patch("extract_translations.subprocess.run", return_value=
-                   subprocess.CompletedProcess([], 1, "", "parse error")):
+        failure = subprocess.CompletedProcess([], 1, "", "parse error")
+        with patch("extract_translations.subprocess.run",
+                   return_value=failure):
             with self.assertRaisesRegex(ValueError, "parse error"):
                 extract([self.source])
 
     def test_missing_tool_has_actionable_error(self):
-        with patch("extract_translations.subprocess.run", side_effect=FileNotFoundError("missing")):
+        with patch("extract_translations.subprocess.run",
+                   side_effect=FileNotFoundError("missing")):
             with self.assertRaisesRegex(ValueError, "cannot run GNU xgettext"):
                 extract([self.source])
 
@@ -74,7 +83,8 @@ class ExtractTranslationsTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "at least one"):
             extract([])
 
-    @unittest.skipUnless(shutil.which("xgettext"), "GNU xgettext is not installed")
+    @unittest.skipUnless(shutil.which("xgettext"),
+                         "GNU xgettext is not installed")
     def test_context_plural_literals_and_no_execution(self):
         self.source.write_text('''
 error("must never execute")
@@ -91,13 +101,15 @@ ccb.services.translate(variable)
         self.assertIn('msgid "Hello"', output)
         self.assertIn('msgctxt "verb"\nmsgid "Open"', output)
         self.assertIn('msgid "apple"\nmsgid_plural "apples"', output)
-        self.assertIn('msgctxt "fruit"\nmsgid "pear"\nmsgid_plural "pears"', output)
+        self.assertIn(
+            'msgctxt "fruit"\nmsgid "pear"\nmsgid_plural "pears"', output)
         self.assertIn("多行", output)
         self.assertNotIn("comment is not a message", output)
         self.assertNotIn("must never execute", output)
         self.assertEqual(output, extract([self.source, self.source]))
 
-    @unittest.skipUnless(shutil.which("xgettext"), "GNU xgettext is not installed")
+    @unittest.skipUnless(shutil.which("xgettext"),
+                         "GNU xgettext is not installed")
     def test_static_content_markers_extract_context_and_plural_forms(self):
         self.source.write_text('''
 local item = ccb.content.Item {
@@ -108,12 +120,16 @@ local other_name = ccb.content.plural_text("fish", "fish")
 local other_description = ccb.content.text("Fresh water.")
 ''', encoding="utf-8")
         output = extract([self.source])
-        self.assertIn('msgctxt "container"\nmsgid "bottle"\nmsgid_plural "bottles"', output)
-        self.assertIn('msgctxt "item description"\nmsgid "A small bottle."', output)
+        self.assertIn(
+            'msgctxt "container"\nmsgid "bottle"\n'
+            'msgid_plural "bottles"', output)
+        self.assertIn(
+            'msgctxt "item description"\nmsgid "A small bottle."', output)
         self.assertIn('msgid "fish"\nmsgid_plural "fish"', output)
         self.assertIn('msgid "Fresh water."', output)
 
-    @unittest.skipUnless(shutil.which("xgettext"), "GNU xgettext is not installed")
+    @unittest.skipUnless(shutil.which("xgettext"),
+                         "GNU xgettext is not installed")
     def test_explicit_translator_notes_are_retained(self):
         self.source.write_text('''
 -- TRANSLATORS: This is a button action, not a door state.
@@ -122,10 +138,12 @@ ccb.services.translate("Open", "MyMod action")
 ccb.content.text("A description.")
 ''', encoding="utf-8")
         output = extract([self.source])
-        self.assertIn("TRANSLATORS: This is a button action, not a door state.", output)
+        self.assertIn(
+            "TRANSLATORS: This is a button action, not a door state.", output)
         self.assertNotIn("This implementation comment", output)
 
-    @unittest.skipUnless(shutil.which("xgettext"), "GNU xgettext is not installed")
+    @unittest.skipUnless(shutil.which("xgettext"),
+                         "GNU xgettext is not installed")
     def test_check_does_not_write_and_rejects_input_overwrite(self):
         destination = self.root / "messages.pot"
         args = [str(self.source), "--output", str(destination)]
@@ -135,11 +153,13 @@ ccb.content.text("A description.")
             self.assertEqual(main(args), 0)
             original = destination.read_bytes()
             self.assertEqual(main(args + ["--check"]), 0)
-            self.source.write_text('ccb.services.translate("changed")', encoding="utf-8")
+            self.source.write_text(
+                'ccb.services.translate("changed")', encoding="utf-8")
             self.assertEqual(main(args + ["--check"]), 1)
             self.assertEqual(destination.read_bytes(), original)
             source_bytes = self.source.read_bytes()
-            self.assertEqual(main([str(self.source), "--output", str(self.source)]), 2)
+            self.assertEqual(
+                main([str(self.source), "--output", str(self.source)]), 2)
             self.assertEqual(self.source.read_bytes(), source_bytes)
 
 

--- a/tools/lua_api/test_extract_translations.py
+++ b/tools/lua_api/test_extract_translations.py
@@ -114,6 +114,18 @@ local other_description = ccb.content.text("Fresh water.")
         self.assertIn('msgid "Fresh water."', output)
 
     @unittest.skipUnless(shutil.which("xgettext"), "GNU xgettext is not installed")
+    def test_explicit_translator_notes_are_retained(self):
+        self.source.write_text('''
+-- TRANSLATORS: This is a button action, not a door state.
+ccb.services.translate("Open", "MyMod action")
+-- This implementation comment is not a translator note.
+ccb.content.text("A description.")
+''', encoding="utf-8")
+        output = extract([self.source])
+        self.assertIn("TRANSLATORS: This is a button action, not a door state.", output)
+        self.assertNotIn("This implementation comment", output)
+
+    @unittest.skipUnless(shutil.which("xgettext"), "GNU xgettext is not installed")
     def test_check_does_not_write_and_rejects_input_overwrite(self):
         destination = self.root / "messages.pot"
         args = [str(self.source), "--output", str(destination)]

--- a/tools/lua_api/test_extract_translations.py
+++ b/tools/lua_api/test_extract_translations.py
@@ -18,6 +18,22 @@ class ExtractTranslationsTest(unittest.TestCase):
         self.source = self.root / "main.lua"
         self.source.write_text('ccb.services.translate("hello")\n', encoding="utf-8")
 
+    @unittest.skipUnless(shutil.which("xgettext"), "GNU xgettext is not installed")
+    def test_no_messages_produces_a_valid_empty_template(self):
+        self.source.write_text("local value = 42\n", encoding="utf-8")
+        output = extract([self.source])
+        self.assertIn('charset=UTF-8', output)
+        self.assertEqual(output.count('msgid '), 1)
+        self.assertNotIn("POT-Creation-Date", output)
+
+    @unittest.skipUnless(shutil.which("xgettext"), "GNU xgettext is not installed")
+    def test_format_flags_follow_enclosing_string_format(self):
+        self.source.write_text('string.format(ccb.services.translate_plural('
+                               '"%d apple", "%d apples", n, "fruit"), n)', encoding="utf-8")
+        output = extract([self.source])
+        self.assertIn("#, lua-format", output)
+        self.assertIn('msgctxt "fruit"', output)
+
     def test_failed_extractor_is_not_success(self):
         with patch("extract_translations.subprocess.run", return_value=
                    subprocess.CompletedProcess([], 1, "", "parse error")):

--- a/tools/lua_api/test_extract_translations.py
+++ b/tools/lua_api/test_extract_translations.py
@@ -7,7 +7,7 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
-from extract_translations import extract, main
+from extract_translations import extract, main, write_template
 
 
 class ExtractTranslationsTest(unittest.TestCase):
@@ -33,6 +33,29 @@ class ExtractTranslationsTest(unittest.TestCase):
         output = extract([self.source])
         self.assertIn("#, lua-format", output)
         self.assertIn('msgctxt "fruit"', output)
+
+    def test_failed_replacement_preserves_the_previous_template(self):
+        destination = self.root / "messages.pot"
+        destination.write_text("existing template", encoding="utf-8")
+        with patch.object(Path, "replace", side_effect=OSError("replacement failed")):
+            with self.assertRaisesRegex(OSError, "replacement failed"):
+                write_template(destination, "new template")
+        self.assertEqual(destination.read_text(), "existing template")
+        self.assertEqual(list(self.root.glob(".messages.pot.*.tmp")), [])
+        write_template(destination, "new template")
+        self.assertEqual(destination.read_text(), "new template")
+
+    def test_hardlinked_input_cannot_be_the_output(self):
+        destination = self.root / "messages.pot"
+        try:
+            destination.hardlink_to(self.source)
+        except OSError as error:
+            self.skipTest(f"hard links unavailable: {error}")
+        before = self.source.read_bytes()
+        with contextlib.redirect_stderr(io.StringIO()), patch("extract_translations.extract") as run:
+            self.assertEqual(main([str(self.source), "--output", str(destination)]), 2)
+            run.assert_not_called()
+        self.assertEqual(self.source.read_bytes(), before)
 
     def test_failed_extractor_is_not_success(self):
         with patch("extract_translations.subprocess.run", return_value=

--- a/tools/lua_api/test_extract_translations.py
+++ b/tools/lua_api/test_extract_translations.py
@@ -1,0 +1,80 @@
+import contextlib
+import io
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from extract_translations import extract, main
+
+
+class ExtractTranslationsTest(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.root = Path(self.directory.name)
+        self.source = self.root / "main.lua"
+        self.source.write_text('ccb.services.translate("hello")\n', encoding="utf-8")
+
+    def test_failed_extractor_is_not_success(self):
+        with patch("extract_translations.subprocess.run", return_value=
+                   subprocess.CompletedProcess([], 1, "", "parse error")):
+            with self.assertRaisesRegex(ValueError, "parse error"):
+                extract([self.source])
+
+    def test_missing_tool_has_actionable_error(self):
+        with patch("extract_translations.subprocess.run", side_effect=FileNotFoundError("missing")):
+            with self.assertRaisesRegex(ValueError, "cannot run GNU xgettext"):
+                extract([self.source])
+
+    def test_no_source_execution_or_directory_traversal(self):
+        with self.assertRaisesRegex(ValueError, "existing Lua source"):
+            extract([self.root])
+        with self.assertRaisesRegex(ValueError, "at least one"):
+            extract([])
+
+    @unittest.skipUnless(shutil.which("xgettext"), "GNU xgettext is not installed")
+    def test_context_plural_literals_and_no_execution(self):
+        self.source.write_text('''
+error("must never execute")
+ccb.services.translate("Hello")
+ccb.services.translate("Open", "verb")
+ccb.services.translate_plural("apple", "apples", n)
+ccb.services.translate_plural("pear", "pears", n, "fruit")
+ccb.services.translate([[多行
+文字]])
+-- ccb.services.translate("comment is not a message")
+ccb.services.translate(variable)
+''', encoding="utf-8")
+        output = extract([self.source])
+        self.assertIn('msgid "Hello"', output)
+        self.assertIn('msgctxt "verb"\nmsgid "Open"', output)
+        self.assertIn('msgid "apple"\nmsgid_plural "apples"', output)
+        self.assertIn('msgctxt "fruit"\nmsgid "pear"\nmsgid_plural "pears"', output)
+        self.assertIn("多行", output)
+        self.assertNotIn("comment is not a message", output)
+        self.assertNotIn("must never execute", output)
+        self.assertEqual(output, extract([self.source, self.source]))
+
+    @unittest.skipUnless(shutil.which("xgettext"), "GNU xgettext is not installed")
+    def test_check_does_not_write_and_rejects_input_overwrite(self):
+        destination = self.root / "messages.pot"
+        args = [str(self.source), "--output", str(destination)]
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(main(args + ["--check"]), 1)
+            self.assertFalse(destination.exists())
+            self.assertEqual(main(args), 0)
+            original = destination.read_bytes()
+            self.assertEqual(main(args + ["--check"]), 0)
+            self.source.write_text('ccb.services.translate("changed")', encoding="utf-8")
+            self.assertEqual(main(args + ["--check"]), 1)
+            self.assertEqual(destination.read_bytes(), original)
+            source_bytes = self.source.read_bytes()
+            self.assertEqual(main([str(self.source), "--output", str(self.source)]), 2)
+            self.assertEqual(self.source.read_bytes(), source_bytes)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/lua_api/test_extract_translations.py
+++ b/tools/lua_api/test_extract_translations.py
@@ -98,6 +98,22 @@ ccb.services.translate(variable)
         self.assertEqual(output, extract([self.source, self.source]))
 
     @unittest.skipUnless(shutil.which("xgettext"), "GNU xgettext is not installed")
+    def test_static_content_markers_extract_context_and_plural_forms(self):
+        self.source.write_text('''
+local item = ccb.content.Item {
+    name = ccb.content.plural_text("bottle", "bottles", "container"),
+    description = ccb.content.text("A small bottle.", "item description")
+}
+local other_name = ccb.content.plural_text("fish", "fish")
+local other_description = ccb.content.text("Fresh water.")
+''', encoding="utf-8")
+        output = extract([self.source])
+        self.assertIn('msgctxt "container"\nmsgid "bottle"\nmsgid_plural "bottles"', output)
+        self.assertIn('msgctxt "item description"\nmsgid "A small bottle."', output)
+        self.assertIn('msgid "fish"\nmsgid_plural "fish"', output)
+        self.assertIn('msgid "Fresh water."', output)
+
+    @unittest.skipUnless(shutil.which("xgettext"), "GNU xgettext is not installed")
     def test_check_does_not_write_and_rejects_input_overwrite(self):
         destination = self.root / "messages.pot"
         args = [str(self.source), "--output", str(destination)]


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

Adds native-catalog runtime services.translate / services.translate_plural after world_ready and immutable deferred content.text / content.plural_text values for static content.

Item names/descriptions accept deferred values; names support counted plurals and descriptions reject them. Skill names/descriptions, SkillDisplay labels, and theory/practice level descriptions accept singular text markers. Ordinary strings remain literal. Skill method arguments are parsed before either description map changes, and collection-kind markers distinguish theory/practice changes in static fingerprints. Item inheritance retains omitted translations and explicit literal overrides replace them; #762 separately fixes omitted-versus-explicit Item defaults.

Adds a GNU xgettext-based extractor for explicit Lua files, without executing Lua. It handles documented full helper names and argument counts, preserves UTF-8 and TRANSLATORS comments, retains format annotations, writes atomically and rejects source/output aliases. LuaLS declarations and author guidance cover the supported fields.

Validation: the unchanged extractor has 11 passing focused tests (0.109 s); changed-region AStyle checks and git diff --check passed. Native runtime/content/rollback/fingerprint regression source exists but was NOT compiled or executed. No catalog compilation, real locale switching, plural-rule or game acceptance ran. Other builders, Mod metadata translation and catalog hot reload remain deferred.

#### Responsible human

@LYHGLYTX

#### Documentation impact

Updates the Lua-first contract or author tooling guidance for the behavior described above.

#### Related CCB-Docs PR

https://github.com/CrimsonCrossBunker/CCB-Docs/pull/47 (draft; publish only after source acceptance).

#### Affected documentation IDs

cpp.lua-bridge

#### Generated reference impact

Generated native references are deferred to batch acceptance; no generated inventories were hand-edited.


#### Additional context

Keep draft; do not merge before morning review.