### PR TITLE
Protect Lua task records across query and migration allocations

### DIFF
--- a/data/lua/LUA_FIRST_PLATFORM.md
+++ b/data/lua/LUA_FIRST_PLATFORM.md
@@ -361,6 +361,16 @@ to use the exact-Item `quote/get/commit` API.
 使用；快照不是可写引擎对象，失效 token 不可复用。内容注册回滚不等于任意世界操作有事务，
 只有接口明确声明的操作才保证原子性；外部文件、进程和原生扩展副作用不在回滚承诺内。
 
+Task query results (`tasks.get`, `tasks.next`, and `tasks.list`) are detached
+snapshots. The draft lifetime fix copies selected native records before allocating
+Lua result tables, so cancellation during a Lua allocation cannot invalidate the
+records being returned. Native regression source models cancellation at that
+boundary; it has not been compiled or executed.
+
+任务查询 `tasks.get`、`tasks.next`、`tasks.list` 返回独立快照。生命周期修复草稿在
+分配 Lua 返回表前复制选中的原生记录，避免 Lua 分配期间取消任务导致正在返回的记录
+失效。回归测试源码模拟该边界上的取消操作，尚未编译或执行。
+
 ## Behaviour instead of EOC / 用 Lua 行为表达能力
 
 Lua expresses conditions, effects, branching, loops, composition, and policy

--- a/data/lua/LUA_FIRST_PLATFORM.md
+++ b/data/lua/LUA_FIRST_PLATFORM.md
@@ -371,6 +371,14 @@ boundary; it has not been compiled or executed.
 分配 Lua 返回表前复制选中的原生记录，避免 Lua 分配期间取消任务导致正在返回的记录
 失效。回归测试源码模拟该边界上的取消操作，尚未编译或执行。
 
+The same task-lifetime draft keeps the existing migration mutation guard active
+while constructing metadata, invoking the callback, decoding its result and
+committing the candidate. It restores the previous flag on success or failure;
+this does not introduce a sandbox or roll back unrelated callback side effects.
+
+同一任务生命周期草稿把已有迁移保护覆盖到元数据构造、回调、返回值解码与候选提交全程，
+成功或失败都会恢复此前的标记；这不引入沙盒，也不回滚无关的回调副作用。
+
 ## Behaviour instead of EOC / 用 Lua 行为表达能力
 
 Lua expresses conditions, effects, branching, loops, composition, and policy

--- a/data/lua/types/ccb_platform_v1.d.lua
+++ b/data/lua/types/ccb_platform_v1.d.lua
@@ -6245,6 +6245,7 @@ function CcbPlatformStateScope.set(key, value) end
 ---@field vehicle_uid? integer Stable Vehicle uid; nil unless kind is 'vehicle'.
 ---@field pending boolean True when this required participant is unavailable; the whole task retries after 3600 turns without invoking its handler or scheduling its next recurring cycle.
 
+---Detached task data: later cancellation or scheduling does not change this snapshot.
 ---@class CcbPlatformTaskSnapshot
 ---@field id integer
 ---@field handler string

