### PR TITLE
Add read-only Lua state key pages for author diagnostics

### DIFF
--- a/ai/lua-first-roadmap.yml
+++ b/ai/lua-first-roadmap.yml
@@ -678,3 +678,4 @@ capabilities:
     next_actions:
       - The initial declaration-snapshot, scaffold/editor and static-diagnostic slice passed local tool tests and the real LuaLS gate; it does not implement an in-game debugger, state/task inspector or native compatibility negotiation.
       - Continue runtime debugging, cookbook and author-workflow improvements as independent batches with their own evidence; do not make the whole author-experience capability a core Platform closure dependency.
+      - Draft state-scope key pages expose copied, owner-scoped names with bounded output; native regression source exists but compilation and runtime acceptance have not run.

--- a/data/lua/LUA_FIRST_PLATFORM.md
+++ b/data/lua/LUA_FIRST_PLATFORM.md
@@ -361,6 +361,21 @@ to use the exact-Item `quote/get/commit` API.
 使用；快照不是可写引擎对象，失效 token 不可复用。内容注册回滚不等于任意世界操作有事务，
 只有接口明确声明的操作才保证原子性；外部文件、进程和原生扩展副作用不在回滚承诺内。
 
+The draft read-only `ccb.state.world.keys(after_key?, limit?)` and character-scope
+equivalent expose copied keys for the owning Mod after `world_ready`. Pages use
+bytewise lexicographic order, an exclusive string cursor and a default limit of
+20 (1..200). They include total/matched/returned counts and `next_after` only when
+another page exists. Values remain behind `get`; modifying the returned table
+does not mutate state. Each call takes a fresh snapshot, so restart pagination
+if keys change between calls. Native regression source exists; compilation and
+runtime acceptance have not run.
+
+只读草稿接口 `ccb.state.world.keys(after_key?, limit?)` 及角色作用域版本在 world-ready
+后枚举当前 Mod 的键，返回复制的键名，不包含值。按字节字典序排列，字符串游标表示严格
+晚于该键；默认每页 20 项，可选 1–200。结果含总数、匹配数、返回数，仅有下一页时提供
+`next_after`。修改返回表不修改状态；每次调用重新获取快照，分页期间键变化时应重新开始。
+回归测试源码已补，尚未编译或进行运行时验收。
+
 ## Behaviour instead of EOC / 用 Lua 行为表达能力
 
 Lua expresses conditions, effects, branching, loops, composition, and policy

--- a/data/lua/types/ccb_platform_v1.d.lua
+++ b/data/lua/types/ccb_platform_v1.d.lua
@@ -6202,6 +6202,15 @@ function CcbPlatformDialogueApi.limits() end
 ---@param callback fun(payload: table<string, boolean|integer|number|string>, migration: PlatformTaskMigration): table<string, boolean|integer|number|string>
 function CcbPlatformRuntime.migrate_task_payload(handler_id, from_version, to_version, callback) end
 
+---@class CcbPlatformStateKeyPage
+---@field items string[] Copied keys in bytewise lexicographic order; values are not included.
+---@field total integer Number of keys in this Mod and scope at snapshot time.
+---@field matched integer Keys strictly after the cursor, including this page.
+---@field returned integer Number of keys in items.
+---@field limit integer Requested page limit.
+---@field truncated boolean More keys matched than fit in this page.
+---@field next_after? string Exclusive cursor for the next page; nil on the last page.
+
 ---@class CcbPlatformStateScope
 local CcbPlatformStateScope = {}
 
@@ -6213,6 +6222,13 @@ function CcbPlatformStateScope.get(key, fallback) end
 ---@param key string
 ---@param value boolean|integer|number|string|nil
 function CcbPlatformStateScope.set(key, value) end
+
+---Read-only discovery for this Mod's selected scope after world_ready.
+---Each call observes current state; restart pagination if keys change between calls.
+---@param after_key? string Exclusive bytewise cursor, not required to identify an existing key.
+---@param requested_limit? integer 1..200; defaults to 20.
+---@return CcbPlatformStateKeyPage
+function CcbPlatformStateScope.keys(after_key, requested_limit) end
 
 ---@class CcbPlatformState
 ---@field character CcbPlatformStateScope

--- a/src/lua_platform_runtime_lifecycle.cpp
+++ b/src/lua_platform_runtime_lifecycle.cpp
@@ -865,6 +865,51 @@ void detail::install_runtime_state_task_api(
             set_persistent_value( owner.get()->*member, key, entry,
                                   "state." + name + ".set" );
         } );
