### PR TITLE
Bound Lua saved-state output and preserve double precision

### DIFF
--- a/data/lua/LUA_FIRST_PLATFORM.md
+++ b/data/lua/LUA_FIRST_PLATFORM.md
@@ -371,6 +371,18 @@ file formats are unchanged; native regression source has not been compiled or ru
 状态 codec 仍为 1 MiB，运行时作用域文件仍为 16 MiB；序列化失败前不会开始写入目标。
 键、值额度与文件格式不变；原生回归测试源码尚未编译或运行。
 
+The Lua save-output draft also overrides the generic JSON writer's fixed decimal
+precision on these private staging streams. Finite state and payload doubles use
+round-trip precision, preserving small fractions and large magnitudes without
+changing other game JSON writers. Old files remain readable, but precision lost
+in earlier saves cannot be recovered. Native float round-trip regression source
+has not been compiled or run.
+
+Lua 存档输出草稿同时覆盖通用 JSON 写入器的固定小数精度，只作用于其私有临时流。
+有限状态数值与任务 payload 的 double 使用往返精度，保留小数和大数量级，不改变其他
+游戏 JSON 写入器。旧文件仍可读取，但此前保存时已经损失的精度无法恢复；新增原生
+浮点往返回归源码尚未编译或执行。
+
 ## Behaviour instead of EOC / 用 Lua 行为表达能力
 
 Lua expresses conditions, effects, branching, loops, composition, and policy

--- a/data/lua/LUA_FIRST_PLATFORM.md
+++ b/data/lua/LUA_FIRST_PLATFORM.md
@@ -361,6 +361,16 @@ to use the exact-Item `quote/get/commit` API.
 使用；快照不是可写引擎对象，失效 token 不可复用。内容注册回滚不等于任意世界操作有事务，
 只有接口明确声明的操作才保证原子性；外部文件、进程和原生扩展副作用不在回滚承诺内。
 
+A draft serializer change enforces the existing encoded-size limits while
+staging JSON, rather than first constructing an arbitrarily larger buffer. The
+state codec retains its 1 MiB limit and runtime scope files retain 16 MiB. Failed
+serialization does not begin writing to the destination. Value/key limits and
+file formats are unchanged; native regression source has not been compiled or run.
+
+序列化草稿在暂存 JSON 时就执行现有编码大小限制，避免先完整生成过大的缓冲区再拒绝。
+状态 codec 仍为 1 MiB，运行时作用域文件仍为 16 MiB；序列化失败前不会开始写入目标。
+键、值额度与文件格式不变；原生回归测试源码尚未编译或运行。
+
 ## Behaviour instead of EOC / 用 Lua 行为表达能力
 
 Lua expresses conditions, effects, branching, loops, composition, and policy

--- a/src/lua_platform_runtime_lifecycle.cpp
+++ b/src/lua_platform_runtime_lifecycle.cpp
@@ -9,6 +9,7 @@
 #include <limits>
 #include <map>
 #include <optional>
+#include <ostream>
 #include <set>
 #include <stdexcept>
 #include <string>
