### PR TITLE
Reject out-of-range saved Lua recurrence turns before integer conversion

### DIFF
--- a/src/lua_platform_runtime_lifecycle.cpp
+++ b/src/lua_platform_runtime_lifecycle.cpp
@@ -1507,8 +1507,11 @@ void runtime_process_character_recurring( Character &character )
             if( const diag_value *stored = character.maybe_get_value(
                                                registration.due_variable ) ) {
                 const double raw = stored->dbl();
-                if( std::isfinite( raw ) && raw >= 0.0 &&
-                    raw <= static_cast<double>( std::numeric_limits<std::int64_t>::max() ) &&
+                // INT64_MAX rounds up to 2^63 as a double. That value must not
+                // reach the integer cast; use the exact, exclusive upper bound.
+                const double upper_bound =
+                    -static_cast<double>( std::numeric_limits<std::int64_t>::min() );
+                if( std::isfinite( raw ) && raw >= 0.0 && raw < upper_bound &&
                     std::trunc( raw ) == raw ) {
                     due = static_cast<std::int64_t>( raw );
                 }

--- a/tests/lua_platform_recurring_turn_range_test.cpp
+++ b/tests/lua_platform_recurring_turn_range_test.cpp
@@ -22,12 +22,14 @@ TEST_CASE( "lua_platform_character_recurrence_rejects_unrepresentable_saved_turn
     lua.set_function( "effect", [&effect_calls]() {
         ++effect_calls;
     } );
-    lua.set_function( "interval", [&interval_calls, &first_schedule]( const sol::table &payload ) {
+    lua.set_function( "interval", [&interval_calls, &first_schedule]( const sol::table & payload ) {
         ++interval_calls;
         first_schedule = payload["first_schedule"].get<bool>();
         return 10;
     } );
-    for( const char *handler : { "effect", "interval" } ) {
+    for( const char *handler : {
+             "effect", "interval"
+         } ) {
         const sol::protected_function_result registered =
             ccb["runtime"]["handler"]( handler, lua[handler] );
         REQUIRE( registered.valid() );

--- a/tests/lua_platform_recurring_turn_range_test.cpp
+++ b/tests/lua_platform_recurring_turn_range_test.cpp
@@ -1,0 +1,68 @@
+#if defined(CATA_ENABLE_LUA_PLATFORM) && CATA_ENABLE_LUA_PLATFORM
+#include "lua_platform_test_support.h"
+#include "lua_platform_runtime_internal.h"
+#include <cmath>
+
+TEST_CASE( "lua_platform_character_recurrence_rejects_unrepresentable_saved_turns",
+           "[lua][platform][runtime][recurring]" )
+{
+    cata::lua_platform::clear_active_runtimes();
+    sol::state lua;
+    sol::table ccb = lua.create_table();
+    const std::shared_ptr<cata::lua_platform::runtime> runtime =
+        cata::lua_platform::make_runtime( "recurring-turn-range", 1903, lua );
+    on_out_of_scope cleanup( []() {
+        cata::lua_platform::clear_active_runtimes();
+    } );
+    cata::lua_platform::install_runtime_api( runtime, lua, ccb );
+    cata::lua_platform::set_active_runtimes( { runtime } );
+    int effect_calls = 0;
+    int interval_calls = 0;
+    bool first_schedule = false;
+    lua.set_function( "effect", [&effect_calls]() {
+        ++effect_calls;
+    } );
+    lua.set_function( "interval", [&interval_calls, &first_schedule]( const sol::table &payload ) {
+        ++interval_calls;
+        first_schedule = payload["first_schedule"].get<bool>();
+        return 10;
+    } );
+    for( const char *handler : { "effect", "interval" } ) {
+        const sol::protected_function_result registered =
+            ccb["runtime"]["handler"]( handler, lua[handler] );
+        REQUIRE( registered.valid() );
+    }
+    const sol::protected_function_result policy =
+        ccb["runtime"]["character_recurring"]( "effect", "interval" );
+    REQUIRE( policy.valid() );
+    REQUIRE( runtime->character_recurring_handlers.size() == 1 );
+    const std::string due_variable = runtime->character_recurring_handlers.front().due_variable;
+    cata::lua_platform::runtime_world_ready( true );
+    npc actor;
+    actor.normalize();
+    actor.setID( character_id( 1903 ), true );
+
+    const double upper_bound =
+        -static_cast<double>( std::numeric_limits<std::int64_t>::min() );
+    SECTION( "rounded maximum does not become a negative due turn" ) {
+        actor.set_value( due_variable, upper_bound );
+        cata::lua_platform::runtime_process_character_recurring( actor );
+        CHECK( effect_calls == 0 );
+        CHECK( interval_calls == 1 );
+        CHECK( first_schedule );
+    }
+    SECTION( "largest representable in-range double remains a future due turn" ) {
+        actor.set_value( due_variable, std::nextafter( upper_bound, 0.0 ) );
+        cata::lua_platform::runtime_process_character_recurring( actor );
+        CHECK( effect_calls == 0 );
+        CHECK( interval_calls == 0 );
+    }
+    SECTION( "fractional due state is rescheduled without invoking the effect" ) {
+        actor.set_value( due_variable, 0.5 );
+        cata::lua_platform::runtime_process_character_recurring( actor );
+        CHECK( effect_calls == 0 );
+        CHECK( interval_calls == 1 );
+        CHECK( first_schedule );
+    }
+}
+#endif


### PR DESCRIPTION
#### Summary
Prevent an out-of-range floating-to-integer conversion when reading a saved Character recurrence due turn.

#### Responsible human
@LYHGLYTX

#### Purpose of change
The old comparison used double(INT64_MAX), which rounds up to 2^63. A stored due value of 2^63 therefore passed the check before an undefined int64_t conversion. It could be interpreted as an already-due negative turn instead of invalid saved state.

#### Describe the solution
Use an exact exclusive upper bound before converting. Invalid values follow the existing first-schedule path without invoking the effect. Add focused regression source for the boundary, its largest in-range neighboring double and fractional saved state.

#### Describe alternatives you've considered
Retain the existing Character-local scheduling representation; this is a narrow range-check correction and does not migrate saves or change the API.

#### Testing
git diff --check passed. Native test source was added but not compiled or run, as explicitly requested for this overnight task. No compiler, linker, game, broad suite or generated-inventory refresh was executed. Native acceptance remains required.

#### Documentation impact
Implementation correctness fix; existing runtime lifecycle and invalid-state behavior remain the contract. Pair with the pending Lua reliability documentation.

#### Related CCB-Docs PR
https://github.com/CrimsonCrossBunker/CCB-Docs/pull/47 (draft)

#### Affected documentation IDs
cpp.lua-bridge

#### Generated reference impact
No public declaration or API-shape change. Source-line inventory refresh is deferred to acceptance.

#### Additional context
Keep draft; do not merge or mark ready.