### PR TITLE
Expose guarded Lua script reload in the developer menu

### DIFF
--- a/data/lua/LUA_FIRST_PLATFORM.md
+++ b/data/lua/LUA_FIRST_PLATFORM.md
@@ -196,6 +196,19 @@ replacement preserves only the state explicitly defined by Platform lifecycle
 and persistence rules; external filesystem or process side effects are trusted
 code responsibilities and are not silently rolled back.
 
+A draft author-tool entry under **Debug menu → Game → Reload Lua Mod scripts**
+also appears in the searchable debug action list. It calls the existing runtime
+swap operation for active Mods, preserves its static-content gate, and displays
+loader failures. Reload is rejected while an active Mod still has an executing
+Lua call stack. A successful swap does not imply callbacks succeeded; inspect
+the message log. This UI integration has not been compiled or interactively
+accepted. Restart the game when static definitions change.
+
+调试菜单的“游戏 → 重新加载 Lua Mod 脚本”草稿入口调用已有脚本替换后端，也可通过调试
+动作搜索找到。活动 Mod 仍在执行 Lua 或静态定义发生变化时会拒绝替换并显示原因；
+成功替换注册表不代表回调无错误，
+应查看消息日志。修改静态定义后重启游戏；菜单集成尚未编译或完成交互验收。
+
 ## Native content model / 原生内容模型
 
 `ccb.content` is a pure-Lua native typed builder and registrar surface, not a

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -85,6 +85,7 @@
 #include "list.h"
 #include "localized_comparator.h"
 #include "lua_platform_hooks.h"
+#include "lua_platform_loader.h"
 #include "magic.h"
 #include "map.h"
 #include "map_extras.h"
@@ -310,6 +311,7 @@ std::string enum_to_string<debug_menu::debug_menu_index>( debug_menu::debug_menu
         case debug_menu::debug_menu_index::VEHICLE_EFFECTS: return "VEHICLE_EFFECTS";
         case debug_menu::debug_menu_index::WISHPROFICIENCY: return "WISHPROFICIENCY";
         case debug_menu::debug_menu_index::RELOAD_GPU_SHADERS: return "RELOAD_GPU_SHADERS";
+        case debug_menu::debug_menu_index::RELOAD_LUA_SCRIPTS: return "RELOAD_LUA_SCRIPTS";
         // *INDENT-ON*
         case debug_menu::debug_menu_index::last:
             break;
@@ -1032,6 +1034,8 @@ static int game_uilist()
         { uilist_entry( debug_menu_index::QUIT_NOSAVE, true, 'Q', _( "Quit to main menu" ) )  },
         { uilist_entry( debug_menu_index::QUICKLOAD, true, 'q', _( "Quickload" ) )  },
         { uilist_entry( debug_menu_index::SNAPSHOT_MENU, true, 'n', _( "Snapshot save/load menu" ) )  },
+        { uilist_entry( debug_menu_index::RELOAD_LUA_SCRIPTS,
+                        cata::lua_platform::is_enabled(), 'l', _( "Reload Lua Mod scripts" ) ) },
     };
 
     return uilist( _( "Game…" ), uilist_initializer );