+        scope.set_function( "keys", [weak, member, name]( sol::this_state state,
+        const sol::optional<std::string> &after_key, const sol::optional<std::int64_t> &requested_limit ) {
+            const std::shared_ptr<runtime> owner = weak.lock();
+            if( !owner || !owner->world_is_ready ) {
+                throw std::runtime_error( "state." + name + " is only available after world_ready" );
+            }
+            const std::int64_t limit = requested_limit.value_or( 20 );
+            if( limit < 1 || limit > 200 ) {
+                throw std::invalid_argument( "state.keys limit must be between 1 and 200" );
+            }
+            const persistent_state &values = owner.get()->*member;
+            const std::size_t total = values.size();
+            std::size_t matched = 0;
+            std::set<std::string> keys;
+            for( const auto &entry : values ) {
+                if( after_key && entry.first <= *after_key ) {
+                    continue;
+                }
+                ++matched;
+                keys.insert( entry.first );
+                if( keys.size() > static_cast<std::size_t>( limit ) ) {
+                    auto last = keys.end();
+                    keys.erase( --last );
+                }
+            }
+            // Finish traversing native state before Lua allocation can run GC.
+            // Keep only one page of copied keys, never borrowed value references.
+            sol::state_view lua_state( state );
+            sol::table result = lua_state.create_table();
+            sol::table items = lua_state.create_table();
+            int index = 1;
+            for( const std::string &key : keys ) {
+                items[index++] = key;
+            }
+            result["items"] = std::move( items );
+            result["total"] = total;
+            result["matched"] = matched;
+            result["returned"] = keys.size();
+            result["limit"] = limit;
+            result["truncated"] = matched > keys.size();
+            if( matched > keys.size() ) {
+                result["next_after"] = *keys.rbegin();
+            }
+            return result;
+        } );
         return scope;
     };
     sol::table state_api = lua.create_table();

--- a/tests/lua_platform_state_keys_test.cpp
+++ b/tests/lua_platform_state_keys_test.cpp
@@ -1,0 +1,86 @@
+#if defined(CATA_ENABLE_LUA_PLATFORM) && CATA_ENABLE_LUA_PLATFORM
+#include "lua_platform_test_support.h"
+#include "lua_platform_runtime_internal.h"
+
+TEST_CASE( "lua_platform_state_keys_are_paged_and_owner_scoped",
+           "[lua][platform][state]" )
+{
+    namespace platform = cata::lua_platform;
+    platform::shutdown();
+    const platform_lua_test_directory first;
+    const platform_lua_test_directory second;
+    const on_out_of_scope cleanup( []() {
+        platform::shutdown();
+    } );
+    first.write( "main.lua", R"lua(
+local ccb = require("ccb")
+assert(not pcall(ccb.state.world.keys))
+ccb.runtime.handler("initialize", function()
+    ccb.state.world.set("zeta", 3)
+    ccb.state.world.set("alpha", "kept private")
+    ccb.state.world.set("middle", true)
+    ccb.state.character.set("character_only", 1)
+end)
+ccb.runtime.on("world_ready", "initialize")
+)lua" );
+    second.write( "main.lua", R"lua(
+local ccb = require("ccb")
+ccb.runtime.handler("initialize", function()
+    ccb.state.world.set("other_mod_only", 99)
+end)
+ccb.runtime.on("world_ready", "initialize")
+)lua" );
+    std::string error;
+    REQUIRE( platform::prepare_mods( {
+        { "state-keys-first", first.root, first.root / "main.lua" },
+        { "state-keys-second", second.root, second.root / "main.lua" }
+    }, error ) );
+    REQUIRE( platform::apply_prepared_content( error ) );
+    REQUIRE( platform::validate_finalized_prepared_content( error ) );
+    platform::commit_prepared_mods();
+    platform::runtime_world_ready( true );
+    const std::shared_ptr<platform::runtime> owner = platform::detail::find_active_runtime(
+                "state-keys-first" );
+    REQUIRE( owner );
+    const auto run = [&owner]( const std::string &source ) {
+        const sol::protected_function_result result = owner->lua->safe_script(
+                    source, sol::script_pass_on_error );
+        if( !result.valid() ) {
+            const sol::error failure = result;
+            INFO( failure.what() );
+            REQUIRE( result.valid() );
+        }
+    };
+    run( R"lua(
+local ccb = require("ccb")
+local page = ccb.state.world.keys(nil, 2)
+assert(page.total == 3 and page.matched == 3 and page.returned == 2 and page.limit == 2)
+assert(page.items[1] == "alpha" and page.items[2] == "middle")
+assert(page.truncated and page.next_after == "middle")
+assert(page.values == nil)
+local tail = ccb.state.world.keys(page.next_after, 2)
+assert(tail.total == 3 and tail.matched == 1 and tail.returned == 1)
+assert(tail.items[1] == "zeta" and not tail.truncated and tail.next_after == nil)
+assert(ccb.state.world.keys("nonexistent").items[1] == "zeta")
+assert(ccb.state.world.keys("zzzz").returned == 0)
+assert(ccb.state.world.keys().limit == 20)
+assert(ccb.state.character.keys().items[1] == "character_only")
+page.items[1] = "modified snapshot"
+assert(ccb.state.world.get("alpha") == "kept private")
+assert(ccb.state.world.keys(nil, 1).items[1] == "alpha")
+assert(not pcall(ccb.state.world.keys, nil, 0))
+assert(not pcall(ccb.state.world.keys, nil, 201))
+ccb.state.world.set("binary\0key", 1)
+local binary_page = ccb.state.world.keys("alpha", 1)
+assert(binary_page.items[1] == "binary\0key")
+assert(ccb.state.world.keys(binary_page.next_after, 1).items[1] == "middle")
+ccb.state.world.set("middle", nil)
+assert(ccb.state.world.keys().total == 3)
+ccb.state.world.set("中文", 1)
+assert(ccb.state.world.keys("zeta", 1).items[1] == "中文")
+saved_keys = ccb.state.world.keys
+)lua" );
+    platform::clear_active_runtimes();
+    run( "assert(not pcall(saved_keys))" );
+}
+#endif

