### PR TITLE
Add an in-game Lua console for loaded Mods

### DIFF
--- a/ai/lua-first-roadmap.yml
+++ b/ai/lua-first-roadmap.yml
@@ -677,4 +677,5 @@ capabilities:
     verification: not_run
     next_actions:
       - The initial declaration-snapshot, scaffold/editor and static-diagnostic slice passed local tool tests and the real LuaLS gate; it does not implement an in-game debugger, state/task inspector or native compatibility negotiation.
+      - A draft Console Lua tab executes explicit chunks in an existing selected Mod state; native regression source covers ownership, errors, return formatting and reentry. Native and interactive acceptance remain not run; this is not a breakpoint debugger.
       - Continue runtime debugging, cookbook and author-workflow improvements as independent batches with their own evidence; do not make the whole author-experience capability a core Platform closure dependency.

--- a/data/lua/LUA_FIRST_PLATFORM.md
+++ b/data/lua/LUA_FIRST_PLATFORM.md
@@ -196,6 +196,19 @@ replacement preserves only the state explicitly defined by Platform lifecycle
 and persistence rules; external filesystem or process side effects are trusted
 code responsibilities and are not silently rolled back.
 
+A draft author-tool entry under **Debug menu → Game → Reload Lua Mod scripts**
+also appears in the searchable debug action list. It calls the existing runtime
+swap operation for active Mods, preserves its static-content gate, and displays
+loader failures. Reload is rejected while an active Mod still has an executing
+Lua call stack. A successful swap does not imply callbacks succeeded; inspect
+the message log. This UI integration has not been compiled or interactively
+accepted. Restart the game when static definitions change.
+
+调试菜单的“游戏 → 重新加载 Lua Mod 脚本”草稿入口调用已有脚本替换后端，也可通过调试
+动作搜索找到。活动 Mod 仍在执行 Lua 或静态定义发生变化时会拒绝替换并显示原因；
+成功替换注册表不代表回调无错误，
+应查看消息日志。修改静态定义后重启游戏；菜单集成尚未编译或完成交互验收。
+
 ## Native content model / 原生内容模型
 
 `ccb.content` is a pure-Lua native typed builder and registrar surface, not a

--- a/data/lua/LUA_FIRST_PLATFORM.md
+++ b/data/lua/LUA_FIRST_PLATFORM.md
@@ -214,6 +214,8 @@ text chunk in a selected, already loaded Mod's state. Use `require("ccb")` as
 usual and `return` to display values. Execution is deferred until outside the
 ImGui drawing frame; it neither creates another runtime nor automatically runs
 saved input. Console changes are immediate and are not rolled back on error.
+The explicit call enters the selected owner's callback scope; normal world-ready,
+handle-generation and domain checks still apply to services.
 Return display shows at most 16 values and 1024 source bytes per string, escaping
 control bytes and replacing invalid UTF-8; other objects appear as type labels
 without invoking `__tostring`. These are display limits, not script quotas.
@@ -224,6 +226,7 @@ have not received interactive acceptance.
 “调试菜单 → 控制台 → Lua”草稿页在选定的已加载 Mod 状态中执行手动提交的文本代码。
 继续使用 `require("ccb")`，用 `return` 显示结果；执行安排在 ImGui 绘制帧之外，
 不创建第二套运行时，也不自动执行保存的输入。修改立即生效，后续报错不会回滚。
+手动调用进入所选 owner 的回调上下文，服务继续检查 world-ready、句柄代次和领域规则。
 最多展示 16 个返回值，每个字符串最多读取 1024 字节，转义控制字节、替换无效 UTF-8；
 其他对象只展示类型，不调用 `__tostring`。这只是显示限制，不是脚本配额。
 同一状态递归执行以及重载过程中的执行会被拒绝。源码和回归测试源码尚未编译或交互验收。

--- a/data/lua/LUA_FIRST_PLATFORM.md
+++ b/data/lua/LUA_FIRST_PLATFORM.md
@@ -217,8 +217,10 @@ saved input. Console changes are immediate and are not rolled back on error.
 The explicit call enters the selected owner's callback scope; normal world-ready,
 handle-generation and domain checks still apply to services.
 Return display shows at most 16 values and 1024 source bytes per string, escaping
-control bytes and replacing invalid UTF-8; other objects appear as type labels
-without invoking `__tostring`. These are display limits, not script quotas.
+control bytes and replacing invalid UTF-8. Returned tables show up to 20 raw
+fields in unspecified order; nested tables and other objects appear as type
+labels. No `__pairs` or `__tostring` runs. Return a nested field explicitly to
+inspect it. These are display limits, not script quotas.
 Recursive execution in the same state and execution during a script reload are
 rejected. This console source and its regression source remain uncompiled and
 have not received interactive acceptance.
@@ -228,7 +230,9 @@ have not received interactive acceptance.
 不创建第二套运行时，也不自动执行保存的输入。修改立即生效，后续报错不会回滚。
 手动调用进入所选 owner 的回调上下文，服务继续检查 world-ready、句柄代次和领域规则。
 最多展示 16 个返回值，每个字符串最多读取 1024 字节，转义控制字节、替换无效 UTF-8；
-其他对象只展示类型，不调用 `__tostring`。这只是显示限制，不是脚本配额。
+返回表最多展示 20 个原始字段，顺序不作保证；嵌套表和其他对象仅显示类型，
+不调用 `__pairs` 或 `__tostring`。要进一步查看，显式返回嵌套字段即可。
+这只是显示限制，不是脚本配额。
 同一状态递归执行以及重载过程中的执行会被拒绝。源码和回归测试源码尚未编译或交互验收。
 
 ## Native content model / 原生内容模型

--- a/data/lua/LUA_FIRST_PLATFORM.md
+++ b/data/lua/LUA_FIRST_PLATFORM.md
@@ -209,6 +209,25 @@ accepted. Restart the game when static definitions change.
 成功替换注册表不代表回调无错误，
 应查看消息日志。修改静态定义后重启游戏；菜单集成尚未编译或完成交互验收。
 
