### PR TITLE
Distinguish inherited Item fields in Lua reload fingerprints

### DIFF
--- a/data/lua/LUA_FIRST_PLATFORM.md
+++ b/data/lua/LUA_FIRST_PLATFORM.md
@@ -196,6 +196,10 @@ replacement preserves only the state explicitly defined by Platform lifecycle
 and persistence rules; external filesystem or process side effects are trusted
 code responsibilities and are not silently rolled back.
 
+Item fingerprints include patch-field presence: omitting a field inherits its
+source value, while explicitly supplying a default value overwrites it.
+物品指纹包含补丁字段是否显式提供：省略字段继承来源值，显式默认值则覆盖来源值。
+
 ## Native content model / 原生内容模型
 
 `ccb.content` is a pure-Lua native typed builder and registrar surface, not a

--- a/src/lua_platform_content_items.cpp
+++ b/src/lua_platform_content_items.cpp
@@ -6686,10 +6686,11 @@ void items_content_transaction::append_fingerprint( const items_content_fingerpr
                 // An omitted patch field inherits its source; an explicitly
                 // supplied default value overwrites it. Both have identical
                 // stored values, so include presence in the reload fingerprint.
-                for( const bool present : { v.has_name, v.has_description, v.has_symbol,
-                                           v.has_mass, v.has_volume, v.has_price, v.has_price_postapoc,
-                                           v.has_color, v.has_category, v.has_looks_like, v.has_magazine_capacity
-                                         } ) {
+                for( const bool present : {
+                         v.has_name, v.has_description, v.has_symbol,
+                         v.has_mass, v.has_volume, v.has_price, v.has_price_postapoc,
+                         v.has_color, v.has_category, v.has_looks_like, v.has_magazine_capacity
+                     } ) {
                     hash_part( state, present ? "present" : "absent" );
                 }
                 hash_part( state, v.id );

--- a/src/lua_platform_content_items.cpp
+++ b/src/lua_platform_content_items.cpp
@@ -6683,6 +6683,15 @@ void items_content_transaction::append_fingerprint( const items_content_fingerpr
                 const auto &v = *entry.definition;
                 hash_part( state, "item" );
                 hash_part( state, operation_name( entry.operation ) );
+                // An omitted patch field inherits its source; an explicitly
+                // supplied default value overwrites it. Both have identical
+                // stored values, so include presence in the reload fingerprint.
+                for( const bool present : { v.has_name, v.has_description, v.has_symbol,
+                                           v.has_mass, v.has_volume, v.has_price, v.has_price_postapoc,
+                                           v.has_color, v.has_category, v.has_looks_like, v.has_magazine_capacity
+                                         } ) {
+                    hash_part( state, present ? "present" : "absent" );
+                }
                 hash_part( state, v.id );
                 hash_part( state, v.copy_from );
                 hash_part( state, v.name );

--- a/tests/lua_platform_item_patch_fingerprint_test.cpp
+++ b/tests/lua_platform_item_patch_fingerprint_test.cpp
@@ -1,0 +1,44 @@
+#if defined(CATA_ENABLE_LUA_PLATFORM) && CATA_ENABLE_LUA_PLATFORM
+#include "lua_platform_test_support.h"
+
+TEST_CASE( "lua_platform_item_patch_fingerprint_distinguishes_omitted_fields",
+           "[lua][platform][content][reload]" )
+{
+    namespace platform = cata::lua_platform;
+    platform::shutdown();
+    const platform_lua_test_directory files;
+    const on_out_of_scope cleanup( []() {
+        platform::shutdown();
+    } );
+    const platform::mod_source source {
+        "item-patch-fingerprint", files.root, files.root / "main.lua"
+    };
+    const auto fingerprint = [&]( const std::string &field ) {
+        files.write( "main.lua", "local ccb = require('ccb')\n"
+                     "ccb.content.add(ccb.content.Item { id = 'lua_patch_fingerprint_item', "
+                     "copy_from = 'rock', " + field + " })\n" );
+        std::string error;
+        const bool prepared = platform::prepare_mods( { source }, error );
+        INFO( error );
+        REQUIRE( prepared );
+        const std::string result = platform::prepared_content_fingerprint();
+        platform::discard_prepared_mods();
+        return result;
+    };
+    const std::string inherited = fingerprint( "" );
+    REQUIRE_FALSE( inherited.empty() );
+    CHECK( fingerprint( "" ) == inherited );
+    // These explicit values equal the C++ defaults of omitted fields, but
+    // applying them replaces rather than inherits the source item's values.
+    for( const char *field : {
+             "name = ''", "description = ''", "symbol = '?'", "mass_grams = 0",
+             "volume_ml = 0", "price_cents = 0", "price_postapoc_cents = 0",
+             "color = 'white'"
+         } ) {
+        INFO( field );
+        const std::string overridden = fingerprint( field );
+        CHECK( overridden != inherited );
+        CHECK( fingerprint( field ) == overridden );
+    }
+}
+#endif

--- a/tests/lua_platform_item_patch_fingerprint_test.cpp
+++ b/tests/lua_platform_item_patch_fingerprint_test.cpp
@@ -13,7 +13,7 @@ TEST_CASE( "lua_platform_item_patch_fingerprint_distinguishes_omitted_fields",
     const platform::mod_source source {
         "item-patch-fingerprint", files.root, files.root / "main.lua"
     };
-    const auto fingerprint = [&]( const std::string &field ) {
+    const auto fingerprint = [&]( const std::string & field ) {
         files.write( "main.lua", "local ccb = require('ccb')\n"
                      "ccb.content.add(ccb.content.Item { id = 'lua_patch_fingerprint_item', "
                      "copy_from = 'rock', " + field + " })\n" );


### PR DESCRIPTION
#### Summary
A Lua Item using copy_from inherits omitted fields, but an explicit default value overwrites the source. For example, omitting mass_grams and setting mass_grams = 0 stored the same scalar in the fingerprint despite different application behavior. Script reload could therefore miss a static-content change.

Include all Item patch presence flags in the static fingerprint. Add native regression source comparing omission with eight valid explicit default-valued fields, and checking fingerprint stability for unchanged inputs.

#### Responsible human
@LYHGLYTX

#### Validation
Passed git diff --cached --check. Source-reviewed Item option parsing, validation, application, and fingerprint comparison.
No compilation, linking, native tests, or broad suites ran, per the user's overnight instruction.
Before acceptance, run lua_platform_item_patch_fingerprint_distinguishes_omitted_fields and the focused reload cases.

57 changed lines in one coherent commit. Keep this PR draft and do not merge before morning acceptance.

#### Documentation impact
Clarify inherited versus explicit Item patch fields in the accepted architecture document.

#### Related CCB-Docs PR
https://github.com/CrimsonCrossBunker/CCB-Docs/pull/47 (draft companion)

#### Affected documentation IDs
cpp.lua-bridge

#### Generated reference impact
No new Lua API or declaration. Generated source-location refresh is deferred to acceptance if needed; no generated file was hand-edited.