@@ -4986,6 +4990,34 @@ const std::vector<debug_action_entry> &all_actions()
             debug_menu_index::IMGUI_DEMO, translate_marker( "ImGui demo" ), "imgui demo", "Game", []()
             {
                 run_imgui_demo();
+            }
+        },
+        {
+            debug_menu_index::RELOAD_LUA_SCRIPTS, translate_marker( "Reload Lua Mod scripts" ),
+            "reload lua mod scripts platform", "Game", []()
+            {
+                if( !cata::lua_platform::is_enabled() ) {
+                    popup( _( "This build does not include Lua Platform support." ) );
+                    return;
+                }
+                const std::vector<std::string> mods = cata::lua_platform::loaded_mod_ids();
+                if( mods.empty() ) {
+                    popup( _( "No Lua Mods are active in this world." ) );
+                    return;
+                }
+                std::string error;
+                if( !cata::lua_platform::reload_active_mods( error ) ) {
+                    if( error.find( "requires_full_data_reload:" ) == 0 ) {
+                        popup( _( "Lua static content changed. Restart the game to reload its definitions. "
+                                  "The previous script registrations remain active.\n\n%s" ), error );
+                    } else {
+                        popup( _( "Lua script reload failed. The previous script registrations remain "
+                                  "active.\n\n%s" ), error );
+                    }
+                    return;
+                }
+                add_msg( m_info, _( "Replaced Lua script registrations for %zu Mods. "
+                                   "Check the message log for callback errors." ), mods.size() );
             }
         },
         {

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -1034,8 +1034,10 @@ static int game_uilist()
         { uilist_entry( debug_menu_index::QUIT_NOSAVE, true, 'Q', _( "Quit to main menu" ) )  },
         { uilist_entry( debug_menu_index::QUICKLOAD, true, 'q', _( "Quickload" ) )  },
         { uilist_entry( debug_menu_index::SNAPSHOT_MENU, true, 'n', _( "Snapshot save/load menu" ) )  },
-        { uilist_entry( debug_menu_index::RELOAD_LUA_SCRIPTS,
-                        cata::lua_platform::is_enabled(), 'l', _( "Reload Lua Mod scripts" ) ) },
+        {
+            uilist_entry( debug_menu_index::RELOAD_LUA_SCRIPTS,
+                          cata::lua_platform::is_enabled(), 'l', _( "Reload Lua Mod scripts" ) )
+        },
     };
 
     return uilist( _( "Game…" ), uilist_initializer );
