### PR TITLE
Keep due Lua tasks cancellable until their dispatch begins

### DIFF
--- a/data/lua/LUA_FIRST_PLATFORM.md
+++ b/data/lua/LUA_FIRST_PLATFORM.md
@@ -361,6 +361,17 @@ to use the exact-Item `quote/get/commit` API.
 使用；快照不是可写引擎对象，失效 token 不可复用。内容注册回滚不等于任意世界操作有事务，
 只有接口明确声明的操作才保证原子性；外部文件、进程和原生扩展副作用不在回滚承诺内。
 
+The draft due-task cancellation fix keeps selected tasks visible to queries and
+cancellable until their individual dispatch starts. A preceding callback can
+cancel a later task due in the same processing pass. Selection still snapshots
+the pass and uses due-turn/ID ordering: newly scheduled tasks wait for a later
+processing pass. Native regression source exists; compilation and execution
+remain pending.
+
+同轮到期任务取消修复草稿让尚未开始派发的任务继续可查、可取消：前一个回调可以取消
+同一处理轮中后续到期任务。该轮候选仍为快照，按到期回合与 ID 排序；回调新建的任务
+留到下一次处理。原生回归测试源码已补，尚未编译或执行。
+
 ## Behaviour instead of EOC / 用 Lua 行为表达能力
 
 Lua expresses conditions, effects, branching, loops, composition, and policy

--- a/data/lua/types/ccb_platform_v1.d.lua
+++ b/data/lua/types/ccb_platform_v1.d.lua
@@ -6289,6 +6289,7 @@ local CcbPlatformTasks = {}
 ---@return integer task_id
 function CcbPlatformTasks.after(turns, handler_id, payload, payload_version, scope, actor, participants) end
 
+---Cancels a pending task, including one due this turn whose callback has not started.
 ---@param task_id integer
 ---@return boolean cancelled
 function CcbPlatformTasks.cancel(task_id) end

--- a/src/lua_platform_runtime_lifecycle.cpp
+++ b/src/lua_platform_runtime_lifecycle.cpp
@@ -1662,17 +1662,16 @@ void runtime_process_tasks()
                 owner->reported_task_migration_failures.erase( task_id );
             }
         }
+        // Snapshot this pass, but keep unstarted tasks cancellable and visible
+        // to queries until immediately before their own dispatch.
         std::vector<persistent_task> due;
-        owner->tasks.erase( std::remove_if( owner->tasks.begin(), owner->tasks.end(),
-        [&due, &owner, now]( const persistent_task & task ) {
+        for( const persistent_task &task : owner->tasks ) {
             const auto handler = owner->handlers.find( task.handler_id );
             if( task.due_turn <= now && handler != owner->handlers.end() &&
                 handler->second.payload_version == task.payload_version ) {
                 due.push_back( task );
-                return true;
             }
-            return false;
-        } ), owner->tasks.end() );
+        }
         for( const persistent_task &task : due ) {
             owner->reported_task_migration_failures.erase( task.id );
         }