--- a/src/lua_platform_runtime_lifecycle.cpp
+++ b/src/lua_platform_runtime_lifecycle.cpp
@@ -769,6 +769,10 @@ void write_scope( const cata_path &path, const std::string &scope )
 bool detail::migrate_task_payload( runtime &owner, persistent_task &task,
                                    std::string &error )
 {
+    // Metadata/result conversion can also allocate Lua objects and run GC.
+    // Keep the task container stable for the entire migration transaction.
+    restore_on_out_of_scope restore_task_migration_active( owner.task_migration_active );
+    owner.task_migration_active = true;
     const auto handler = owner.handlers.find( task.handler_id );
     if( handler == owner.handlers.end() ) {
         error = "missing handler '" + task.handler_id + "'";
@@ -804,14 +808,8 @@ bool detail::migrate_task_payload( runtime &owner, persistent_task &task,
         metadata["from_version"] = candidate.payload_version;
         metadata["to_version"] = transition->second.target_version;
         sol::protected_function callback = transition->second.callback;
-        const sol::protected_function_result result = [&]() {
-            restore_on_out_of_scope restore_task_migration_active(
-                owner.task_migration_active );
-            owner.task_migration_active = true;
-            return callback(
-                       persistent_table( *owner.lua, candidate.payload ), metadata );
-        }
-        ();
+        const sol::protected_function_result result = callback(
+                persistent_table( *owner.lua, candidate.payload ), metadata );
         if( !result.valid() ) {
             const sol::error callback_error = result;
             error = callback_error.what();

--- a/src/lua_platform_runtime_lifecycle.cpp
+++ b/src/lua_platform_runtime_lifecycle.cpp
@@ -1141,10 +1141,13 @@ void detail::install_runtime_state_task_api(
     sol::table tasks = lua.create_table();
     const auto task_snapshot = []( runtime & owner,
     const persistent_task & task ) {
-        sol::table result = owner.lua->create_table();
         const std::int64_t now =
             to_turn<std::int64_t>( calendar::turn );
         const auto handler = owner.handlers.find( task.handler_id );
+        const bool handler_available = handler != owner.handlers.end();
+        const bool payload_current = handler_available &&
+                                     handler->second.payload_version == task.payload_version;
+        sol::table result = owner.lua->create_table();
         result["id"] = static_cast<std::int64_t>( task.id );
         result["handler"] = task.handler_id;
         result["due_turn"] = task.due_turn;
@@ -1230,10 +1233,8 @@ void detail::install_runtime_state_task_api(
         }
         result["participants"] = std::move( participant_snapshots );
         result["payload_version"] = task.payload_version;
-        result["handler_available"] = handler != owner.handlers.end();
-        result["payload_current"] =
-            handler != owner.handlers.end() &&
-            handler->second.payload_version == task.payload_version;
+        result["handler_available"] = handler_available;
+        result["payload_current"] = payload_current;
         result["payload"] = persistent_table( *owner.lua, task.payload );
         return result;
     };
@@ -1305,8 +1306,11 @@ void detail::install_runtime_state_task_api(
         if( found == owner->tasks.end() ) {
             return sol::make_object( lua_state, sol::nil );
         }
+        // Lua allocation may run a finalizer that cancels or schedules tasks.
+        // Detach the native record before creating any Lua return values.
+        const persistent_task snapshot = *found;
         return sol::make_object(
-                   lua_state, task_snapshot( *owner, *found ) );
+                   lua_state, task_snapshot( *owner, snapshot ) );
     } );
     tasks.set_function( "next", [weak, task_snapshot](
                             sol::this_state state, const std::string & handler_id,
@@ -1337,8 +1341,9 @@ void detail::install_runtime_state_task_api(
         if( next == nullptr ) {
             return sol::make_object( lua_state, sol::nil );
         }
+        const persistent_task snapshot = *next;
         return sol::make_object(
-                   lua_state, task_snapshot( *owner, *next ) );
+                   lua_state, task_snapshot( *owner, snapshot ) );
     } );
     tasks.set_function( "list", [weak, task_snapshot](
                             sol::this_state state,
@@ -1375,12 +1380,19 @@ void detail::install_runtime_state_task_api(
         const std::size_t returned = std::min(
                                          matches.size(),
                                          static_cast<std::size_t>( limit ) );
+        // Copy only the selected page, before allocations can invalidate any
+        // pointer into owner->tasks. Remaining matches are never dereferenced.
+        std::vector<persistent_task> snapshots;
+        snapshots.reserve( returned );
+        for( std::size_t index = 0; index < returned; ++index ) {
+            snapshots.push_back( *matches[index] );
+        }
         sol::state_view lua_state( state );
         sol::table entries = lua_state.create_table(
                                  static_cast<int>( returned ), 0 );
         for( std::size_t index = 0; index < returned; ++index ) {
             entries[index + 1] =
-                task_snapshot( *owner, *matches[index] );
+                task_snapshot( *owner, snapshots[index] );
         }
         sol::table result = lua_state.create_table();
         result["items"] = std::move( entries );

--- a/tests/lua_platform_task_snapshot_lifetime_test.cpp
+++ b/tests/lua_platform_task_snapshot_lifetime_test.cpp
@@ -1,0 +1,123 @@
+#if defined(CATA_ENABLE_LUA_PLATFORM) && CATA_ENABLE_LUA_PLATFORM
+#include "lua_platform_test_support.h"
+#include "lua_platform_runtime_internal.h"
+
+namespace
+{
+// Model task cancellation at a Lua allocation boundary without relying on the
+// collector's nondeterministic choice of when to run a Lua __gc callback.
+struct task_snapshot_allocator {
+    lua_Alloc original = nullptr;
+    void *original_data = nullptr;
+    cata::lua_platform::runtime *owner = nullptr;
+    bool armed = false;
+    bool cancelled = false;
+
+    static void *allocate( void *data, void *pointer, std::size_t old_size,
+                           std::size_t new_size ) {
+        auto &probe = *static_cast<task_snapshot_allocator *>( data );
+        if( probe.armed && new_size > 0 ) {
+            probe.armed = false;
+            probe.owner->tasks.erase( probe.owner->tasks.begin() );
+            probe.cancelled = true;
+        }
+        return probe.original( probe.original_data, pointer, old_size, new_size );
+    }
+};
+} // namespace
+
+TEST_CASE( "lua_platform_task_queries_detach_records_before_lua_allocation",
+           "[lua][platform][tasks]" )
+{
+    namespace platform = cata::lua_platform;
+    platform::shutdown();
+    const platform_lua_test_directory directory;
+    const on_out_of_scope cleanup( []() {
+        platform::shutdown();
+    } );
+    directory.write( "main.lua", R"lua(
+local ccb = require("ccb")
+ccb.runtime.handler("tick", function() end)
+query_get = ccb.tasks.get
+query_next = ccb.tasks.next
+query_list = ccb.tasks.list
+)lua" );
+    std::string error;
+    REQUIRE( platform::prepare_mods( {
+        { "snapshot-lifetime", directory.root, directory.root / "main.lua" }
+    }, error ) );
+    REQUIRE( platform::apply_prepared_content( error ) );
+    REQUIRE( platform::validate_finalized_prepared_content( error ) );
+    platform::commit_prepared_mods();
+    platform::runtime_world_ready( true );
+    const std::shared_ptr<platform::runtime> owner = platform::detail::find_active_runtime(
+                "snapshot-lifetime" );
+    REQUIRE( owner );
+    lua_State *lua = owner->lua->lua_state();
+    REQUIRE( lua_checkstack( lua, 32 ) );
+    const auto populate = [&owner]() {
+        owner->tasks.clear();
+        for( std::uint64_t id : { 11U, 12U, 13U } ) {
+            platform::persistent_task task;
+            task.id = id;
+            task.handler_id = "tick";
+            task.owner = "world";
+            task.owner_mod_id = "snapshot-lifetime";
+            task.due_turn = static_cast<std::int64_t>( id );
+            owner->tasks.push_back( std::move( task ) );
+        }
+    };
+    for( const char *query : { "query_get", "query_next", "query_list" } ) {
+        INFO( query );
+        populate();
+        const auto push_query = [lua, query]() {
+            lua_getglobal( lua, query );
+            if( std::string_view( query ) == "query_get" ) {
+                lua_pushinteger( lua, 11 );
+                return 1;
+            }
+            if( std::string_view( query ) == "query_next" ) {
+                lua_pushliteral( lua, "tick" );
+                return 1;
+            }
+            lua_pushnil( lua );
+            lua_pushnil( lua );
+            lua_pushinteger( lua, 2 );
+            return 3;
+        };
+        // Warm the call frame and interned names before arming the probe.
+        int arguments = push_query();
+        REQUIRE( lua_pcall( lua, arguments, 1, 0 ) == LUA_OK );
+        lua_pop( lua, 1 );
+        arguments = push_query();
+        task_snapshot_allocator probe;
+        probe.owner = owner.get();
+        probe.original = lua_getallocf( lua, &probe.original_data );
+        const on_out_of_scope restore_allocator( [&]() {
+            lua_setallocf( lua, probe.original, probe.original_data );
+        } );
+        lua_setallocf( lua, task_snapshot_allocator::allocate, &probe );
+        probe.armed = true;
+        REQUIRE( lua_pcall( lua, arguments, 1, 0 ) == LUA_OK );
+        REQUIRE( probe.cancelled );
+        REQUIRE( owner->tasks.size() == 2 );
+        CHECK( owner->tasks.front().id == 12 );
+        REQUIRE( lua_istable( lua, -1 ) );
+        if( std::string_view( query ) == "query_list" ) {
+            lua_getfield( lua, -1, "items" );
+            for( int index = 1; index <= 2; ++index ) {
+                lua_rawgeti( lua, -1, index );
+                lua_getfield( lua, -1, "id" );
+                CHECK( lua_tointeger( lua, -1 ) == 10 + index );
+                lua_pop( lua, 2 );
+            }
+            lua_pop( lua, 1 );
+        } else {
+            lua_getfield( lua, -1, "id" );
+            CHECK( lua_tointeger( lua, -1 ) == 11 );
+            lua_pop( lua, 1 );
+        }
+        lua_pop( lua, 1 );
+    }
+}
+#endif

--- a/tests/lua_platform_task_snapshot_lifetime_test.cpp
+++ b/tests/lua_platform_task_snapshot_lifetime_test.cpp
@@ -12,14 +12,22 @@ struct task_snapshot_allocator {
     cata::lua_platform::runtime *owner = nullptr;
     bool armed = false;
     bool cancelled = false;
+    bool observe_migration = false;
+    bool migration_guarded = true;
+    int observed_allocations = 0;
 
     static void *allocate( void *data, void *pointer, std::size_t old_size,
                            std::size_t new_size ) {
         auto &probe = *static_cast<task_snapshot_allocator *>( data );
         if( probe.armed && new_size > 0 ) {
-            probe.armed = false;
-            probe.owner->tasks.erase( probe.owner->tasks.begin() );
-            probe.cancelled = true;
+            if( probe.observe_migration ) {
+                probe.migration_guarded = probe.migration_guarded && probe.owner->task_migration_active;
+                ++probe.observed_allocations;
+            } else {
+                probe.armed = false;
+                probe.owner->tasks.erase( probe.owner->tasks.begin() );
+                probe.cancelled = true;
+            }
         }
         return probe.original( probe.original_data, pointer, old_size, new_size );
     }
@@ -123,5 +131,63 @@ query_list = ccb.tasks.list
         }
         lua_pop( lua, 1 );
     }
+}
+
+TEST_CASE( "lua_platform_task_migration_guards_all_lua_allocation_boundaries",
+           "[lua][platform][tasks][persistence]" )
+{
+    namespace platform = cata::lua_platform;
+    sol::state lua;
+    lua.open_libraries( sol::lib::base );
+    const std::shared_ptr<platform::runtime> owner = platform::make_runtime( "migration-guard", 2013,
+        lua );
+    sol::table ccb = lua.create_table();
+    platform::install_runtime_api( owner, lua, ccb );
+    lua["ccb"] = ccb;
+    owner->world_is_ready = true;
+    bool valid_result = true;
+    SECTION( "valid migrated payload" ) {}
+    SECTION( "invalid result preserves the original task and restores the guard" ) {
+        valid_result = false;
+    }
+    lua["valid_result"] = valid_result;
+    const sol::protected_function_result setup = lua.safe_script( R"lua(
+ccb.runtime.handler("tick", function() end, 2)
+ccb.runtime.migrate_task_payload("tick", 1, 2, function(payload)
+    assert(not pcall(ccb.tasks.cancel, 41))
+    if valid_result then return {value = payload.value + 1} end
+    return nil
+end)
+)lua", sol::script_pass_on_error );
+    REQUIRE( setup.valid() );
+    platform::persistent_task task;
+    task.id = 41;
+    task.handler_id = "tick";
+    task.payload["value"] = std::int64_t( 1 );
+    owner->tasks.push_back( std::move( task ) );
+    task_snapshot_allocator probe;
+    probe.owner = owner.get();
+    probe.observe_migration = true;
+    probe.original = lua_getallocf( lua.lua_state(), &probe.original_data );
+    bool migrated = false;
+    std::string error;
+    {
+        const on_out_of_scope restore_allocator( [&]() {
+            lua_setallocf( lua.lua_state(), probe.original, probe.original_data );
+        } );
+        lua_setallocf( lua.lua_state(), task_snapshot_allocator::allocate, &probe );
+        probe.armed = true;
+        migrated = platform::detail::migrate_task_payload( *owner, owner->tasks.front(), error );
+        probe.armed = false;
+    }
+    CHECK( probe.observed_allocations > 0 );
+    CHECK( probe.migration_guarded );
+    CHECK_FALSE( owner->task_migration_active );
+    CHECK( migrated == valid_result );
+    REQUIRE( owner->tasks.size() == 1 );
+    CHECK( owner->tasks.front().payload_version == ( valid_result ? 2 : 1 ) );
+    CHECK( std::get<std::int64_t>( owner->tasks.front().payload.at( "value" ) ) ==
+           ( valid_result ? 2 : 1 ) );
+    CHECK( error.empty() == valid_result );
 }
 #endif

--- a/tests/lua_platform_task_snapshot_lifetime_test.cpp
+++ b/tests/lua_platform_task_snapshot_lifetime_test.cpp
@@ -51,13 +51,15 @@ query_list = ccb.tasks.list
     platform::commit_prepared_mods();
     platform::runtime_world_ready( true );
     const std::shared_ptr<platform::runtime> owner = platform::detail::find_active_runtime(
-                "snapshot-lifetime" );
+            "snapshot-lifetime" );
     REQUIRE( owner );
     lua_State *lua = owner->lua->lua_state();
     REQUIRE( lua_checkstack( lua, 32 ) );
     const auto populate = [&owner]() {
         owner->tasks.clear();
-        for( std::uint64_t id : { 11U, 12U, 13U } ) {
+        for( std::uint64_t id : {
+                 11U, 12U, 13U
+             } ) {
             platform::persistent_task task;
             task.id = id;
             task.handler_id = "tick";
@@ -67,7 +69,9 @@ query_list = ccb.tasks.list
             owner->tasks.push_back( std::move( task ) );
         }
     };
-    for( const char *query : { "query_get", "query_next", "query_list" } ) {
+    for( const char *query : {
+             "query_get", "query_next", "query_list"
+         } ) {
         INFO( query );
         populate();
         const auto push_query = [lua, query]() {


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

Protects native task records across Lua allocation boundaries, where garbage collection may invoke finalizers:

- get/next copy their selected record and list copies only its selected page before creating Lua result tables. Handler flags are resolved before allocation; callbacks cannot invalidate borrowed task-vector records while snapshots are constructed.
- The existing task-mutation guard now covers the entire payload migration transaction: metadata construction, callback invocation, result decoding and candidate commit. The previous flag is restored on success and failure, including malformed results.

Native allocator-probe regression source models cancellation during query result allocation and observes the migration guard across allocation boundaries for valid/invalid results. Existing API signatures, limits and unrelated callback side effects remain unchanged.

Validation: focused AStyle checks on changed regions and git diff --check passed. These native tests and probes were NOT compiled or executed. No game or broad acceptance ran; morning native acceptance remains required.

#### Responsible human

@LYHGLYTX

#### Documentation impact

Updates the Lua-first contract or author tooling guidance for the behavior described above.

#### Related CCB-Docs PR

https://github.com/CrimsonCrossBunker/CCB-Docs/pull/47 (draft; publish only after source acceptance).

#### Affected documentation IDs

cpp.lua-bridge

#### Generated reference impact

Generated native references are deferred to batch acceptance; no generated inventories were hand-edited.


#### Additional context

Keep draft; do not merge before morning review.