### PR TITLE
Persist allocated Lua task IDs across empty saved scopes

### DIFF
--- a/data/lua/LUA_FIRST_PLATFORM.md
+++ b/data/lua/LUA_FIRST_PLATFORM.md
@@ -361,6 +361,19 @@ to use the exact-Item `quote/get/commit` API.
 使用；快照不是可写引擎对象，失效 token 不可复用。内容注册回滚不等于任意世界操作有事务，
 只有接口明确声明的操作才保证原子性；外部文件、进程和原生扩展副作用不在回滚承诺内。
 
+The draft task-counter persistence fix stores each Mod's `last_task_id` in both
+state scopes, including records with no pending tasks. Loading takes the maximum
+counter across loaded scopes and pending records; exhausted signed task-ID space
+remains exhausted. Absent-Mod records retain the counter when resaved. Older
+version-1 records without this optional field still load using their pending task
+IDs; IDs already discarded before that legacy save cannot be reconstructed.
+No compilation or native save/load acceptance has run for this draft.
+
+任务计数器持久化草稿在两个存档作用域的 Mod 记录中保存 `last_task_id`，任务列表为空时
+也保留。加载时合并所加载作用域的最大计数，耗尽的有符号 ID 空间不会因重进而重置；
+暂未加载的 Mod 记录再次保存时也保留计数。旧版 v1 记录缺少该可选字段时，仍按尚存任务
+推导计数；旧存档写入前已丢弃的任务 ID 无法追溯恢复。该草稿尚未编译或进行原生存取验收。
+
 ## Behaviour instead of EOC / 用 Lua 行为表达能力
 
 Lua expresses conditions, effects, branching, loops, composition, and policy

--- a/src/lua_platform_runtime_lifecycle.cpp
+++ b/src/lua_platform_runtime_lifecycle.cpp
@@ -56,6 +56,7 @@ using persistent_value = script_persistent_value;
 struct persistent_scope_record {
     persistent_state values;
     std::vector<persistent_task> tasks;
+    std::uint64_t last_task_id = 0;
 };
 
 constexpr std::uintmax_t maximum_platform_state_file_bytes =