@@ -5017,7 +5019,7 @@ const std::vector<debug_action_entry> &all_actions()
                     return;
                 }
                 add_msg( m_info, _( "Replaced Lua script registrations for %zu Mods. "
-                                   "Check the message log for callback errors." ), mods.size() );
+                                    "Check the message log for callback errors." ), mods.size() );
             }
         },
         {

--- a/src/debug_menu_types.h
+++ b/src/debug_menu_types.h
@@ -118,6 +118,7 @@ enum class debug_menu_index : int {
     VEHICLE_EFFECTS,
     WISHPROFICIENCY,
     RELOAD_GPU_SHADERS,
+    RELOAD_LUA_SCRIPTS,
     last
 };
 

--- a/src/lua_platform_loader.cpp
+++ b/src/lua_platform_loader.cpp
@@ -715,6 +715,12 @@ bool reload_active_mods( std::string &error )
     std::vector<mod_source> sources;
     sources.reserve( active_states.size() );
     for( const runtime_state &state : active_states ) {
+        lua_Debug frame;
+        if( lua_getstack( state.lua->lua_state(), 0, &frame ) != 0 ) {
+            error = "Lua code is still executing for Mod '" + state.id +
+                    "'; retry script reload after it returns";
+            return false;
+        }
         active_fingerprint << state.id.size() << ':' << state.id << ':'
                            << runtime_fingerprint( state.platform ) << ';';
         sources.push_back( { state.id, state.root, state.entry } );

--- a/src/lua_platform_loader.cpp
+++ b/src/lua_platform_loader.cpp
@@ -47,6 +47,7 @@ extern "C" {
 
 #include "lua_platform_runtime.h"
 #include "lua_platform_sol.h"
+#include "cata_scope_helpers.h"
 #include "generic_factory.h"
 #include "item_factory.h"
 #include "itype.h"
@@ -72,6 +73,7 @@ std::vector<runtime_state> prepared_states;
 bool candidate_is_prepared = false;
 bool candidate_content_is_applied = false;
 bool candidate_content_is_finalized = false;
+bool script_reload_in_progress = false;
 std::size_t generation_counter = 0;
 
 bool path_is_within( const fs::path &path, const fs::path &directory )
@@ -706,6 +708,10 @@ std::string prepared_content_fingerprint()
 
 bool reload_active_mods( std::string &error )
 {
+    if( script_reload_in_progress ) {
+        error = "Lua script reload is already in progress; retry after it returns";
+        return false;
+    }
     if( active_states.empty() ) {
         error.clear();
         return true;
@@ -726,6 +732,12 @@ bool reload_active_mods( std::string &error )
         sources.push_back( { state.id, state.root, state.entry } );
     }
 
+    // Candidate entry scripts and replacement lifecycle callbacks can enter
+    // native code. In particular, new world_ready callbacks execute before
+    // prepared_states becomes active_states, so the old stack check is not
+    // sufficient to protect the transaction from a nested reload.
+    const restore_on_out_of_scope<bool> restore_reload_flag( script_reload_in_progress );
+    script_reload_in_progress = true;
     if( !prepare_mods( sources, error ) ) {
         return false;
     }

--- a/src/lua_platform_loader.h
+++ b/src/lua_platform_loader.h
@@ -91,7 +91,8 @@ std::string prepared_content_fingerprint();
 /**
  * Re-execute active entries and swap runtime registrations only when their
  * static content fingerprint is unchanged.  A changed fingerprint returns
- * false with `requires_full_data_reload` in @p error.
+ * false with `requires_full_data_reload` in @p error. Reentrant calls while
+ * an active Mod is executing Lua are rejected before touching its state.
  */
 bool reload_active_mods( std::string &error );
 

--- a/src/lua_platform_loader.h
+++ b/src/lua_platform_loader.h
@@ -92,7 +92,8 @@ std::string prepared_content_fingerprint();
  * Re-execute active entries and swap runtime registrations only when their
  * static content fingerprint is unchanged.  A changed fingerprint returns
  * false with `requires_full_data_reload` in @p error. Reentrant calls while
- * an active Mod is executing Lua are rejected before touching its state.
+ * an active Mod is executing Lua, or another reload is replacing registrations,
+ * are rejected before touching its state.
  */
 bool reload_active_mods( std::string &error );
 

--- a/tests/lua_platform_reload_guard_test.cpp
+++ b/tests/lua_platform_reload_guard_test.cpp
@@ -1,0 +1,48 @@
+#if defined(CATA_ENABLE_LUA_PLATFORM) && CATA_ENABLE_LUA_PLATFORM
+#include "lua_platform_test_support.h"
+#include "lua_platform_runtime_internal.h"
+
+TEST_CASE( "lua_platform_reload_rejects_an_active_lua_call_stack",
+           "[lua][platform][runtime][reload]" )
+{
+    namespace platform = cata::lua_platform;
+    platform::shutdown();
+    const platform_lua_test_directory files;
+    bool attempted = false;
+    bool accepted = true;
+    std::string reload_error;
+    const on_out_of_scope cleanup( []() {
+        platform::shutdown();
+    } );
+    files.write( "main.lua", R"lua(
+local ccb = require("ccb")
+ccb.runtime.handler("try_reload", function()
+    attempt_reload()
+end)
+ccb.runtime.on("world_ready", "try_reload")
+)lua" );
+    const platform::mod_source source { "reload-guard", files.root, files.root / "main.lua" };
+    std::string error;
+    REQUIRE( platform::prepare_mods( { source }, error ) );
+    REQUIRE( platform::apply_prepared_content( error ) );
+    REQUIRE( platform::validate_finalized_prepared_content( error ) );
+    platform::commit_prepared_mods();
+    const std::shared_ptr<platform::runtime> owner = platform::detail::find_active_runtime(
+                "reload-guard" );
+    REQUIRE( owner );
+    owner->lua->set_function( "attempt_reload", [&]() {
+        attempted = true;
+        accepted = platform::reload_active_mods( reload_error );
+    } );
+    platform::runtime_world_ready( true );
+    CHECK( attempted );
+    CHECK_FALSE( accepted );
+    CHECK( reload_error.find( "still executing" ) != std::string::npos );
+    CHECK( reload_error.find( "reload-guard" ) != std::string::npos );
+    CHECK( platform::detail::find_active_runtime( "reload-guard" ) == owner );
+    const sol::protected_function_result still_alive = owner->lua->safe_script(
+                "return 42", sol::script_pass_on_error );
+    REQUIRE( still_alive.valid() );
+    CHECK( still_alive.get<int>() == 42 );
+}
+#endif

--- a/tests/lua_platform_reload_guard_test.cpp
+++ b/tests/lua_platform_reload_guard_test.cpp
@@ -104,4 +104,47 @@ ccb.content.add(item)
     REQUIRE( result.valid() );
     CHECK( result.get<int>() == 42 );
 }
+TEST_CASE( "lua_platform_reload_rejects_reentry_during_replacement",
+           "[lua][platform][runtime][reload]" )
+{
+    namespace platform = cata::lua_platform;
+    platform::shutdown();
+    const platform_lua_test_directory files;
+    int attempts = 0;
+    bool nested_accepted = true;
+    std::string nested_error;
+    const on_out_of_scope cleanup( []() {
+        platform::shutdown();
+    } );
+    files.write( "main.lua", R"lua(
+local ccb = require("ccb")
+ccb.runtime.handler("shutdown_reload", function()
+    if attempt_reload then attempt_reload() end
+end)
+ccb.runtime.on("shutdown", "shutdown_reload")
+)lua" );
+    const platform::mod_source source { "reload-reentry", files.root, files.root / "main.lua" };
+    std::string error;
+    REQUIRE( platform::prepare_mods( { source }, error ) );
+    REQUIRE( platform::apply_prepared_content( error ) );
+    REQUIRE( platform::validate_finalized_prepared_content( error ) );
+    platform::commit_prepared_mods();
+    platform::runtime_world_ready( true );
+    {
+        const std::shared_ptr<platform::runtime> owner = platform::detail::find_active_runtime(
+                    "reload-reentry" );
+        REQUIRE( owner );
+        owner->lua->set_function( "attempt_reload", [&]() {
+            ++attempts;
+            nested_accepted = platform::reload_active_mods( nested_error );
+        } );
+    } // Do not retain Lua references across a successful replacement.
+    REQUIRE( platform::reload_active_mods( error ) );
+    CHECK( attempts == 1 );
+    CHECK_FALSE( nested_accepted );
+    CHECK( nested_error.find( "already in progress" ) != std::string::npos );
+    // The scope guard must release the transaction after the outer reload.
+    REQUIRE( platform::reload_active_mods( error ) );
+    CHECK( attempts == 1 );
+}
 #endif

--- a/tests/lua_platform_reload_guard_test.cpp
+++ b/tests/lua_platform_reload_guard_test.cpp
@@ -29,7 +29,7 @@ ccb.runtime.on("world_ready", "try_reload")
     REQUIRE( platform::validate_finalized_prepared_content( error ) );
     platform::commit_prepared_mods();
     const std::shared_ptr<platform::runtime> owner = platform::detail::find_active_runtime(
-                "reload-guard" );
+            "reload-guard" );
     REQUIRE( owner );
     owner->lua->set_function( "attempt_reload", [&]() {
         attempted = true;
@@ -42,7 +42,7 @@ ccb.runtime.on("world_ready", "try_reload")
     CHECK( reload_error.find( "reload-guard" ) != std::string::npos );
     CHECK( platform::detail::find_active_runtime( "reload-guard" ) == owner );
     const sol::protected_function_result still_alive = owner->lua->safe_script(
-                "return 42", sol::script_pass_on_error );
+            "return 42", sol::script_pass_on_error );
     REQUIRE( still_alive.valid() );
     CHECK( still_alive.get<int>() == 42 );
 }
@@ -68,7 +68,7 @@ ccb.runtime.handler("kept", function() return 42 end)
     platform::commit_prepared_mods();
     platform::runtime_world_ready( true );
     const std::shared_ptr<platform::runtime> owner = platform::detail::find_active_runtime(
-                "reload-preserve" );
+            "reload-preserve" );
     REQUIRE( owner );
     owner->world_state.emplace( "reload_marker", std::int64_t( 17 ) );
     sol::protected_function kept = owner->handlers.at( "kept" ).callback;
@@ -132,7 +132,7 @@ ccb.runtime.on("shutdown", "shutdown_reload")
     platform::runtime_world_ready( true );
     {
         const std::shared_ptr<platform::runtime> owner = platform::detail::find_active_runtime(
-                    "reload-reentry" );
+                "reload-reentry" );
         REQUIRE( owner );
         owner->lua->set_function( "attempt_reload", [&]() {
             ++attempts;

--- a/tests/lua_platform_reload_guard_test.cpp
+++ b/tests/lua_platform_reload_guard_test.cpp
@@ -1,6 +1,7 @@
 #if defined(CATA_ENABLE_LUA_PLATFORM) && CATA_ENABLE_LUA_PLATFORM
 #include "lua_platform_test_support.h"
 #include "lua_platform_runtime_internal.h"
+#include <variant>
 
 TEST_CASE( "lua_platform_reload_rejects_an_active_lua_call_stack",
            "[lua][platform][runtime][reload]" )
@@ -36,7 +37,7 @@ ccb.runtime.on("world_ready", "try_reload")
     } );
     platform::runtime_world_ready( true );
     CHECK( attempted );
-    CHECK_FALSE( accepted );
+    REQUIRE_FALSE( accepted );
     CHECK( reload_error.find( "still executing" ) != std::string::npos );
     CHECK( reload_error.find( "reload-guard" ) != std::string::npos );
     CHECK( platform::detail::find_active_runtime( "reload-guard" ) == owner );
@@ -44,5 +45,63 @@ ccb.runtime.on("world_ready", "try_reload")
                 "return 42", sol::script_pass_on_error );
     REQUIRE( still_alive.valid() );
     CHECK( still_alive.get<int>() == 42 );