+A draft **Debug menu → Console → Lua** tab executes an explicitly submitted
+text chunk in a selected, already loaded Mod's state. Use `require("ccb")` as
+usual and `return` to display values. Execution is deferred until outside the
+ImGui drawing frame; it neither creates another runtime nor automatically runs
+saved input. Console changes are immediate and are not rolled back on error.
+Return display shows at most 16 values and 1024 source bytes per string, escaping
+control bytes and replacing invalid UTF-8; other objects appear as type labels
+without invoking `__tostring`. These are display limits, not script quotas.
+Recursive execution in the same state and execution during a script reload are
+rejected. This console source and its regression source remain uncompiled and
+have not received interactive acceptance.
+
+“调试菜单 → 控制台 → Lua”草稿页在选定的已加载 Mod 状态中执行手动提交的文本代码。
+继续使用 `require("ccb")`，用 `return` 显示结果；执行安排在 ImGui 绘制帧之外，
+不创建第二套运行时，也不自动执行保存的输入。修改立即生效，后续报错不会回滚。
+最多展示 16 个返回值，每个字符串最多读取 1024 字节，转义控制字节、替换无效 UTF-8；
+其他对象只展示类型，不调用 `__tostring`。这只是显示限制，不是脚本配额。
+同一状态递归执行以及重载过程中的执行会被拒绝。源码和回归测试源码尚未编译或交互验收。
+
 ## Native content model / 原生内容模型
 
 `ccb.content` is a pure-Lua native typed builder and registrar surface, not a

--- a/src/debug_console.cpp
+++ b/src/debug_console.cpp
@@ -3549,7 +3549,7 @@ void tab_lua_view::draw_body( debug_console &host )
         ImGui::TextUnformatted( "No Lua Mods are loaded in this world." );
         return;
     }
-    if( std::find( mods.begin(), mods.end(), selected_mod ) == mods.end() ) {
+    if( selected_mod.empty() ) {
         selected_mod = mods.front();
     }
     if( ImGui::BeginCombo( "Mod", selected_mod.c_str() ) ) {
@@ -3564,9 +3564,15 @@ void tab_lua_view::draw_body( debug_console &host )
                        "rolled back on error. Use return to display values; return a nested "
                        "field explicitly to inspect it." );
     ImGui::InputTextMultiline( "##lua_source", &source, ImVec2( -1.0f, 180.0f ) );
+    const bool selected_loaded = std::find( mods.begin(), mods.end(), selected_mod ) != mods.end();
+    if( !selected_loaded ) {
+        ImGui::TextUnformatted( "The selected Mod is no longer loaded. Choose another Mod explicitly." );
+    }
+    ImGui::BeginDisabled( !selected_loaded );
     if( ImGui::Button( "Run Lua" ) ) {
         host.request_lua( selected_mod, source );
     }
+    ImGui::EndDisabled();
     if( !result.empty() ) {
         ImGui::Separator();
         ImGui::TextWrapped( "%s", result.c_str() );

--- a/src/debug_console.cpp
+++ b/src/debug_console.cpp
@@ -3561,8 +3561,8 @@ void tab_lua_view::draw_body( debug_console &host )
         ImGui::EndCombo();
     }
     ImGui::TextWrapped( "Runs in the selected Mod's existing Lua state. Changes are not "
-                       "rolled back on error. Use return to display values; return a nested "
-                       "field explicitly to inspect it." );
+                        "rolled back on error. Use return to display values; return a nested "
+                        "field explicitly to inspect it." );
     ImGui::InputTextMultiline( "##lua_source", &source, ImVec2( -1.0f, 180.0f ) );
     const bool selected_loaded = std::find( mods.begin(), mods.end(), selected_mod ) != mods.end();
     if( !selected_loaded ) {

--- a/src/debug_console.cpp
+++ b/src/debug_console.cpp
@@ -3561,7 +3561,8 @@ void tab_lua_view::draw_body( debug_console &host )
         ImGui::EndCombo();
     }
     ImGui::TextWrapped( "Runs in the selected Mod's existing Lua state. Changes are not "
-                       "rolled back on error. Use return to display values." );
+                       "rolled back on error. Use return to display values; return a nested "
+                       "field explicitly to inspect it." );
     ImGui::InputTextMultiline( "##lua_source", &source, ImVec2( -1.0f, 180.0f ) );
     if( ImGui::Button( "Run Lua" ) ) {
         host.request_lua( selected_mod, source );

--- a/src/debug_console.cpp
+++ b/src/debug_console.cpp
@@ -1,4 +1,5 @@
 #include "debug_console.h"
+#include "lua_platform_loader.h"
 
 // IWYU pragma: no_include "flat_set.h"
 
@@ -160,6 +161,7 @@ const std::vector<tab_descriptor> &tab_registry()
         r.push_back( { "creatures", [] { return std::make_unique<tab_creatures_view>(); }, {} } );
         r.push_back( { "items",     [] { return std::make_unique<tab_items_view>(); },     {} } );
         r.push_back( { "tiles",     [] { return std::make_unique<tab_tiles_view>(); },     {} } );
+        r.push_back( { "lua",       [] { return std::make_unique<tab_lua_view>(); },       {} } );
         return r;
     }();
     return reg;
@@ -792,6 +794,22 @@ void debug_console::execute()
             continue;
         }
 
+        if( pending_lua ) {
+            const auto request = std::move( *pending_lua );
+            pending_lua.reset();
+            // Lua services can open popups. Execute only between ImGui frames.
+            suspend_draw_ = true;
+            const on_out_of_scope restore_draw( [this]() {
+                suspend_draw_ = false;
+            } );
+            std::string output;
+            std::string error;
+            const bool ok = cata::lua_platform::execute_console(
+                                request.first, request.second, output, error );
+            lua_result = eval_result_view{ ok ? "[" + request.first + "]\n" + output : error, ok };
+            continue;
+        }
+
         if( eval_pending ) {
             eval_pending = false;
             pending_eval_ok = true;
@@ -916,6 +934,18 @@ std::optional<debug_console::eval_result_view> debug_console::consume_eval_resul
     pending_eval_result.clear();
     pending_eval_result_ready = false;
     return rv;
+}
+
+void debug_console::request_lua( const std::string &mod_id, const std::string &source )
+{
+    pending_lua = std::make_pair( mod_id, source );
+}
+
+std::optional<debug_console::eval_result_view> debug_console::consume_lua_result()
+{
+    std::optional<eval_result_view> result = std::move( lua_result );
+    lua_result.reset();
+    return result;
 }
 
 void debug_console::set_eoc_trace_visible( bool v )
@@ -3499,6 +3529,48 @@ void tab_items_view::draw_body( debug_console &host )
     }
 }
 