--- a/tests/lua_platform_state_keys_test.cpp
+++ b/tests/lua_platform_state_keys_test.cpp
@@ -40,11 +40,11 @@ ccb.runtime.on("world_ready", "initialize")
     platform::commit_prepared_mods();
     platform::runtime_world_ready( true );
     const std::shared_ptr<platform::runtime> owner = platform::detail::find_active_runtime(
-                "state-keys-first" );
+            "state-keys-first" );
     REQUIRE( owner );
-    const auto run = [&owner]( const std::string &source ) {
+    const auto run = [&owner]( const std::string & source ) {
         const sol::protected_function_result result = owner->lua->safe_script(
-                    source, sol::script_pass_on_error );
+                source, sol::script_pass_on_error );
         if( !result.valid() ) {
             const sol::error failure = result;
             INFO( failure.what() );


### PR DESCRIPTION
#### Summary
Authors can read state only when they already know a key. Add state.world.keys(after_key?, limit?) and the matching character-scope method to discover retained keys for the current Mod after world_ready.

Pages contain copied key names in bytewise order, total/matched/returned counts, and an exclusive next_after cursor. The default page size is 20, with a 1–200 range. Values remain available through the existing get method. Calls take fresh snapshots; restart pagination if keys change.

The implementation keeps only one page of copied keys and finishes native-map traversal before allocating Lua tables, so Lua GC cannot invalidate an in-progress native iteration. It does not add a runtime, expose other Mod state, or return writable native references.

#### Responsible human
@LYHGLYTX

#### Validation
Passed git diff --cached --check. Added native regression source covering owner/scope separation, sorted continuation, missing cursor keys, detached results, limits, binary/Unicode key names, deletion and retired runtime rejection.

Per user instruction, compilation, native tests, UI, broad suites and generated inventory refresh were NOT run. Before acceptance, run lua_platform_state_keys_are_paged_and_owner_scoped and refresh the affected public contract inventories once.

163 changed lines in one coherent commit. Keep draft; do not merge or mark ready before morning acceptance.

#### Documentation impact
Updated the accepted architecture, LuaLS declarations and author-experience roadmap follow-up. Native verification remains not run.

#### Related CCB-Docs PR
https://github.com/CrimsonCrossBunker/CCB-Docs/pull/47 (draft companion)

#### Affected documentation IDs
cpp.lua-bridge

#### Generated reference impact
New shared state-scope keys method and CcbPlatformStateKeyPage declaration. Generated refresh is deferred to acceptance; no generated file was hand-edited.