@@ -336,6 +337,14 @@ void load_scope( const cata_path &path, const std::string &scope,
             const std::shared_ptr<runtime> owner = detail::find_active_runtime( member.name() );
             const JsonObject stored = member.get_object();
             persistent_scope_record record;
+            const bool has_last_task_id = stored.has_member( "last_task_id" );
+            if( has_last_task_id ) {
+                const std::int64_t last_task_id = stored.get_int64( "last_task_id" );
+                if( last_task_id < 0 ) {
+                    throw std::runtime_error( "Platform last task id must be non-negative" );
+                }
+                record.last_task_id = static_cast<std::uint64_t>( last_task_id );
+            }
             record.values = read_typed_values( stored.get_object( "values" ) );
             std::set<std::uint64_t> stored_task_ids;
             if( stored.has_array( "tasks" ) ) {
@@ -350,6 +359,10 @@ void load_scope( const cata_path &path, const std::string &scope,
                         throw std::runtime_error( "Platform task id must be positive" );
                     }
                     task.id = static_cast<std::uint64_t>( stored_id );
+                    if( has_last_task_id && task.id > record.last_task_id ) {
+                        throw std::runtime_error( "Platform task id exceeds its saved counter" );
+                    }
+                    record.last_task_id = std::max( record.last_task_id, task.id );
                     if( !stored_task_ids.insert( task.id ).second ) {
                         throw std::runtime_error( "Platform state repeats a persistent task id" );
                     }
@@ -596,8 +609,8 @@ void load_scope( const cata_path &path, const std::string &scope,
                 persistent_state &state = scope == "character" ?
                                           owner->character_state : owner->world_state;
                 state = std::move( record.values );
+                owner->next_task_id = std::max( owner->next_task_id, record.last_task_id + 1 );
                 for( persistent_task &task : record.tasks ) {
-                    owner->next_task_id = std::max( owner->next_task_id, task.id + 1 );
                     owner->tasks.push_back( std::move( task ) );
                 }
             } else {
@@ -616,9 +629,14 @@ void load_scope( const cata_path &path, const std::string &scope,
 
 void write_scope_record( JsonOut &json, const persistent_state &state,
                          const std::vector<persistent_task> &tasks,
+                         const std::uint64_t last_task_id,
                          const std::string &scope, const std::string &mod_id )
 {
+    if( last_task_id > static_cast<std::uint64_t>( std::numeric_limits<std::int64_t>::max() ) ) {
+        throw std::runtime_error( "Platform last task id is outside the native range" );
+    }
     json.start_object();
+    json.member( "last_task_id", static_cast<std::int64_t>( last_task_id ) );
     json.member( "values" );
     write_typed_values( json, state );
     json.member( "tasks" );
@@ -630,6 +648,9 @@ void write_scope_record( JsonOut &json, const persistent_state &state,
         if( !task.owner_mod_id.empty() && task.owner_mod_id != mod_id ) {
             throw std::runtime_error(
                 "Platform task owner Mod does not match its runtime" );
+        }
+        if( task.id == 0 || task.id > last_task_id ) {
+            throw std::runtime_error( "Platform task id exceeds its saved counter" );
         }
         json.start_object();
         json.member( "id", static_cast<std::int64_t>( task.id ) );
@@ -742,7 +763,7 @@ void write_scope( const cata_path &path, const std::string &scope )
             continue;
         }
         json.member( mod_id );
-        write_scope_record( json, record.values, record.tasks, scope, mod_id );
+        write_scope_record( json, record.values, record.tasks, record.last_task_id, scope, mod_id );
     }
     for( const std::shared_ptr<runtime> &owner : detail::active_runtime_values() ) {
         if( !owner ) {
@@ -751,7 +772,7 @@ void write_scope( const cata_path &path, const std::string &scope )
         const persistent_state &state = scope == "character" ?
                                         owner->character_state : owner->world_state;
         json.member( owner->mod_id );
-        write_scope_record( json, state, owner->tasks, scope, owner->mod_id );
+        write_scope_record( json, state, owner->tasks, owner->next_task_id - 1, scope, owner->mod_id );
     }
     json.end_object();
     json.end_object();

--- a/tests/lua_platform_task_counter_persistence_test.cpp
+++ b/tests/lua_platform_task_counter_persistence_test.cpp
@@ -1,0 +1,142 @@
+#if defined(CATA_ENABLE_LUA_PLATFORM) && CATA_ENABLE_LUA_PLATFORM
+#include "lua_platform_test_support.h"
+#include "cata_path.h"
+#include "lua_platform_runtime_internal.h"
+#include "path_info.h"
+#include "worldfactory.h"
+
+TEST_CASE( "lua_platform_task_counter_survives_empty_save_and_exhaustion",
+           "[lua][platform][tasks][persistence]" )
+{
+    namespace platform = cata::lua_platform;
+    platform::clear_active_runtimes();
+    REQUIRE( world_generator != nullptr );
+    const platform_lua_test_directory temporary;
+    const std::string old_savedir = PATH_INFO::savedir();
+    WORLD *old_world = world_generator->active_world;
+    WORLD isolated_world( "task_counter_persistence" );
+    sol::state old_lua;
+    sol::state new_lua;
+    const on_out_of_scope cleanup( [&]() {
+        platform::clear_active_runtimes();
+        world_generator->active_world = old_world;
+        PATH_INFO::set_savedir( old_savedir );
+    } );
+    PATH_INFO::set_savedir( temporary.root.string() + "/" );
+    world_generator->active_world = &isolated_world;
+    REQUIRE( std::filesystem::create_directory( isolated_world.folder_path().get_unrelative_path() ) );
+    const auto install = []( sol::state & lua ) {
+        const std::shared_ptr<platform::runtime> owner = platform::make_runtime(
+                "counter-owner", 2010, lua );
+        sol::table ccb = lua.create_table();
+        platform::install_runtime_api( owner, lua, ccb );
+        lua["ccb"] = ccb;
+        lua.set_function( "noop", []() {} );
+        const sol::protected_function_result registered = ccb["runtime"]["handler"](
+                "tick", lua["noop"] );
+        REQUIRE( registered.valid() );
+        platform::set_active_runtimes( { owner } );
+        return owner;
+    };
+    const auto schedule = []( sol::state & lua ) {
+        const sol::protected_function_result result = lua["ccb"]["tasks"]["after"](
+                100, "tick", lua.create_table(), 1, "world" );
+        REQUIRE( result.valid() );
+        return result.get<std::int64_t>();
+    };
+    const std::shared_ptr<platform::runtime> before = install( old_lua );
+    platform::runtime_world_ready( true );
+    bool exhausted = false;
+    SECTION( "cancelled task ids are not reused" ) {
+        const std::int64_t id = schedule( old_lua );
+        const sol::protected_function_result cancelled = old_lua["ccb"]["tasks"]["cancel"]( id );
+        REQUIRE( cancelled.valid() );
+        REQUIRE( cancelled.get<bool>() );
+        REQUIRE( before->tasks.empty() );
+    }
+    SECTION( "exhausted signed id space remains exhausted" ) {
+        before->next_task_id = static_cast<std::uint64_t>(
+                                   std::numeric_limits<std::int64_t>::max() ) + 1;
+        exhausted = true;
+    }
+    const std::uint64_t expected_next = before->next_task_id;
+    std::string error;
+    REQUIRE( platform::runtime_save( error ) );
+    const cata_path saved = isolated_world.folder_path() / "lua_platform_world.json";
+    const JsonObject root = json_loader::from_path( saved ).get_object();
+    root.allow_omitted_members();
+    const JsonObject mods = root.get_object( "mods" );
+    mods.allow_omitted_members();
+    const JsonObject record = mods.get_object( "counter-owner" );
+    record.allow_omitted_members();
+    CHECK( record.get_int64( "last_task_id" ) == static_cast<std::int64_t>( expected_next - 1 ) );
+    platform::clear_active_runtimes();
+    const std::shared_ptr<platform::runtime> after = install( new_lua );
+    platform::runtime_world_ready( false );
+    REQUIRE( after->tasks.empty() );
+    CHECK( after->next_task_id == expected_next );
+    if( exhausted ) {
+        const sol::protected_function_result result = new_lua["ccb"]["tasks"]["after"](
+                100, "tick", new_lua.create_table(), 1, "world" );
+        CHECK_FALSE( result.valid() );
+        CHECK( after->tasks.empty() );
+    } else {
+        const std::int64_t new_id = schedule( new_lua );
+        CHECK( static_cast<std::uint64_t>( new_id ) == expected_next );
+        const sol::protected_function_result cancelled = new_lua["ccb"]["tasks"]["cancel"](
+                new_id - 1 );
+        REQUIRE( cancelled.valid() );
+        CHECK_FALSE( cancelled.get<bool>() );
+        CHECK( after->tasks.size() == 1 );
+    }
+}
+
+TEST_CASE( "lua_platform_preserves_absent_mod_task_counters_and_reads_legacy_records",
+           "[lua][platform][tasks][persistence]" )
+{
+    namespace platform = cata::lua_platform;
+    platform::clear_active_runtimes();
+    REQUIRE( world_generator != nullptr );
+    const platform_lua_test_directory temporary;
+    const std::string old_savedir = PATH_INFO::savedir();
+    WORLD *old_world = world_generator->active_world;
+    WORLD isolated_world( "orphan_task_counter" );
+    sol::state lua;
+    const on_out_of_scope cleanup( [&]() {
+        platform::clear_active_runtimes();
+        world_generator->active_world = old_world;
+        PATH_INFO::set_savedir( old_savedir );
+    } );
+    PATH_INFO::set_savedir( temporary.root.string() + "/" );
+    world_generator->active_world = &isolated_world;
+    REQUIRE( std::filesystem::create_directory( isolated_world.folder_path().get_unrelative_path() ) );
+    const cata_path saved = isolated_world.folder_path() / "lua_platform_world.json";
+    std::string source;
+    SECTION( "counter without pending tasks" ) {
+        source = R"({"last_task_id":77,"values":{},"tasks":[]})";
+    }
+    SECTION( "legacy pending task without counter" ) {
+        source = R"({"values":{},"tasks":[{"id":77,"handler":"tick","due_turn":9223372036854775807,"payload_version":1,"payload":{}}]})";
+    }
+    {
+        std::ofstream output( saved.get_unrelative_path() );
+        output << R"({"version":1,"scope":"world","mods":{"absent-owner":)" << source << "}}";
+        output.close();
+        REQUIRE( output.good() );
+    }
+    const std::shared_ptr<platform::runtime> owner = platform::make_runtime( "other-owner", 2011, lua );
+    sol::table ccb = lua.create_table();
+    platform::install_runtime_api( owner, lua, ccb );
+    platform::set_active_runtimes( { owner } );
+    platform::runtime_world_ready( false );
+    std::string error;
+    REQUIRE( platform::runtime_save( error ) );
+    const JsonObject root = json_loader::from_path( saved ).get_object();
+    root.allow_omitted_members();
+    const JsonObject mods = root.get_object( "mods" );
+    mods.allow_omitted_members();
+    const JsonObject retained = mods.get_object( "absent-owner" );
+    retained.allow_omitted_members();
+    CHECK( retained.get_int64( "last_task_id" ) == 77 );
+}
+#endif


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

Task IDs were reconstructed only from pending tasks. After all tasks completed or were cancelled, reloading an empty saved task list could reuse an old ID, allowing stale author state to refer to a newly scheduled task.

Persist an optional per-Mod last_task_id in both state scopes, merge the counters when loading, preserve absent-Mod counters when resaving, and retain exhausted signed-ID space. Old version-1 files without this field still derive the counter from pending IDs; completed IDs already absent from legacy saves cannot be recovered. Reject negative/out-of-range or inconsistent counters before accepting records. Existing task APIs and save version remain unchanged.

Native regression source covers cancellation followed by an empty-list save and fresh runtime, exhausted counters, and absent-Mod/legacy record preservation. Validation: changed C++ files pass the focused AStyle dry-run and git diff --check. No compiler, native test, game or broad acceptance ran. The companion inspector in #756 supports both old and counter-bearing records; 12 focused Python tests passed there.

#### Responsible human

@LYHGLYTX

#### Documentation impact

Documents the optional saved counter and legacy limitation in the architecture contract.

#### Related CCB-Docs PR

https://github.com/CrimsonCrossBunker/CCB-Docs/pull/47 (draft).

#### Affected documentation IDs

cpp.lua-bridge

#### Generated reference impact

No new Lua signatures; native location inventory refresh is deferred to batch acceptance.


#### Additional context

Keep draft; do not merge before morning review.