+
+const char *tab_lua_view::label() const
+{
+    return "Lua";
+}
+
+void tab_lua_view::draw_body( debug_console &host )
+{
+    if( auto completed = host.consume_lua_result() ) {
+        result = ( completed->ok ? "" : "Error: " ) + completed->result;
+    }
+    if( !cata::lua_platform::is_enabled() ) {
+        ImGui::TextUnformatted( "Lua Platform is not enabled in this build." );
+        return;
+    }
+    const std::vector<std::string> mods = cata::lua_platform::loaded_mod_ids();
+    if( mods.empty() ) {
+        ImGui::TextUnformatted( "No Lua Mods are loaded in this world." );
+        return;
+    }
+    if( std::find( mods.begin(), mods.end(), selected_mod ) == mods.end() ) {
+        selected_mod = mods.front();
+    }
+    if( ImGui::BeginCombo( "Mod", selected_mod.c_str() ) ) {
+        for( const std::string &mod : mods ) {
+            if( ImGui::Selectable( mod.c_str(), mod == selected_mod ) ) {
+                selected_mod = mod;
+            }
+        }
+        ImGui::EndCombo();
+    }
+    ImGui::TextWrapped( "Runs in the selected Mod's existing Lua state. Changes are not "
+                       "rolled back on error. Use return to display values." );
+    ImGui::InputTextMultiline( "##lua_source", &source, ImVec2( -1.0f, 180.0f ) );
+    if( ImGui::Button( "Run Lua" ) ) {
+        host.request_lua( selected_mod, source );
+    }
+    if( !result.empty() ) {
+        ImGui::Separator();
+        ImGui::TextWrapped( "%s", result.c_str() );
+    }
+}
 
 const char *tab_eoc_view::label() const
 {

--- a/src/debug_console.h
+++ b/src/debug_console.h
@@ -122,6 +122,18 @@ class tab_player_view : public console_tab_view
         character_edit_state char_edit;
 };
 
+class tab_lua_view : public console_tab_view
+{
+    public:
+        const char *label() const override;
+        void draw_body( debug_console &host ) override;
+
+    private:
+        std::string selected_mod;
+        std::string source = "local ccb = require(\"ccb\")\nreturn ccb.services.turn()";
+        std::string result;
+};
+
 class tab_eoc_view : public console_tab_view
 {
     public:
@@ -429,6 +441,8 @@ class debug_console : public cataimgui::window
             bool ok = true;
         };
         std::optional<eval_result_view> consume_eval_result();
+        void request_lua( const std::string &mod_id, const std::string &source );
+        std::optional<eval_result_view> consume_lua_result();
 
         // Trace tab reads; EOC tab clears when the user pins a per-EOC
         // monitor (raw feed becomes redundant).
@@ -487,6 +501,8 @@ class debug_console : public cataimgui::window
         std::string pending_eval_result;
         bool pending_eval_ok = true;
         bool pending_eval_result_ready = false;
+        std::optional<std::pair<std::string, std::string>> pending_lua;
+        std::optional<eval_result_view> lua_result;
 
         // Owns the step / play / fast-forward state machine plus the footer
         // controls that drive it. Hidden behind pimpl so the host header does

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -85,6 +85,7 @@
 #include "list.h"
 #include "localized_comparator.h"
 #include "lua_platform_hooks.h"
+#include "lua_platform_loader.h"
 #include "magic.h"
 #include "map.h"
 #include "map_extras.h"
@@ -310,6 +311,7 @@ std::string enum_to_string<debug_menu::debug_menu_index>( debug_menu::debug_menu
         case debug_menu::debug_menu_index::VEHICLE_EFFECTS: return "VEHICLE_EFFECTS";
         case debug_menu::debug_menu_index::WISHPROFICIENCY: return "WISHPROFICIENCY";
         case debug_menu::debug_menu_index::RELOAD_GPU_SHADERS: return "RELOAD_GPU_SHADERS";
+        case debug_menu::debug_menu_index::RELOAD_LUA_SCRIPTS: return "RELOAD_LUA_SCRIPTS";
         // *INDENT-ON*
         case debug_menu::debug_menu_index::last:
             break;
@@ -1032,6 +1034,8 @@ static int game_uilist()
         { uilist_entry( debug_menu_index::QUIT_NOSAVE, true, 'Q', _( "Quit to main menu" ) )  },
         { uilist_entry( debug_menu_index::QUICKLOAD, true, 'q', _( "Quickload" ) )  },
         { uilist_entry( debug_menu_index::SNAPSHOT_MENU, true, 'n', _( "Snapshot save/load menu" ) )  },
+        { uilist_entry( debug_menu_index::RELOAD_LUA_SCRIPTS,
+                        cata::lua_platform::is_enabled(), 'l', _( "Reload Lua Mod scripts" ) ) },
     };
 
     return uilist( _( "Game…" ), uilist_initializer );