@@ -1681,6 +1680,14 @@ void runtime_process_tasks()
             return std::tie( lhs.due_turn, lhs.id ) < std::tie( rhs.due_turn, rhs.id );
         } );
         for( const persistent_task &task : due ) {
+            const auto pending = std::find_if( owner->tasks.begin(), owner->tasks.end(),
+            [&task]( const persistent_task & candidate ) {
+                return candidate.id == task.id;
+            } );
+            if( pending == owner->tasks.end() ) {
+                continue; // A preceding callback cancelled this task.
+            }
+            owner->tasks.erase( pending );
             const auto handler = owner->handlers.find( task.handler_id );
             if( handler == owner->handlers.end() ) {
                 DebugLog( D_ERROR, D_MAIN ) << "Discarding Lua-first task " << task.id
@@ -1689,7 +1696,7 @@ void runtime_process_tasks()
                 continue;
             }
             if( handler->second.payload_version != task.payload_version ) {
-                // Invalid tasks are retired before due extraction.  Keep this
+                // Invalid tasks are retired before due selection.  Keep this
                 // guard for corrupted in-memory input copied into the due list.
                 DebugLog( D_ERROR, D_MAIN ) << "Discarding Lua-first task " << task.id
                                             << " because payload version "

--- a/tests/lua_platform_due_task_cancel_test.cpp
+++ b/tests/lua_platform_due_task_cancel_test.cpp
@@ -1,0 +1,60 @@
+#if defined(CATA_ENABLE_LUA_PLATFORM) && CATA_ENABLE_LUA_PLATFORM
+#include "lua_platform_test_support.h"
+#include "lua_platform_runtime_internal.h"
+
+TEST_CASE( "lua_platform_due_task_can_be_cancelled_by_an_earlier_callback",
+           "[lua][platform][tasks]" )
+{
+    namespace platform = cata::lua_platform;
+    platform::clear_active_runtimes();
+    sol::state lua;
+    lua.open_libraries( sol::lib::base );
+    sol::table ccb = lua.create_table();
+    const std::shared_ptr<platform::runtime> owner = platform::make_runtime( "due-cancel", 2012, lua );
+    const on_out_of_scope cleanup( []() {
+        platform::clear_active_runtimes();
+    } );
+    platform::install_runtime_api( owner, lua, ccb );
+    lua["ccb"] = ccb;
+    // The first callback cancels a sibling and adds a task for a later pass.
+    const sol::protected_function_result setup = lua.safe_script( R"lua(
+ran_first = 0
+ran_cancelled = 0
+ran_last = 0
+ran_new = 0
+ccb.runtime.handler("first", function()
+    ran_first = ran_first + 1
+    assert(ccb.tasks.get(cancel_id).handler == "cancelled")
+    assert(ccb.tasks.list().total == 2)
+    assert(ccb.tasks.cancel(cancel_id))
+    assert(ccb.tasks.get(cancel_id) == nil)
+    ccb.tasks.after(0, "new")
+end)
+ccb.runtime.handler("cancelled", function() ran_cancelled = ran_cancelled + 1 end)
+ccb.runtime.handler("last", function()
+    ran_last = ran_last + 1
+    assert(ran_first == 1 and ran_cancelled == 0 and ran_new == 0)
+end)
+ccb.runtime.handler("new", function() ran_new = ran_new + 1 end)
+)lua", sol::script_pass_on_error );
+    REQUIRE( setup.valid() );
+    platform::set_active_runtimes( { owner } );
+    platform::runtime_world_ready( true );
+    const sol::protected_function_result scheduled = lua.safe_script( R"lua(
+ccb.tasks.after(0, "first")
+cancel_id = ccb.tasks.after(0, "cancelled")
+ccb.tasks.after(0, "last")
+)lua", sol::script_pass_on_error );
+    REQUIRE( scheduled.valid() );
+    platform::runtime_process_tasks();
+    CHECK( lua["ran_first"].get<int>() == 1 );
+    CHECK( lua["ran_cancelled"].get<int>() == 0 );
+    CHECK( lua["ran_last"].get<int>() == 1 );
+    CHECK( lua["ran_new"].get<int>() == 0 );
+    REQUIRE( owner->tasks.size() == 1 );
+    CHECK( owner->tasks.front().handler_id == "new" );
+    platform::runtime_process_tasks();
+    CHECK( lua["ran_new"].get<int>() == 1 );
+    CHECK( owner->tasks.empty() );
+}
+#endif


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

The dispatcher removed every due task before invoking the first callback. An earlier callback therefore could not query or cancel a later task due in the same pass.

Keep selected tasks in the owning queue until each dispatch begins, skip candidates cancelled by preceding callbacks, and preserve due-turn/ID ordering. The pass still snapshots its candidates, so tasks newly scheduled by a callback wait for a later processing pass. Existing task APIs and limits remain unchanged.

Adds native regression source covering same-pass query/cancellation, skipped callback execution, unaffected sibling ordering and deferral of a new zero-delay task. Focused AStyle dry-run and git diff --check passed. No compiler, native tests, game or broad acceptance ran; the native scenario remains pending.

#### Responsible human

@LYHGLYTX

#### Documentation impact

Clarifies cancellation timing and pass boundaries in the architecture contract and LuaLS comment.

#### Related CCB-Docs PR

https://github.com/CrimsonCrossBunker/CCB-Docs/pull/47 (draft).

#### Affected documentation IDs

cpp.lua-bridge

#### Generated reference impact

No new signatures; source-location inventory refresh is deferred to batch acceptance.


#### Additional context

Keep draft; do not merge before morning review.