+}
+
+TEST_CASE( "lua_platform_failed_reload_keeps_the_active_runtime_and_state",
+           "[lua][platform][runtime][reload]" )
+{
+    namespace platform = cata::lua_platform;
+    platform::shutdown();
+    const platform_lua_test_directory files;
+    const on_out_of_scope cleanup( []() {
+        platform::shutdown();
+    } );
+    files.write( "main.lua", R"lua(
+local ccb = require("ccb")
+ccb.runtime.handler("kept", function() return 42 end)
+)lua" );
+    const platform::mod_source source { "reload-preserve", files.root, files.root / "main.lua" };
+    std::string error;
+    REQUIRE( platform::prepare_mods( { source }, error ) );
+    REQUIRE( platform::apply_prepared_content( error ) );
+    REQUIRE( platform::validate_finalized_prepared_content( error ) );
+    platform::commit_prepared_mods();
+    platform::runtime_world_ready( true );
+    const std::shared_ptr<platform::runtime> owner = platform::detail::find_active_runtime(
+                "reload-preserve" );
+    REQUIRE( owner );
+    owner->world_state.emplace( "reload_marker", std::int64_t( 17 ) );
+    sol::protected_function kept = owner->handlers.at( "kept" ).callback;
+    std::string expected_error;
+    SECTION( "syntax failure" ) {
+        files.write( "main.lua", "local = invalid syntax" );
+    }
+    SECTION( "entry execution failure" ) {
+        files.write( "main.lua", "error('candidate execution sentinel')" );
+        expected_error = "candidate execution sentinel";
+    }
+    SECTION( "static definitions changed" ) {
+        files.write( "main.lua", R"lua(
+local ccb = require("ccb")
+local item = ccb.content.Item {
+    id = "lua_reload_preserve_new_item", name = "reload fixture",
+    description = "Only a candidate definition; must not be applied.", symbol = "?"
+}
+item:mass_grams(1)
+item:volume_ml(1)
+ccb.content.add(item)
+)lua" );
+        expected_error = "requires_full_data_reload";
+    }
+    REQUIRE_FALSE( platform::reload_active_mods( error ) );
+    CHECK_FALSE( error.empty() );
+    if( !expected_error.empty() ) {
+        CHECK( error.find( expected_error ) != std::string::npos );
+    }
+    REQUIRE( platform::detail::find_active_runtime( "reload-preserve" ) == owner );
+    CHECK( std::get<std::int64_t>( owner->world_state.at( "reload_marker" ) ) == 17 );
+    const sol::protected_function_result result = kept();
+    REQUIRE( result.valid() );
+    CHECK( result.get<int>() == 42 );
 }
 #endif


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

Adds a Reload Lua action to the debug Game menu and action search, using the existing static-content fingerprint gate. Success refreshes Lua registrations; static definition changes require a restart. Failures display actionable diagnostics.

The backend rejects reload while Lua is executing and guards the entire reload transaction against nested reload from candidate/replacement lifecycle callbacks. A scope guard resets the transaction flag on failure and success so a later valid retry is possible.

Adds native regression source for active-stack rejection, failed syntax/entry/static candidates preserving old behavior, nested shutdown reload rejection and later retry. Validation: git diff --check passed. No compilation, native tests, UI or game acceptance ran. #761 is a dependent console draft based on this branch.

#### Responsible human

@LYHGLYTX

#### Documentation impact

Updates the Lua-first contract or author tooling guidance for the behavior described above.

#### Related CCB-Docs PR

https://github.com/CrimsonCrossBunker/CCB-Docs/pull/47 (draft; publish only after source acceptance).

#### Affected documentation IDs

cpp.lua-bridge

#### Generated reference impact

Generated native references are deferred to batch acceptance; no generated inventories were hand-edited.


#### Additional context

Keep draft; do not merge before morning review.