@@ -4986,6 +4990,34 @@ const std::vector<debug_action_entry> &all_actions()
             debug_menu_index::IMGUI_DEMO, translate_marker( "ImGui demo" ), "imgui demo", "Game", []()
             {
                 run_imgui_demo();
+            }
+        },
+        {
+            debug_menu_index::RELOAD_LUA_SCRIPTS, translate_marker( "Reload Lua Mod scripts" ),
+            "reload lua mod scripts platform", "Game", []()
+            {
+                if( !cata::lua_platform::is_enabled() ) {
+                    popup( _( "This build does not include Lua Platform support." ) );
+                    return;
+                }
+                const std::vector<std::string> mods = cata::lua_platform::loaded_mod_ids();
+                if( mods.empty() ) {
+                    popup( _( "No Lua Mods are active in this world." ) );
+                    return;
+                }
+                std::string error;
+                if( !cata::lua_platform::reload_active_mods( error ) ) {
+                    if( error.find( "requires_full_data_reload:" ) == 0 ) {
+                        popup( _( "Lua static content changed. Restart the game to reload its definitions. "
+                                  "The previous script registrations remain active.\n\n%s" ), error );
+                    } else {
+                        popup( _( "Lua script reload failed. The previous script registrations remain "
+                                  "active.\n\n%s" ), error );
+                    }
+                    return;
+                }
+                add_msg( m_info, _( "Replaced Lua script registrations for %zu Mods. "
+                                   "Check the message log for callback errors." ), mods.size() );
             }
         },
         {

--- a/src/debug_menu_types.h
+++ b/src/debug_menu_types.h
@@ -118,6 +118,7 @@ enum class debug_menu_index : int {
     VEHICLE_EFFECTS,
     WISHPROFICIENCY,
     RELOAD_GPU_SHADERS,
+    RELOAD_LUA_SCRIPTS,
     last
 };
 

--- a/src/lua_platform_loader.cpp
+++ b/src/lua_platform_loader.cpp
@@ -857,7 +857,7 @@ bool execute_console( const std::string &mod_id, const std::string &source,
         return false;
     }
     const auto found = std::find_if( active_states.begin(), active_states.end(),
-    [&mod_id]( const runtime_state &state ) {
+    [&mod_id]( const runtime_state & state ) {
         return state.id == mod_id;
     } );
     if( found == active_states.end() ) {
@@ -875,7 +875,7 @@ bool execute_console( const std::string &mod_id, const std::string &source,
         // existing world-ready, owner, handle and domain mutation checks.
         const detail::callback_scope callback( *found->platform );
         const sol::protected_function_result result = found->lua->safe_script(
-                    source, sol::script_pass_on_error, "=CCB console: " + mod_id, sol::load_mode::text );
+                source, sol::script_pass_on_error, "=CCB console: " + mod_id, sol::load_mode::text );
         if( !result.valid() ) {
             const sol::error script_error = result;
             error = "Lua console [" + mod_id + "]: " + script_error.what();

--- a/src/lua_platform_loader.cpp
+++ b/src/lua_platform_loader.cpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <exception>
+#include <iomanip>
 #include <iterator>
 #include <limits>
 #include <memory>
@@ -793,6 +794,57 @@ std::string console_string( const char *text, const std::size_t size )
     }
     return result;
 }
+
+std::string console_value( lua_State *lua, const int index, const bool expand_table )
+{
+    const int type = lua_type( lua, index );
+    if( type == LUA_TSTRING ) {
+        std::size_t size = 0;
+        const char *text = lua_tolstring( lua, index, &size );
+        return console_string( text, size );
+    }
+    if( type == LUA_TNUMBER ) {
+        // Do not convert a live lua_next numeric key into a string on the stack.
+        if( lua_isinteger( lua, index ) ) {
+            return std::to_string( lua_tointeger( lua, index ) );
+        }
+        std::ostringstream number;
+        number << std::setprecision( std::numeric_limits<lua_Number>::max_digits10 ) <<
+               lua_tonumber( lua, index );
+        return number.str();
+    }
+    if( type == LUA_TBOOLEAN ) {
+        return lua_toboolean( lua, index ) ? "true" : "false";
+    }
+    if( type == LUA_TNIL ) {
+        return "nil";
+    }
+    if( type == LUA_TTABLE && expand_table ) {
+        if( !lua_checkstack( lua, 2 ) ) {
+            return "<table: insufficient stack space>";
+        }
+        const int top = lua_gettop( lua );
+        const on_out_of_scope restore_stack( [lua, top]() {
+            lua_settop( lua, top );
+        } );
+        const int table = lua_absindex( lua, index );
+        int count = 0;
+        std::string result = "{";
+        lua_pushnil( lua );
+        while( lua_next( lua, table ) != 0 ) {
+            if( count == 20 ) {
+                result += "\n  [remaining fields omitted]";
+                break;
+            }
+            result += "\n  [" + console_value( lua, -2, false ) + "] = " +
+                      console_value( lua, -1, false );
+            ++count;
+            lua_pop( lua, 1 );
+        }
+        return result + ( count == 0 ? "}" : "\n}" );
+    }
+    return std::string( "<" ) + lua_typename( lua, type ) + ">";
+}
 } // namespace
 
 bool execute_console( const std::string &mod_id, const std::string &source,
@@ -835,20 +887,7 @@ bool execute_console( const std::string &mod_id, const std::string &source,
             if( i != 0 ) {
                 output += '\n';
             }
-            const int type = lua_type( lua, index );
-            if( type == LUA_TSTRING ) {
-                std::size_t size = 0;
-                const char *text = lua_tolstring( lua, index, &size );
-                output += console_string( text, size );
-            } else if( type == LUA_TNUMBER ) {
-                output += lua_tolstring( lua, index, nullptr );
-            } else if( type == LUA_TBOOLEAN ) {
-                output += lua_toboolean( lua, index ) ? "true" : "false";
-            } else if( type == LUA_TNIL ) {
-                output += "nil";
-            } else {
-                output += std::string( "<" ) + lua_typename( lua, type ) + ">";
-            }
+            output += console_value( lua, index, true );
         }
         if( result.return_count() == 0 ) {
             output = "Completed (no return values)";

--- a/src/lua_platform_loader.cpp
+++ b/src/lua_platform_loader.cpp
@@ -715,6 +715,12 @@ bool reload_active_mods( std::string &error )
     std::vector<mod_source> sources;
     sources.reserve( active_states.size() );
     for( const runtime_state &state : active_states ) {
+        lua_Debug frame;
+        if( lua_getstack( state.lua->lua_state(), 0, &frame ) != 0 ) {
+            error = "Lua code is still executing for Mod '" + state.id +
+                    "'; retry script reload after it returns";
+            return false;
+        }
         active_fingerprint << state.id.size() << ':' << state.id << ':'
                            << runtime_fingerprint( state.platform ) << ';';
         sources.push_back( { state.id, state.root, state.entry } );

--- a/src/lua_platform_loader.cpp
+++ b/src/lua_platform_loader.cpp
@@ -46,6 +46,7 @@ extern "C" {
 #endif
 
 #include "lua_platform_runtime.h"
+#include "lua_platform_runtime_internal.h"
 #include "lua_platform_sol.h"
 #include "cata_scope_helpers.h"
 #include "catacharset.h"
@@ -818,6 +819,9 @@ bool execute_console( const std::string &mod_id, const std::string &source,
         return false;
     }
     try {
+        // The explicit console invocation is a runtime callback. Keep the
+        // existing world-ready, owner, handle and domain mutation checks.
+        const detail::callback_scope callback( *found->platform );
         const sol::protected_function_result result = found->lua->safe_script(
                     source, sol::script_pass_on_error, "=CCB console: " + mod_id, sol::load_mode::text );
         if( !result.valid() ) {

--- a/src/lua_platform_loader.cpp
+++ b/src/lua_platform_loader.cpp
@@ -47,6 +47,7 @@ extern "C" {
 
 #include "lua_platform_runtime.h"
 #include "lua_platform_sol.h"
+#include "cata_scope_helpers.h"
 #include "generic_factory.h"
 #include "item_factory.h"
 #include "itype.h"
@@ -72,6 +73,7 @@ std::vector<runtime_state> prepared_states;
 bool candidate_is_prepared = false;
 bool candidate_content_is_applied = false;
 bool candidate_content_is_finalized = false;
+bool script_reload_in_progress = false;
 std::size_t generation_counter = 0;
 
 bool path_is_within( const fs::path &path, const fs::path &directory )
@@ -706,6 +708,10 @@ std::string prepared_content_fingerprint()
 
 bool reload_active_mods( std::string &error )
 {
+    if( script_reload_in_progress ) {
+        error = "Lua script reload is already in progress; retry after it returns";
+        return false;
+    }
     if( active_states.empty() ) {
         error.clear();
         return true;
@@ -726,6 +732,12 @@ bool reload_active_mods( std::string &error )
         sources.push_back( { state.id, state.root, state.entry } );
     }
 
+    // Candidate entry scripts and replacement lifecycle callbacks can enter
+    // native code. In particular, new world_ready callbacks execute before
+    // prepared_states becomes active_states, so the old stack check is not
+    // sufficient to protect the transaction from a nested reload.
+    const restore_on_out_of_scope<bool> restore_reload_flag( script_reload_in_progress );
+    script_reload_in_progress = true;
     if( !prepare_mods( sources, error ) ) {
         return false;
     }

--- a/src/lua_platform_loader.cpp
+++ b/src/lua_platform_loader.cpp
@@ -48,6 +48,7 @@ extern "C" {
 #include "lua_platform_runtime.h"
 #include "lua_platform_sol.h"
 #include "cata_scope_helpers.h"
+#include "catacharset.h"
 #include "generic_factory.h"
 #include "item_factory.h"
 #include "itype.h"
@@ -764,6 +765,99 @@ bool reload_active_mods( std::string &error )
     return true;
 }
 
+namespace
+{
+std::string console_string( const char *text, const std::size_t size )
+{
+    // Bound presentation only, without restricting script execution or values.
+    int remaining = static_cast<int>( std::min<std::size_t>( size, 1024 ) );
+    std::string result = "\"";
+    while( remaining > 0 ) {
+        const std::uint32_t ch = UTF8_getch( &text, &remaining );
+        if( ch == '\\' || ch == '"' ) {
+            result += '\\';
+            result += static_cast<char>( ch );
+        } else if( ch < 32 || ch == 127 ) {
+            constexpr char hex[] = "0123456789abcdef";
+            result += "\\x";
+            result += hex[ch >> 4];
+            result += hex[ch & 15];
+        } else {
+            result += utf32_to_utf8( ch );
+        }
+    }
+    result += '"';
+    if( size > 1024 ) {
+        result += " [truncated]";
+    }
+    return result;
+}
+} // namespace
+
+bool execute_console( const std::string &mod_id, const std::string &source,
+                      std::string &output, std::string &error )
+{
+    output.clear();
+    error.clear();
+    if( script_reload_in_progress ) {
+        error = "Lua script reload is in progress; retry after it returns";
+        return false;
+    }
+    const auto found = std::find_if( active_states.begin(), active_states.end(),
+    [&mod_id]( const runtime_state &state ) {
+        return state.id == mod_id;
+    } );
+    if( found == active_states.end() ) {
+        error = "No active Lua Mod named '" + mod_id + "'";
+        return false;
+    }
+    lua_State *const lua = found->lua->lua_state();
+    lua_Debug frame;
+    if( lua_getstack( lua, 0, &frame ) != 0 ) {
+        error = "Lua code is still executing for Mod '" + mod_id + "'";
+        return false;
+    }
+    try {
+        const sol::protected_function_result result = found->lua->safe_script(
+                    source, sol::script_pass_on_error, "=CCB console: " + mod_id, sol::load_mode::text );
+        if( !result.valid() ) {
+            const sol::error script_error = result;
+            error = "Lua console [" + mod_id + "]: " + script_error.what();
+            return false;
+        }
+        const int shown = std::min( result.return_count(), 16 );
+        for( int i = 0; i < shown; ++i ) {
+            const int index = result.stack_index() + i;
+            if( i != 0 ) {
+                output += '\n';
+            }
+            const int type = lua_type( lua, index );
+            if( type == LUA_TSTRING ) {
+                std::size_t size = 0;
+                const char *text = lua_tolstring( lua, index, &size );
+                output += console_string( text, size );
+            } else if( type == LUA_TNUMBER ) {
+                output += lua_tolstring( lua, index, nullptr );
+            } else if( type == LUA_TBOOLEAN ) {
+                output += lua_toboolean( lua, index ) ? "true" : "false";
+            } else if( type == LUA_TNIL ) {
+                output += "nil";
+            } else {
+                output += std::string( "<" ) + lua_typename( lua, type ) + ">";
+            }
+        }
+        if( result.return_count() == 0 ) {
+            output = "Completed (no return values)";
+        } else if( result.return_count() > shown ) {
+            output += "\n[remaining return values omitted]";
+        }
+        return true;
+    } catch( const std::exception &exception ) {
+        error = "Lua console [" + mod_id + "]: " + exception.what();
+        return false;
+    }
+}
+
 void on_world_ready( bool new_game )
 {
     runtime_world_ready( new_game );
@@ -867,6 +961,14 @@ bool reload_active_mods( std::string &error )
 {
     error.clear();
     return true;
+}
+
+bool execute_console( const std::string &, const std::string &,
+                      std::string &output, std::string &error )
+{
+    output.clear();
+    error = disabled_error;
+    return false;
 }
 
 void on_world_ready( bool )

--- a/src/lua_platform_loader.h
+++ b/src/lua_platform_loader.h
@@ -91,7 +91,8 @@ std::string prepared_content_fingerprint();
 /**
  * Re-execute active entries and swap runtime registrations only when their
  * static content fingerprint is unchanged.  A changed fingerprint returns
- * false with `requires_full_data_reload` in @p error.
+ * false with `requires_full_data_reload` in @p error. Reentrant calls while
+ * an active Mod is executing Lua are rejected before touching its state.
  */
 bool reload_active_mods( std::string &error );
 

--- a/src/lua_platform_loader.h
+++ b/src/lua_platform_loader.h
@@ -100,7 +100,8 @@ bool reload_active_mods( std::string &error );
 /**
  * Run an explicitly submitted console chunk in an existing Mod state. This is
  * not a sandbox or a transaction: changes survive a later script error.
- * Output describes up to 16 return values without invoking their metamethods.
+ * Output describes up to 16 return values, expanding at most 20 raw fields of
+ * each returned table without traversing nested tables or invoking metamethods.
  */
 bool execute_console( const std::string &mod_id, const std::string &source,
                       std::string &output, std::string &error );

--- a/src/lua_platform_loader.h
+++ b/src/lua_platform_loader.h
@@ -97,6 +97,14 @@ std::string prepared_content_fingerprint();
  */
 bool reload_active_mods( std::string &error );
 
+/**
+ * Run an explicitly submitted console chunk in an existing Mod state. This is
+ * not a sandbox or a transaction: changes survive a later script error.
+ * Output describes up to 16 return values without invoking their metamethods.
+ */
+bool execute_console( const std::string &mod_id, const std::string &source,
+                      std::string &output, std::string &error );
+
 /** Activate world-bound services and load engine-owned Platform sidecars. */
 void on_world_ready( bool new_game );
 

--- a/src/lua_platform_loader.h
+++ b/src/lua_platform_loader.h
@@ -92,7 +92,8 @@ std::string prepared_content_fingerprint();
  * Re-execute active entries and swap runtime registrations only when their
  * static content fingerprint is unchanged.  A changed fingerprint returns
  * false with `requires_full_data_reload` in @p error. Reentrant calls while
- * an active Mod is executing Lua are rejected before touching its state.
+ * an active Mod is executing Lua, or another reload is replacing registrations,
+ * are rejected before touching its state.
  */
 bool reload_active_mods( std::string &error );
 

--- a/tests/lua_platform_console_test.cpp
+++ b/tests/lua_platform_console_test.cpp
@@ -1,0 +1,100 @@
+#if defined(CATA_ENABLE_LUA_PLATFORM) && CATA_ENABLE_LUA_PLATFORM
+#include "lua_platform_test_support.h"
+#include "lua_platform_runtime_internal.h"
+
+TEST_CASE( "lua_platform_console_uses_the_selected_mod_and_preserves_errors",
+           "[lua][platform][console]" )
+{
+    namespace platform = cata::lua_platform;
+    platform::shutdown();
+    const platform_lua_test_directory first;
+    const platform_lua_test_directory second;
+    const on_out_of_scope cleanup( []() {
+        platform::shutdown();
+    } );
+    first.write( "main.lua", "console_counter = 3" );
+    second.write( "main.lua", "console_counter = 9" );
+    std::string error;
+    REQUIRE( platform::prepare_mods( {
+        { "console-first", first.root, first.root / "main.lua" },
+        { "console-second", second.root, second.root / "main.lua" }
+    }, error ) );
+    REQUIRE( platform::apply_prepared_content( error ) );
+    REQUIRE( platform::validate_finalized_prepared_content( error ) );
+    platform::commit_prepared_mods();
+    platform::runtime_world_ready( true );
+    std::string output = "old output";
+    REQUIRE_FALSE( platform::execute_console( "missing", "error('must not run')", output, error ) );
+    CHECK( output.empty() );
+    CHECK( error.find( "missing" ) != std::string::npos );
+
+    REQUIRE( platform::execute_console( "console-first",
+                                        "console_counter = console_counter + 1; return console_counter", output, error ) );
+    CHECK( output == "4" );
+    CHECK( error.empty() );
+    REQUIRE( platform::execute_console( "console-second", "return console_counter", output, error ) );
+    CHECK( output == "9" );
+
+    REQUIRE_FALSE( platform::execute_console( "console-first",
+                   "console_counter = 17; error('console sentinel')", output, error ) );
+    CHECK( output.empty() );
+    CHECK( error.find( "console-first" ) != std::string::npos );
+    CHECK( error.find( "console sentinel" ) != std::string::npos );
+    REQUIRE( platform::execute_console( "console-first", "return console_counter", output, error ) );
+    CHECK( output == "17" ); // Console execution does not promise rollback.
+    REQUIRE_FALSE( platform::execute_console( "console-first", "local = invalid", output, error ) );
+    CHECK( error.find( "console-first" ) != std::string::npos );
+
+    REQUIRE( platform::execute_console( "console-first", R"lua(
+return 9223372036854775807, true, nil, "a\0b", "中文",
+    setmetatable({}, { __tostring = function() error("must not stringify") end })
+)lua", output, error ) );
+    CHECK( output == "9223372036854775807\ntrue\nnil\n\"a\\x00b\"\n\"中文\"\n<table>" );
+    REQUIRE( platform::execute_console( "console-first", "", output, error ) );
+    CHECK( output == "Completed (no return values)" );
+}
+
+TEST_CASE( "lua_platform_console_bounds_display_and_rejects_recursive_execution",
+           "[lua][platform][console]" )
+{
+    namespace platform = cata::lua_platform;
+    platform::shutdown();
+    const platform_lua_test_directory files;
+    const on_out_of_scope cleanup( []() {
+        platform::shutdown();
+    } );
+    files.write( "main.lua", "-- console fixture" );
+    std::string error;
+    REQUIRE( platform::prepare_mods( {
+        { "console-bounds", files.root, files.root / "main.lua" }
+    }, error ) );
+    REQUIRE( platform::apply_prepared_content( error ) );
+    REQUIRE( platform::validate_finalized_prepared_content( error ) );
+    platform::commit_prepared_mods();
+    std::string output;
+    REQUIRE( platform::execute_console( "console-bounds",
+                                        "return string.rep('x', 1025)", output, error ) );
+    CHECK( output == "\"" + std::string( 1024, 'x' ) + "\" [truncated]" );
+    REQUIRE( platform::execute_console( "console-bounds",
+                                        "return 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17", output, error ) );
+    CHECK( output.find( "\n16\n[remaining return values omitted]" ) != std::string::npos );
+
+    const std::shared_ptr<platform::runtime> owner = platform::detail::find_active_runtime(
+                "console-bounds" );
+    REQUIRE( owner );
+    owner->lua->set_function( "recursive_console", []() {
+        std::string nested_output;
+        std::string nested_error;
+        return platform::execute_console( "console-bounds", "return 1", nested_output, nested_error );
+    } );
+    owner->lua->set_function( "recursive_reload", []() {
+        std::string nested_error;
+        return platform::reload_active_mods( nested_error );
+    } );
+    REQUIRE( platform::execute_console( "console-bounds",
+                                        "return recursive_console(), recursive_reload()", output, error ) );
+    CHECK( output == "false\nfalse" );
+    REQUIRE( platform::execute_console( "console-bounds", "return 42", output, error ) );
+    CHECK( output == "42" );
+}
+#endif

--- a/tests/lua_platform_console_test.cpp
+++ b/tests/lua_platform_console_test.cpp
@@ -41,7 +41,7 @@ return ccb.services.characters.recalculate_enchantments(ccb.services.handles.ava
     CHECK( output == "true" );
 
     REQUIRE_FALSE( platform::execute_console( "console-first",
-                   "console_counter = 17; error('console sentinel')", output, error ) );
+            "console_counter = 17; error('console sentinel')", output, error ) );
     CHECK( output.empty() );
     CHECK( error.find( "console-first" ) != std::string::npos );
     CHECK( error.find( "console sentinel" ) != std::string::npos );
@@ -103,7 +103,7 @@ return t
     CHECK( output.find( "[remaining fields omitted]" ) != std::string::npos );
 
     const std::shared_ptr<platform::runtime> owner = platform::detail::find_active_runtime(
-                "console-bounds" );
+            "console-bounds" );
     REQUIRE( owner );
     owner->lua->set_function( "recursive_console", []() {
         std::string nested_output;

--- a/tests/lua_platform_console_test.cpp
+++ b/tests/lua_platform_console_test.cpp
@@ -55,7 +55,7 @@ return ccb.services.characters.recalculate_enchantments(ccb.services.handles.ava
 return 9223372036854775807, true, nil, "a\0b", "中文",
     setmetatable({}, { __tostring = function() error("must not stringify") end })
 )lua", output, error ) );
-    CHECK( output == "9223372036854775807\ntrue\nnil\n\"a\\x00b\"\n\"中文\"\n<table>" );
+    CHECK( output == "9223372036854775807\ntrue\nnil\n\"a\\x00b\"\n\"中文\"\n{}" );
     REQUIRE( platform::execute_console( "console-first", "", output, error ) );
     CHECK( output == "Completed (no return values)" );
 }
@@ -84,6 +84,23 @@ TEST_CASE( "lua_platform_console_bounds_display_and_rejects_recursive_execution"
     REQUIRE( platform::execute_console( "console-bounds",
                                         "return 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17", output, error ) );
     CHECK( output.find( "\n16\n[remaining return values omitted]" ) != std::string::npos );
+    REQUIRE( platform::execute_console( "console-bounds", R"lua(
+local t = { [1] = "one", name = "snapshot" }
+t.self = t
+return setmetatable(t, {
+    __pairs = function() error("must not call __pairs") end,
+    __tostring = function() error("must not call __tostring") end
+})
+)lua", output, error ) );
+    CHECK( output.find( "[1] = \"one\"" ) != std::string::npos );
+    CHECK( output.find( "[\"name\"] = \"snapshot\"" ) != std::string::npos );
+    CHECK( output.find( "[\"self\"] = <table>" ) != std::string::npos );
+    REQUIRE( platform::execute_console( "console-bounds", R"lua(
+local t = {}
+for i = 1, 21 do t[i] = i end
+return t
+)lua", output, error ) );
+    CHECK( output.find( "[remaining fields omitted]" ) != std::string::npos );
 
     const std::shared_ptr<platform::runtime> owner = platform::detail::find_active_runtime(
                 "console-bounds" );

--- a/tests/lua_platform_console_test.cpp
+++ b/tests/lua_platform_console_test.cpp
@@ -34,12 +34,18 @@ TEST_CASE( "lua_platform_console_uses_the_selected_mod_and_preserves_errors",
     CHECK( error.empty() );
     REQUIRE( platform::execute_console( "console-second", "return console_counter", output, error ) );
     CHECK( output == "9" );
+    REQUIRE( platform::execute_console( "console-first", R"lua(
+local ccb = require("ccb")
+return ccb.services.characters.recalculate_enchantments(ccb.services.handles.avatar()).ok
+)lua", output, error ) );
+    CHECK( output == "true" );
 
     REQUIRE_FALSE( platform::execute_console( "console-first",
                    "console_counter = 17; error('console sentinel')", output, error ) );
     CHECK( output.empty() );
     CHECK( error.find( "console-first" ) != std::string::npos );
     CHECK( error.find( "console sentinel" ) != std::string::npos );
+    CHECK( platform::detail::find_active_runtime( "console-first" )->callback_depth == 0 );
     REQUIRE( platform::execute_console( "console-first", "return console_counter", output, error ) );
     CHECK( output == "17" ); // Console execution does not promise rollback.
     REQUIRE_FALSE( platform::execute_console( "console-first", "local = invalid", output, error ) );

--- a/tests/lua_platform_reload_guard_test.cpp
+++ b/tests/lua_platform_reload_guard_test.cpp
@@ -1,0 +1,48 @@
+#if defined(CATA_ENABLE_LUA_PLATFORM) && CATA_ENABLE_LUA_PLATFORM
+#include "lua_platform_test_support.h"
+#include "lua_platform_runtime_internal.h"
+
+TEST_CASE( "lua_platform_reload_rejects_an_active_lua_call_stack",
+           "[lua][platform][runtime][reload]" )
+{
+    namespace platform = cata::lua_platform;
+    platform::shutdown();
+    const platform_lua_test_directory files;
+    bool attempted = false;
+    bool accepted = true;
+    std::string reload_error;
+    const on_out_of_scope cleanup( []() {
+        platform::shutdown();
+    } );
+    files.write( "main.lua", R"lua(
+local ccb = require("ccb")
+ccb.runtime.handler("try_reload", function()
+    attempt_reload()
+end)
+ccb.runtime.on("world_ready", "try_reload")
+)lua" );
+    const platform::mod_source source { "reload-guard", files.root, files.root / "main.lua" };
+    std::string error;
+    REQUIRE( platform::prepare_mods( { source }, error ) );
+    REQUIRE( platform::apply_prepared_content( error ) );
+    REQUIRE( platform::validate_finalized_prepared_content( error ) );
+    platform::commit_prepared_mods();
+    const std::shared_ptr<platform::runtime> owner = platform::detail::find_active_runtime(
+                "reload-guard" );
+    REQUIRE( owner );
+    owner->lua->set_function( "attempt_reload", [&]() {
+        attempted = true;
+        accepted = platform::reload_active_mods( reload_error );
+    } );
+    platform::runtime_world_ready( true );
+    CHECK( attempted );
+    CHECK_FALSE( accepted );
+    CHECK( reload_error.find( "still executing" ) != std::string::npos );
+    CHECK( reload_error.find( "reload-guard" ) != std::string::npos );
+    CHECK( platform::detail::find_active_runtime( "reload-guard" ) == owner );
+    const sol::protected_function_result still_alive = owner->lua->safe_script(
+                "return 42", sol::script_pass_on_error );
+    REQUIRE( still_alive.valid() );
+    CHECK( still_alive.get<int>() == 42 );
+}
+#endif

--- a/tests/lua_platform_reload_guard_test.cpp
+++ b/tests/lua_platform_reload_guard_test.cpp
@@ -104,4 +104,47 @@ ccb.content.add(item)
     REQUIRE( result.valid() );
     CHECK( result.get<int>() == 42 );
 }
+TEST_CASE( "lua_platform_reload_rejects_reentry_during_replacement",
+           "[lua][platform][runtime][reload]" )
+{
+    namespace platform = cata::lua_platform;
+    platform::shutdown();
+    const platform_lua_test_directory files;
+    int attempts = 0;
+    bool nested_accepted = true;
+    std::string nested_error;
+    const on_out_of_scope cleanup( []() {
+        platform::shutdown();
+    } );
+    files.write( "main.lua", R"lua(
+local ccb = require("ccb")
+ccb.runtime.handler("shutdown_reload", function()
+    if attempt_reload then attempt_reload() end
+end)
+ccb.runtime.on("shutdown", "shutdown_reload")
+)lua" );
+    const platform::mod_source source { "reload-reentry", files.root, files.root / "main.lua" };
+    std::string error;
+    REQUIRE( platform::prepare_mods( { source }, error ) );
+    REQUIRE( platform::apply_prepared_content( error ) );
+    REQUIRE( platform::validate_finalized_prepared_content( error ) );
+    platform::commit_prepared_mods();
+    platform::runtime_world_ready( true );
+    {
+        const std::shared_ptr<platform::runtime> owner = platform::detail::find_active_runtime(
+                    "reload-reentry" );
+        REQUIRE( owner );
+        owner->lua->set_function( "attempt_reload", [&]() {
+            ++attempts;
+            nested_accepted = platform::reload_active_mods( nested_error );
+        } );
+    } // Do not retain Lua references across a successful replacement.
+    REQUIRE( platform::reload_active_mods( error ) );
+    CHECK( attempts == 1 );
+    CHECK_FALSE( nested_accepted );
+    CHECK( nested_error.find( "already in progress" ) != std::string::npos );
+    // The scope guard must release the transaction after the outer reload.
+    REQUIRE( platform::reload_active_mods( error ) );
+    CHECK( attempts == 1 );
+}
 #endif

--- a/tests/lua_platform_reload_guard_test.cpp
+++ b/tests/lua_platform_reload_guard_test.cpp
@@ -1,6 +1,7 @@
 #if defined(CATA_ENABLE_LUA_PLATFORM) && CATA_ENABLE_LUA_PLATFORM
 #include "lua_platform_test_support.h"
 #include "lua_platform_runtime_internal.h"
+#include <variant>
 
 TEST_CASE( "lua_platform_reload_rejects_an_active_lua_call_stack",
            "[lua][platform][runtime][reload]" )
@@ -36,7 +37,7 @@ ccb.runtime.on("world_ready", "try_reload")
     } );
     platform::runtime_world_ready( true );
     CHECK( attempted );
-    CHECK_FALSE( accepted );
+    REQUIRE_FALSE( accepted );
     CHECK( reload_error.find( "still executing" ) != std::string::npos );
     CHECK( reload_error.find( "reload-guard" ) != std::string::npos );
     CHECK( platform::detail::find_active_runtime( "reload-guard" ) == owner );
@@ -44,5 +45,63 @@ ccb.runtime.on("world_ready", "try_reload")
                 "return 42", sol::script_pass_on_error );
     REQUIRE( still_alive.valid() );
     CHECK( still_alive.get<int>() == 42 );
+}
+
+TEST_CASE( "lua_platform_failed_reload_keeps_the_active_runtime_and_state",
+           "[lua][platform][runtime][reload]" )
+{
+    namespace platform = cata::lua_platform;
+    platform::shutdown();
+    const platform_lua_test_directory files;
+    const on_out_of_scope cleanup( []() {
+        platform::shutdown();
+    } );
+    files.write( "main.lua", R"lua(
+local ccb = require("ccb")
+ccb.runtime.handler("kept", function() return 42 end)
+)lua" );
+    const platform::mod_source source { "reload-preserve", files.root, files.root / "main.lua" };
+    std::string error;
+    REQUIRE( platform::prepare_mods( { source }, error ) );
+    REQUIRE( platform::apply_prepared_content( error ) );
+    REQUIRE( platform::validate_finalized_prepared_content( error ) );
+    platform::commit_prepared_mods();
+    platform::runtime_world_ready( true );
+    const std::shared_ptr<platform::runtime> owner = platform::detail::find_active_runtime(
+                "reload-preserve" );
+    REQUIRE( owner );
+    owner->world_state.emplace( "reload_marker", std::int64_t( 17 ) );
+    sol::protected_function kept = owner->handlers.at( "kept" ).callback;
+    std::string expected_error;
+    SECTION( "syntax failure" ) {
+        files.write( "main.lua", "local = invalid syntax" );
+    }
+    SECTION( "entry execution failure" ) {
+        files.write( "main.lua", "error('candidate execution sentinel')" );
+        expected_error = "candidate execution sentinel";
+    }
+    SECTION( "static definitions changed" ) {
+        files.write( "main.lua", R"lua(
+local ccb = require("ccb")
+local item = ccb.content.Item {
+    id = "lua_reload_preserve_new_item", name = "reload fixture",
+    description = "Only a candidate definition; must not be applied.", symbol = "?"
+}
+item:mass_grams(1)
+item:volume_ml(1)
+ccb.content.add(item)
+)lua" );
+        expected_error = "requires_full_data_reload";
+    }
+    REQUIRE_FALSE( platform::reload_active_mods( error ) );
+    CHECK_FALSE( error.empty() );
+    if( !expected_error.empty() ) {
+        CHECK( error.find( expected_error ) != std::string::npos );
+    }
+    REQUIRE( platform::detail::find_active_runtime( "reload-preserve" ) == owner );
+    CHECK( std::get<std::int64_t>( owner->world_state.at( "reload_marker" ) ) == 17 );
+    const sol::protected_function_result result = kept();
+    REQUIRE( result.valid() );
+    CHECK( result.get<int>() == 42 );
 }
 #endif


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

Depends on #760; this draft targets codex/lua-debug-reload.

Adds Debug menu → Console → Lua. Select a loaded Mod, edit multiline Lua, and explicitly run it in that Mod's existing state. Execution is deferred until outside the drawing frame and uses the normal callback context so owner/world/handle checks remain active. A disappeared selection is not silently retargeted to another Mod. Globals and world/external side effects remain if a later statement fails.

Displays up to 16 return values, up to 1024 source bytes per string, and one layer of up to 20 raw table fields. It never invokes __pairs or __tostring; nested values use type labels and table order is unspecified. Numeric keys remain unchanged during raw iteration; UTF-8/control-byte display and temporary Lua stack cleanup are explicit. Recursive same-state execution and execution during reload are refused.

Native regression source covers Mod isolation, actual service mutation, errors with retained side effects, callback-depth cleanup, integer/string formatting, raw/cyclic tables, truncation and recursive console/reload guards. Validation: git diff --check passed. No compiler, native tests, interactive UI/game or broad acceptance ran. No automatic execution or persistent command history is introduced.

#### Responsible human

@LYHGLYTX

#### Documentation impact

Updates the Lua-first contract or author tooling guidance for the behavior described above.

#### Related CCB-Docs PR

https://github.com/CrimsonCrossBunker/CCB-Docs/pull/47 (draft; publish only after source acceptance).

#### Affected documentation IDs

cpp.lua-bridge

#### Generated reference impact

Generated native references are deferred to batch acceptance; no generated inventories were hand-edited.


#### Additional context

Keep draft; do not merge before morning review.