@@ -724,7 +725,10 @@ void write_scope_record( JsonOut &json, const persistent_state &state,
 
 void write_scope( const cata_path &path, const std::string &scope )
 {
-    std::ostringstream buffer;
+    detail::bounded_state_output_buffer storage( static_cast<std::size_t>( maximum_platform_state_file_bytes ),
+            "Platform state file exceeds 16 MiB" );
+    std::ostream buffer( &storage );
+    buffer.exceptions( std::ios::badbit | std::ios::failbit );
     JsonOut json( buffer, true );
     json.start_object();
     json.member( "version", 1 );
@@ -755,10 +759,7 @@ void write_scope( const cata_path &path, const std::string &scope )
     }
     json.end_object();
     json.end_object();
-    const std::string serialized = buffer.str();
-    if( serialized.size() > maximum_platform_state_file_bytes ) {
-        throw std::runtime_error( "Platform state file exceeds 16 MiB" );
-    }
+    const std::string &serialized = storage.str();
     write_to_file( path, [&serialized]( std::ostream & output ) {
         output << serialized;
     } );

--- a/src/lua_platform_runtime_lifecycle.cpp
+++ b/src/lua_platform_runtime_lifecycle.cpp
@@ -725,7 +725,8 @@ void write_scope_record( JsonOut &json, const persistent_state &state,
 
 void write_scope( const cata_path &path, const std::string &scope )
 {
-    detail::bounded_state_output_buffer storage( static_cast<std::size_t>( maximum_platform_state_file_bytes ),
+    detail::bounded_state_output_buffer storage( static_cast<std::size_t>
+            ( maximum_platform_state_file_bytes ),
             "Platform state file exceeds 16 MiB" );
     std::ostream buffer( &storage );
     buffer.exceptions( std::ios::badbit | std::ios::failbit );

--- a/src/lua_platform_runtime_lifecycle.cpp
+++ b/src/lua_platform_runtime_lifecycle.cpp
@@ -731,6 +731,9 @@ void write_scope( const cata_path &path, const std::string &scope )
     std::ostream buffer( &storage );
     buffer.exceptions( std::ios::badbit | std::ios::failbit );
     JsonOut json( buffer, true );
+    // JsonOut defaults to fixed precision; persistent doubles must round-trip.
+    buffer.unsetf( std::ios_base::floatfield );
+    buffer.precision( std::numeric_limits<double>::max_digits10 );
     json.start_object();
     json.member( "version", 1 );
     json.member( "scope", scope );

--- a/src/lua_platform_state.cpp
+++ b/src/lua_platform_state.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include <ostream>
 #include <stdexcept>
 #include <string>
@@ -147,6 +148,9 @@ void write_persistent_state( std::ostream &output, const script_persistent_state
     std::ostream buffer( &storage );
     buffer.exceptions( std::ios::badbit | std::ios::failbit );
     JsonOut json( buffer, true );
+    // JsonOut defaults to fixed precision; persistent doubles must round-trip.
+    buffer.unsetf( std::ios_base::floatfield );
+    buffer.precision( std::numeric_limits<double>::max_digits10 );
     json.start_object();
     json.member( "version", persistent_state_format_version );
     json.member( "values" );

--- a/src/lua_platform_state.cpp
+++ b/src/lua_platform_state.cpp
@@ -2,7 +2,7 @@
 
 #include <algorithm>
 #include <cmath>
-#include <sstream>
+#include <ostream>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -78,6 +78,38 @@ void validate_state( const script_persistent_state &state )
 
 } // namespace
 
+detail::bounded_state_output_buffer::bounded_state_output_buffer(
+    const std::size_t maximum_bytes, std::string limit_error ) :
+    maximum_bytes_( maximum_bytes ), limit_error_( std::move( limit_error ) )
+{}
+
+const std::string &detail::bounded_state_output_buffer::str() const noexcept
+{
+    return output_;
+}
+
+std::streamsize detail::bounded_state_output_buffer::xsputn( const char *data,
+        const std::streamsize count )
+{
+    if( count < 0 || static_cast<std::uintmax_t>( count ) > maximum_bytes_ - output_.size() ) {
+        throw std::invalid_argument( limit_error_ );
+    }
+    if( count != 0 ) {
+        output_.append( data, static_cast<std::size_t>( count ) );
+    }
+    return count;
+}
+
+std::streambuf::int_type detail::bounded_state_output_buffer::overflow( const int_type ch )
+{
+    if( traits_type::eq_int_type( ch, traits_type::eof() ) ) {
+        return traits_type::not_eof( ch );
+    }
+    const char value = traits_type::to_char_type( ch );
+    xsputn( &value, 1 );
+    return ch;
+}
+
 void assign_persistent_value( script_persistent_state &state, const std::string &key,
                               const script_persistent_value &value )
 {
@@ -110,7 +142,10 @@ void write_persistent_state( std::ostream &output, const script_persistent_state
     }
     std::sort( keys.begin(), keys.end() );
 
-    std::ostringstream buffer;
+    detail::bounded_state_output_buffer storage( persistent_state_max_file_bytes,
+            "Lua persistent state file exceeds 1 MiB after JSON encoding" );
+    std::ostream buffer( &storage );
+    buffer.exceptions( std::ios::badbit | std::ios::failbit );
     JsonOut json( buffer, true );
     json.start_object();
     json.member( "version", persistent_state_format_version );
@@ -138,10 +173,7 @@ void write_persistent_state( std::ostream &output, const script_persistent_state
     json.end_object();
     json.end_object();
 
-    const std::string serialized = buffer.str();
-    if( serialized.size() > persistent_state_max_file_bytes ) {
-        throw std::invalid_argument( "Lua persistent state file exceeds 1 MiB after JSON encoding" );
-    }
+    const std::string &serialized = storage.str();
     output << serialized;
     if( !output ) {
         throw std::runtime_error( "Unable to write Lua persistent state" );

--- a/src/lua_platform_state.h
+++ b/src/lua_platform_state.h
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <iosfwd>
 #include <map>
+#include <streambuf>
 #include <string>
 #include <unordered_map>
 #include <variant>
@@ -24,6 +25,27 @@ constexpr std::size_t persistent_state_max_key_bytes = 256;
 constexpr std::size_t persistent_state_max_string_bytes = 64U * 1024U;
 constexpr std::size_t persistent_state_max_value_bytes = 512U * 1024U;
 constexpr std::size_t persistent_state_max_file_bytes = 1024U * 1024U;
+
+namespace detail
+{
+// Append-only staging for state JSON. The attached ostream must enable badbit
+// exceptions so a limit failure stops serialization immediately.
+class bounded_state_output_buffer final : public std::streambuf
+{
+    public:
+        bounded_state_output_buffer( std::size_t maximum_bytes, std::string limit_error );
+        const std::string &str() const noexcept;
+
+    protected:
+        std::streamsize xsputn( const char *data, std::streamsize count ) override;
+        int_type overflow( int_type ch ) override;
+
+    private:
+        std::size_t maximum_bytes_;
+        std::string limit_error_;
+        std::string output_;
+};
+} // namespace detail
 
 // Assign one validated value without partially changing the state on failure.
 // Throws std::invalid_argument when a key, value, or total state limit is

--- a/tests/lua_platform_bounded_output_test.cpp
+++ b/tests/lua_platform_bounded_output_test.cpp
@@ -47,9 +47,11 @@ TEST_CASE( "lua_platform_oversized_encoded_state_does_not_touch_its_destination"
     platform::script_persistent_state state;
     // Raw values fit the 512 KiB state allowance, but JSON escapes exceed the
     // existing 1 MiB codec limit. Only three 64 KiB raw values are needed.
-    for( const char *key : { "one", "two", "three" } ) {
+    for( const char *key : {
+             "one", "two", "three"
+         } ) {
         platform::assign_persistent_value( state, key,
-                                          std::string( platform::persistent_state_max_string_bytes, '\x01' ) );
+                                           std::string( platform::persistent_state_max_string_bytes, '\x01' ) );
     }
     std::ostringstream destination;
     destination << "previous output";

--- a/tests/lua_platform_bounded_output_test.cpp
+++ b/tests/lua_platform_bounded_output_test.cpp
@@ -1,0 +1,59 @@
+#if defined(CATA_ENABLE_LUA_PLATFORM) && CATA_ENABLE_LUA_PLATFORM
+#include <ostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+#include "cata_catch.h"
+#include "lua_platform_state.h"
+
+TEST_CASE( "lua_platform_state_output_stops_at_its_byte_limit",
+           "[lua][platform][state]" )
+{
+    cata::lua_platform::detail::bounded_state_output_buffer storage( 4, "bounded output sentinel" );
+    std::ostream output( &storage );
+    output.exceptions( std::ios::badbit | std::ios::failbit );
+    output.write( "ab", 2 );
+    output.put( 'c' );
+    output.write( "d", 1 );
+    CHECK( storage.str() == "abcd" );
+    CHECK_THROWS_WITH( output.put( 'e' ), "bounded output sentinel" );
+    CHECK( storage.str() == "abcd" );
+    output.clear();
+    output.write( "", 0 );
+    CHECK_THROWS_AS( output.write( "extra", 5 ), std::invalid_argument );
+    CHECK( storage.str() == "abcd" );
+}
+
+TEST_CASE( "lua_platform_state_output_counts_binary_bytes_and_rejects_whole_chunks",
+           "[lua][platform][state]" )
+{
+    cata::lua_platform::detail::bounded_state_output_buffer storage( 4, "bounded output sentinel" );
+    std::ostream output( &storage );
+    output.exceptions( std::ios::badbit | std::ios::failbit );
+    output.write( "a\0b", 3 );
+    CHECK( storage.str() == std::string( "a\0b", 3 ) );
+    CHECK_THROWS_AS( output.write( "cd", 2 ), std::invalid_argument );
+    CHECK( storage.str().size() == 3 );
+    output.clear();
+    output.put( 'c' );
+    CHECK( storage.str() == std::string( "a\0bc", 4 ) );
+}
+
+TEST_CASE( "lua_platform_oversized_encoded_state_does_not_touch_its_destination",
+           "[lua][platform][state]" )
+{
+    namespace platform = cata::lua_platform;
+    platform::script_persistent_state state;
+    // Raw values fit the 512 KiB state allowance, but JSON escapes exceed the
+    // existing 1 MiB codec limit. Only three 64 KiB raw values are needed.
+    for( const char *key : { "one", "two", "three" } ) {
+        platform::assign_persistent_value( state, key,
+                                          std::string( platform::persistent_state_max_string_bytes, '\x01' ) );
+    }
+    std::ostringstream destination;
+    destination << "previous output";
+    CHECK_THROWS_AS( platform::write_persistent_state( destination, state ), std::invalid_argument );
+    CHECK( destination.str() == "previous output" );
+}
+#endif

--- a/tests/lua_platform_state_float_persistence_test.cpp
+++ b/tests/lua_platform_state_float_persistence_test.cpp
@@ -1,0 +1,76 @@
+#if defined(CATA_ENABLE_LUA_PLATFORM) && CATA_ENABLE_LUA_PLATFORM
+#include "lua_platform_test_support.h"
+#include <array>
+#include <cmath>
+#include <limits>
+
+#include "cata_path.h"
+#include "lua_platform_state.h"
+#include "path_info.h"
+#include "worldfactory.h"
+
+TEST_CASE( "lua_platform_state_codec_preserves_double_precision_and_signed_zero",
+           "[lua][platform][state][persistence]" )
+{
+    namespace platform = cata::lua_platform;
+    const std::array<double, 7> values = {{
+            1.2345678901234567, std::nextafter( 1.0, 2.0 ), 1.0e-20, 1.0e20,
+            std::numeric_limits<double>::max(), std::numeric_limits<double>::denorm_min(), -0.0
+        }
+    };
+    platform::script_persistent_state source;
+    for( std::size_t index = 0; index < values.size(); ++index ) {
+        platform::assign_persistent_value( source, std::to_string( index ), values[index] );
+    }
+    std::ostringstream output;
+    platform::write_persistent_state( output, source );
+    const platform::script_persistent_state restored = platform::read_persistent_state(
+            json_loader::from_string( output.str() ) );
+    REQUIRE( restored.size() == values.size() );
+    for( std::size_t index = 0; index < values.size(); ++index ) {
+        INFO( index );
+        const double value = std::get<double>( restored.at( std::to_string( index ) ) );
+        CHECK( value == values[index] );
+        CHECK( std::signbit( value ) == std::signbit( values[index] ) );
+    }
+}
+
+TEST_CASE( "lua_platform_runtime_scope_files_preserve_small_and_adjacent_doubles",
+           "[lua][platform][state][persistence]" )
+{
+    namespace platform = cata::lua_platform;
+    platform::clear_active_runtimes();
+    REQUIRE( world_generator != nullptr );
+    const platform_lua_test_directory temporary;
+    const std::string old_savedir = PATH_INFO::savedir();
+    WORLD *old_world = world_generator->active_world;
+    WORLD isolated_world( "state_float_precision" );
+    sol::state old_lua;
+    sol::state new_lua;
+    const on_out_of_scope cleanup( [&]() {
+        platform::clear_active_runtimes();
+        world_generator->active_world = old_world;
+        PATH_INFO::set_savedir( old_savedir );
+    } );
+    PATH_INFO::set_savedir( temporary.root.string() + "/" );
+    world_generator->active_world = &isolated_world;
+    REQUIRE( std::filesystem::create_directory( isolated_world.folder_path().get_unrelative_path() ) );
+    const std::shared_ptr<platform::runtime> before = platform::make_runtime( "float-owner", 2014,
+        old_lua );
+    platform::set_active_runtimes( { before } );
+    platform::assign_persistent_value( before->world_state, "tiny", 1.0e-20 );
+    const double adjacent = std::nextafter( 1.0, 2.0 );
+    platform::assign_persistent_value( before->character_state, "adjacent", adjacent );
+    std::string error;
+    REQUIRE( platform::runtime_save( error ) );
+    platform::clear_active_runtimes();
+    const std::shared_ptr<platform::runtime> after = platform::make_runtime( "float-owner", 2015,
+        new_lua );
+    platform::set_active_runtimes( { after } );
+    platform::runtime_world_ready( false );
+    REQUIRE( after->world_state.size() == 1 );
+    REQUIRE( after->character_state.size() == 1 );
+    CHECK( std::get<double>( after->world_state.at( "tiny" ) ) == 1.0e-20 );
+    CHECK( std::get<double>( after->character_state.at( "adjacent" ) ) == adjacent );
+}
+#endif


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

Fixes two Lua saved-state encoding problems without changing the generic game JSON writer:

- Stop temporary encoding when it would exceed the existing 1 MiB codec or 16 MiB runtime-scope limit, instead of constructing the entire oversized JSON first. Avoid a second output copy before the destination write.
- Override JsonOut's default fixed decimal precision only on these private staging streams, using round-trip precision for finite doubles. Small fractions previously rounded to zero; old lost precision cannot be recovered.

Save schemas and size limits remain unchanged. Native regression source covers exact limits, binary/chunk writes, unchanged destination on encoding failure, tiny/adjacent/extreme doubles and signed zero, plus world/character scope round trips.

Validation: focused formatting checks on changed C++ regions and git diff --check passed. No compilation, native tests, game execution or broad validation ran. Float/parser and scope-file round trips remain pending native acceptance; this draft is not a completed acceptance claim.

#### Responsible human

@LYHGLYTX

#### Documentation impact

Updates the Lua-first contract or author tooling guidance for the behavior described above.

#### Related CCB-Docs PR

https://github.com/CrimsonCrossBunker/CCB-Docs/pull/47 (draft; publish only after source acceptance).

#### Affected documentation IDs

cpp.lua-bridge

#### Generated reference impact

Generated native references are deferred to batch acceptance; no generated inventories were hand-edited.


#### Additional context

Keep draft; do not merge before morning review.