### PR TITLE
feat: 核心包迁移为 ccb，兼容旧 dda 依赖和存档

### DIFF
--- a/ai/lua-first-replacement-ledger.yml
+++ b/ai/lua-first-replacement-ledger.yml
@@ -31,17 +31,17 @@ sources:
 - id: json-object-types
   path: data/reference/json/ccb_json_object_types.json
   selector: type
-  source_fingerprint: sha256:b7fe62c8c994763cb903fbec791fb09c134728d3c64b6b64f6d34d8220cb475d
+  source_fingerprint: sha256:ac64490ef82dfeb84676692b4f0ce3e7aa39311d5d75cb6456f99256c472014a
   entry_count: 190
 - id: eoc-conditions
   path: data/reference/json/ccb_eoc_conditions.json
   selector: key
-  source_fingerprint: sha256:b7fe62c8c994763cb903fbec791fb09c134728d3c64b6b64f6d34d8220cb475d
+  source_fingerprint: sha256:ac64490ef82dfeb84676692b4f0ce3e7aa39311d5d75cb6456f99256c472014a
   entry_count: 275
 - id: eoc-effects
   path: data/reference/json/ccb_eoc_effects.json
   selector: key
-  source_fingerprint: sha256:b7fe62c8c994763cb903fbec791fb09c134728d3c64b6b64f6d34d8220cb475d
+  source_fingerprint: sha256:ac64490ef82dfeb84676692b4f0ce3e7aa39311d5d75cb6456f99256c472014a
   entry_count: 311
 summary:
   total: 776

--- a/ai/lua-first-replacement-ledger.yml
+++ b/ai/lua-first-replacement-ledger.yml
@@ -31,17 +31,17 @@ sources:
 - id: json-object-types
   path: data/reference/json/ccb_json_object_types.json
   selector: type
-  source_fingerprint: sha256:c297767ef67c6073668bd82d32bd8d06d912dae8cdc5b08a7edc6f872ebe1d93
+  source_fingerprint: sha256:b7fe62c8c994763cb903fbec791fb09c134728d3c64b6b64f6d34d8220cb475d
   entry_count: 190
 - id: eoc-conditions
   path: data/reference/json/ccb_eoc_conditions.json
   selector: key
-  source_fingerprint: sha256:c297767ef67c6073668bd82d32bd8d06d912dae8cdc5b08a7edc6f872ebe1d93
+  source_fingerprint: sha256:b7fe62c8c994763cb903fbec791fb09c134728d3c64b6b64f6d34d8220cb475d
   entry_count: 275
 - id: eoc-effects
   path: data/reference/json/ccb_eoc_effects.json
   selector: key
-  source_fingerprint: sha256:c297767ef67c6073668bd82d32bd8d06d912dae8cdc5b08a7edc6f872ebe1d93
+  source_fingerprint: sha256:b7fe62c8c994763cb903fbec791fb09c134728d3c64b6b64f6d34d8220cb475d
   entry_count: 311
 summary:
   total: 776

--- a/ai/lua-first-replacement-ledger.yml
+++ b/ai/lua-first-replacement-ledger.yml
@@ -31,17 +31,17 @@ sources:
 - id: json-object-types
   path: data/reference/json/ccb_json_object_types.json
   selector: type
-  source_fingerprint: sha256:3e82cd9f883daf22f8889d57b052eb9c965fa5d4dccd9db80fff05dfe65cb9cb
+  source_fingerprint: sha256:c297767ef67c6073668bd82d32bd8d06d912dae8cdc5b08a7edc6f872ebe1d93
   entry_count: 190
 - id: eoc-conditions
   path: data/reference/json/ccb_eoc_conditions.json
   selector: key
-  source_fingerprint: sha256:3e82cd9f883daf22f8889d57b052eb9c965fa5d4dccd9db80fff05dfe65cb9cb
+  source_fingerprint: sha256:c297767ef67c6073668bd82d32bd8d06d912dae8cdc5b08a7edc6f872ebe1d93
   entry_count: 275
 - id: eoc-effects
   path: data/reference/json/ccb_eoc_effects.json
   selector: key
-  source_fingerprint: sha256:3e82cd9f883daf22f8889d57b052eb9c965fa5d4dccd9db80fff05dfe65cb9cb
+  source_fingerprint: sha256:c297767ef67c6073668bd82d32bd8d06d912dae8cdc5b08a7edc6f872ebe1d93
   entry_count: 311
 summary:
   total: 776

--- a/data/core/mod_migrations.json
+++ b/data/core/mod_migrations.json
@@ -1,5 +1,9 @@
 [
-  { "type": "mod_migration", "id": "dda", "new_id": "ccb" },
+  {
+    "type": "mod_migration",
+    "id": "dda",
+    "new_id": "ccb"
+  },
   {
     "type": "mod_migration",
     "//": "Removed in 0.I",

--- a/data/core/mod_migrations.json
+++ b/data/core/mod_migrations.json
@@ -1,4 +1,5 @@
 [
+  { "type": "mod_migration", "id": "dda", "new_id": "ccb" },
   {
     "type": "mod_migration",
     "//": "Removed in 0.I",

--- a/data/lua/reference/ccb_platform_api_v1.json
+++ b/data/lua/reference/ccb_platform_api_v1.json
@@ -27338,7 +27338,7 @@
         "lua_name": "ComputerAccessContext",
         "registration": {
           "installer": "platform_v1.install_runtime_api",
-          "line": 1571,
+          "line": 1572,
           "namespace": "ccb",
           "path": "src/lua_platform_runtime_services.cpp"
         },
@@ -27898,7 +27898,7 @@
         "lua_name": "ItemUseContext",
         "registration": {
           "installer": "platform_v1.install_runtime_api",
-          "line": 1561,
+          "line": 1562,
           "namespace": "ccb",
           "path": "src/lua_platform_runtime_services.cpp"
         },

--- a/data/lua/reference/ccb_platform_native_inventory.json
+++ b/data/lua/reference/ccb_platform_native_inventory.json
@@ -702,7 +702,7 @@
         "namespace": "ccb",
         "source": {
           "path": "src/lua_platform_runtime_services.cpp",
-          "line": 1555
+          "line": 1556
         },
         "direct_roots": [
           "ComputerAccessContext",
@@ -1165,7 +1165,7 @@
         "callee": "platform_v1.content_transaction.install_lua_api",
         "source": {
           "path": "src/lua_platform_runtime_services.cpp",
-          "line": 1558
+          "line": 1559
         },
         "surfaces": [
           "platform_v1"
@@ -1176,7 +1176,7 @@
         "callee": "platform_v1.install_runtime_callback_api",
         "source": {
           "path": "src/lua_platform_runtime_services.cpp",
-          "line": 1591
+          "line": 1592
         },
         "surfaces": [
           "platform_v1"
@@ -1187,7 +1187,7 @@
         "callee": "platform_v1.install_runtime_dialogue_presentation_api",
         "source": {
           "path": "src/lua_platform_runtime_services.cpp",
-          "line": 1589
+          "line": 1590
         },
         "surfaces": [
           "platform_v1"
@@ -1198,7 +1198,7 @@
         "callee": "platform_v1.install_runtime_state_task_api",
         "source": {
           "path": "src/lua_platform_runtime_services.cpp",
-          "line": 1593
+          "line": 1594
         },
         "surfaces": [
           "platform_v1"
@@ -1275,7 +1275,7 @@
         "callee": "shared.install_value_type_api",
         "source": {
           "path": "src/lua_platform_runtime_services.cpp",
-          "line": 1824
+          "line": 1825
         },
         "surfaces": [
           "platform_v1"
@@ -1286,7 +1286,7 @@
         "callee": "shared.install_game_handle_api",
         "source": {
           "path": "src/lua_platform_runtime_services.cpp",
-          "line": 1827
+          "line": 1828
         },
         "surfaces": [
           "platform_v1"
@@ -1297,7 +1297,7 @@
         "callee": "shared.install_mission_api",
         "source": {
           "path": "src/lua_platform_runtime_services.cpp",
-          "line": 2302
+          "line": 2303
         },
         "surfaces": [
           "platform_v1"
@@ -1308,7 +1308,7 @@
         "callee": "shared.install_horde_api",
         "source": {
           "path": "src/lua_platform_runtime_services.cpp",
-          "line": 2304
+          "line": 2305
         },
         "surfaces": [
           "platform_v1"
@@ -1319,7 +1319,7 @@
         "callee": "shared.install_script_mapgen_context_api",
         "source": {
           "path": "src/lua_platform_runtime_services.cpp",
-          "line": 1559
+          "line": 1560
         },
         "surfaces": [
           "platform_v1"
@@ -1330,7 +1330,7 @@
         "callee": "shared.install_mapgen_service_api",
         "source": {
           "path": "src/lua_platform_runtime_services.cpp",
-          "line": 1821
+          "line": 1822
         },
         "surfaces": [
           "platform_v1"
@@ -1341,7 +1341,7 @@
         "callee": "shared.install_trade_api",
         "source": {
           "path": "src/lua_platform_runtime_services.cpp",
-          "line": 2298
+          "line": 2299
         },
         "surfaces": [
           "platform_v1"
@@ -1352,7 +1352,7 @@
         "callee": "shared.install_zone_api",
         "source": {
           "path": "src/lua_platform_runtime_services.cpp",
-          "line": 2368
+          "line": 2369
         },
         "surfaces": [
           "platform_v1"
@@ -1363,7 +1363,7 @@
         "callee": "shared.install_camp_api",
         "source": {
           "path": "src/lua_platform_runtime_services.cpp",
-          "line": 2401
+          "line": 2402
         },
         "surfaces": [
           "platform_v1"
@@ -1374,7 +1374,7 @@
         "callee": "shared.install_overmap_api",
         "source": {
           "path": "src/lua_platform_runtime_services.cpp",
-          "line": 2537
+          "line": 2538
         },
         "surfaces": [
           "platform_v1"
@@ -1385,7 +1385,7 @@
         "callee": "shared.install_map_api",
         "source": {
           "path": "src/lua_platform_runtime_services.cpp",
-          "line": 2308
+          "line": 2309
         },
         "surfaces": [
           "platform_v1"
@@ -4824,7 +4824,7 @@
       "registration_name": "ComputerAccessContext",
       "registration": {
         "path": "src/lua_platform_runtime_services.cpp",
-        "line": 1571,
+        "line": 1572,
         "installer": "platform_v1.install_runtime_api",
         "namespace": "ccb"
       },
@@ -4862,7 +4862,7 @@
             "evidence": [
               {
                 "path": "src/lua_platform_runtime_services.cpp",
-                "line": 1576
+                "line": 1577
               }
             ]
           },
@@ -4880,7 +4880,7 @@
             "evidence": [
               {
                 "path": "src/lua_platform_runtime_services.cpp",
-                "line": 1580
+                "line": 1581
               }
             ]
           },
@@ -4897,7 +4897,7 @@
             "evidence": [
               {
                 "path": "src/lua_platform_runtime_services.cpp",
-                "line": 1584
+                "line": 1585
               }
             ]
           },
@@ -4914,7 +4914,7 @@
             "evidence": [
               {
                 "path": "src/lua_platform_runtime_services.cpp",
-                "line": 1586
+                "line": 1587
               }
             ]
           },
@@ -4931,7 +4931,7 @@
             "evidence": [
               {
                 "path": "src/lua_platform_runtime_services.cpp",
-                "line": 1573
+                "line": 1574
               }
             ]
           },
@@ -4949,7 +4949,7 @@
             "evidence": [
               {
                 "path": "src/lua_platform_runtime_services.cpp",
-                "line": 1582
+                "line": 1583
               }
             ]
           },
@@ -4967,7 +4967,7 @@
             "evidence": [
               {
                 "path": "src/lua_platform_runtime_services.cpp",
-                "line": 1574
+                "line": 1575
               }
             ]
           },
@@ -4984,7 +4984,7 @@
             "evidence": [
               {
                 "path": "src/lua_platform_runtime_services.cpp",
-                "line": 1585
+                "line": 1586
               }
             ]
           },
@@ -5001,7 +5001,7 @@
             "evidence": [
               {
                 "path": "src/lua_platform_runtime_services.cpp",
-                "line": 1588
+                "line": 1589
               }
             ]
           },
@@ -5019,7 +5019,7 @@
             "evidence": [
               {
                 "path": "src/lua_platform_runtime_services.cpp",
-                "line": 1578
+                "line": 1579
               }
             ]
           },
@@ -5036,7 +5036,7 @@
             "evidence": [
               {
                 "path": "src/lua_platform_runtime_services.cpp",
-                "line": 1587
+                "line": 1588
               }
             ]
           }
@@ -11155,7 +11155,7 @@
       "registration_name": "ItemUseContext",
       "registration": {
         "path": "src/lua_platform_runtime_services.cpp",
-        "line": 1561,
+        "line": 1562,
         "installer": "platform_v1.install_runtime_api",
         "namespace": "ccb"
       },
@@ -11199,7 +11199,7 @@
             "evidence": [
               {
                 "path": "src/lua_platform_runtime_services.cpp",
-                "line": 1566
+                "line": 1567
               }
             ]
           },
@@ -11217,7 +11217,7 @@
             "evidence": [
               {
                 "path": "src/lua_platform_runtime_services.cpp",
-                "line": 1569
+                "line": 1570
               }
             ]
           },
@@ -11234,7 +11234,7 @@
             "evidence": [
               {
                 "path": "src/lua_platform_runtime_services.cpp",
-                "line": 1567
+                "line": 1568
               }
             ]
           },
@@ -11251,7 +11251,7 @@
             "evidence": [
               {
                 "path": "src/lua_platform_runtime_services.cpp",
-                "line": 1565
+                "line": 1566
               }
             ]
           },
@@ -11268,7 +11268,7 @@
             "evidence": [
               {
                 "path": "src/lua_platform_runtime_services.cpp",
-                "line": 1563
+                "line": 1564
               }
             ]
           },
@@ -11285,7 +11285,7 @@
             "evidence": [
               {
                 "path": "src/lua_platform_runtime_services.cpp",
-                "line": 191
+                "line": 192
               }
             ]
           },
@@ -11302,7 +11302,7 @@
             "evidence": [
               {
                 "path": "src/lua_platform_runtime_services.cpp",
-                "line": 194
+                "line": 195
               }
             ]
           },
@@ -11319,7 +11319,7 @@
             "evidence": [
               {
                 "path": "src/lua_platform_runtime_services.cpp",
-                "line": 182
+                "line": 183
               }
             ]
           },
@@ -11336,7 +11336,7 @@
             "evidence": [
               {
                 "path": "src/lua_platform_runtime_services.cpp",
-                "line": 181
+                "line": 182
               }
             ]
           },
@@ -11353,7 +11353,7 @@
             "evidence": [
               {
                 "path": "src/lua_platform_runtime_services.cpp",
-                "line": 189
+                "line": 190
               }
             ]
           },
@@ -11370,7 +11370,7 @@
             "evidence": [
               {
                 "path": "src/lua_platform_runtime_services.cpp",
-                "line": 184
+                "line": 185
               }
             ]
           },
@@ -11387,7 +11387,7 @@
             "evidence": [
               {
                 "path": "src/lua_platform_runtime_services.cpp",
-                "line": 183
+                "line": 184
               }
             ]
           },
@@ -11404,7 +11404,7 @@
             "evidence": [
               {
                 "path": "src/lua_platform_runtime_services.cpp",
-                "line": 193
+                "line": 194
               }
             ]
           },
@@ -11421,7 +11421,7 @@
             "evidence": [
               {
                 "path": "src/lua_platform_runtime_services.cpp",
-                "line": 194
+                "line": 195
               }
             ]
           },
@@ -11438,7 +11438,7 @@
             "evidence": [
               {
                 "path": "src/lua_platform_runtime_services.cpp",
-                "line": 190
+                "line": 191
               }
             ]
           },
@@ -11455,7 +11455,7 @@
             "evidence": [
               {
                 "path": "src/lua_platform_runtime_services.cpp",
-                "line": 1564
+                "line": 1565
               }
             ]
           },
@@ -11472,7 +11472,7 @@
             "evidence": [
               {
                 "path": "src/lua_platform_runtime_services.cpp",
-                "line": 1568
+                "line": 1569
               }
             ]
           }

--- a/data/mods/Backrooms/modinfo.json
+++ b/data/mods/Backrooms/modinfo.json
@@ -8,7 +8,7 @@
     "description": "A strange place between dimensions traps you.  Can you survive among endless halls of yellowed carpet and harshly humming fluorescents?\n\nReplaces all normal worldgen: no wilderness, no rivers, no cities, no farms, no sky.  Just endless, winding indoor halls of mildewy carpeting, faded drywall, desolate breakrooms and abandoned boardrooms.\n\nPlay Now!  (Default Scenario) is not supported.",
     "category": "total_conversion",
     "conflicts": [ "aftershock_exoplanet", "desertpack", "tropicata", "classic_zombies", "innawood", "Isolation_Protocol", "no_hope" ],
-    "dependencies": [ "dda" ],
+    "dependencies": [ "ccb" ],
     "version": "0.1"
   },
   {

--- a/data/mods/BombasticPerks/modinfo.json
+++ b/data/mods/BombasticPerks/modinfo.json
@@ -7,6 +7,6 @@
     "maintainers": [ "Maleclypse" ],
     "description": "Killing enemies allows you to level up, unlocking powerful and fun perks for your character.  Just after game start a configuration menu should open to let you enable the mod.",
     "category": "misc_additions",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "ccb" ]
   }
 ]

--- a/data/mods/CrazyCataclysm/modinfo.json
+++ b/data/mods/CrazyCataclysm/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "Maya" ],
     "description": "Want a little crazy in your Cataclysm?  Try this one.",
     "category": "misc_additions",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "ccb" ]
   },
   {
     "type": "MONSTER_WHITELIST",

--- a/data/mods/Defense_Mode/modinfo.json
+++ b/data/mods/Defense_Mode/modinfo.json
@@ -8,6 +8,6 @@
     "maintainers": [ "MNG-cataclysm" ],
     "category": "total_conversion",
     "obsolete": true,
-    "dependencies": [ "dda" ]
+    "dependencies": [ "ccb" ]
   }
 ]

--- a/data/mods/DinoMod/modinfo.json
+++ b/data/mods/DinoMod/modinfo.json
@@ -6,7 +6,7 @@
     "maintainers": [ "ephemeralstoryteller", "damien", "LyleSy" ],
     "description": "Adds dinosaurs.  Some rideable, others less friendly.  Life will find a way.",
     "category": "creatures",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "ccb" ]
   },
   {
     "type": "EXTERNAL_OPTION",

--- a/data/mods/FuturismCataclysmLegacy/modinfo.json
+++ b/data/mods/FuturismCataclysmLegacy/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "LunaGlaze" ],
     "description": "Brings back the nostalgic classic Cataclysm lore and deleted near-future elements, packed with even more content and enhancements.  Atomic technology goes commercial, the US and China engage in an arms race over CBM technologies, and AI is fully deployed in police robotics…  Plus, plenty of other ultra-cool, near-future sci-fi gear awaits you!",
     "category": "content",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "ccb" ],
     "conflicts": [ "aftershock_exoplanet" ]
   }
 ]

--- a/data/mods/Generic_Guns/modinfo.json
+++ b/data/mods/Generic_Guns/modinfo.json
@@ -7,6 +7,6 @@
     "maintainers": [ "CleverRaven" ],
     "description": "Replaces guns and ammo with generic types.  Warning: can cause issues with other gun mods.",
     "category": "accessibility",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "ccb" ]
   }
 ]

--- a/data/mods/Isolation-Protocol/modinfo.json
+++ b/data/mods/Isolation-Protocol/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "Candlebury" ],
     "description": "A total conversion mod inspired by traditional dungeon crawler roguelikes.  Reach the bottom of an altered lab and prevent the Cataclysm from spreading to the surface!",
     "category": "total_conversion",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "ccb" ],
     "conflicts": [
       "generic_guns",
       "aftershock_exoplanet",

--- a/data/mods/Limb_WIP/modinfo.json
+++ b/data/mods/Limb_WIP/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "Venera3" ],
     "description": "A repository for the in-progress Limb Project, containing all JSON-defined limb content for dedicated testing (and limit breakage for players who don't want to be on the bleeding edge).  Things might not work properly, so please report any limb-related weirdness on GitHub!",
     "category": "misc",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "ccb" ],
     "obsolete": true
   }
 ]

--- a/data/mods/Lua_First_Example/mod.lua
+++ b/data/mods/Lua_First_Example/mod.lua
@@ -4,5 +4,5 @@ return ccb.ModDefinition {
     id = "Lua_First_Example",
     name = "Lua-first playable example",
     version = "0.1.0",
-    dependencies = { "dda" },
+    dependencies = { "ccb" },
 }

--- a/data/mods/MA/modinfo.json
+++ b/data/mods/MA/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "ZhilkinSerg" ],
     "description": "Cataclysm in one state.",
     "category": "total_conversion",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "ccb" ],
     "conflicts": [ "aftershock_exoplanet" ]
   }
 ]

--- a/data/mods/MMA/modinfo.json
+++ b/data/mods/MMA/modinfo.json
@@ -7,6 +7,6 @@
     "maintainers": [ "Hymore246" ],
     "description": "A collection of fictional, mythologically inspired or otherwise unrealistic martial arts.",
     "category": "misc_additions",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "ccb" ]
   }
 ]

--- a/data/mods/Magiclysm/modinfo.json
+++ b/data/mods/Magiclysm/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "Maleclypse", "Standing-Storm" ],
     "description": "Cataclysm but with magic spells!",
     "category": "content",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "ccb" ]
   },
   {
     "type": "EXTERNAL_OPTION",

--- a/data/mods/Megafauna/modinfo.json
+++ b/data/mods/Megafauna/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "merrygin" ],
     "description": "Adds extinct pleistocene megafauna to the game, replacing modern day and introduced animals.",
     "category": "creatures",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "ccb" ],
     "obsolete": false
   }
 ]

--- a/data/mods/Migrated_Core/mod.lua
+++ b/data/mods/Migrated_Core/mod.lua
@@ -4,5 +4,5 @@ return ccb.ModDefinition {
     id = "Migrated_Core",
     name = "Migrated core content",
     version = "0.1.0",
-    dependencies = { "dda" },
+    dependencies = { "ccb" },
 }

--- a/data/mods/MindOverMatter/modinfo.json
+++ b/data/mods/MindOverMatter/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "StandingStorm" ],
     "description": "Psionic powers for Cataclysm.  The Readme contains extensive information on how the process of gaining and using powers works, so make sure to check it if you're confused.",
     "category": "content",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "ccb" ],
     "conflicts": [ "aftershock_exoplanet" ]
   },
   {

--- a/data/mods/MindOverMatterNoKnacks/modinfo.json
+++ b/data/mods/MindOverMatterNoKnacks/modinfo.json
@@ -6,6 +6,6 @@
     "authors": [ "Standing-Storm" ],
     "description": "Changes Mind Over Matter so that only psychic knacks exist, meaning only those born with them have psychic powers.  Removes higher-level feral psions and psionic awakenings, leaves crafting and locations.\n\nTriffids and mi-go still get powerful psychics, so watch out.",
     "category": "rebalance",
-    "dependencies": [ "dda", "mindovermatter" ]
+    "dependencies": [ "ccb", "mindovermatter" ]
   }
 ]

--- a/data/mods/My_Sweet_Cataclysm/modinfo.json
+++ b/data/mods/My_Sweet_Cataclysm/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "Fris0uman" ],
     "description": "In the wake of the Cataclysm, sweets and snacks are coming to life.  You could be one of them and walk through the Cataclysm as a human shaped piece of sugar with your pet necco wafer, or you could just hunt them for some sweet treats.",
     "category": "misc_additions",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "ccb" ],
     "loading_images": [ "msc.png" ]
   }
 ]

--- a/data/mods/Mythos-Creatures/modinfo.json
+++ b/data/mods/Mythos-Creatures/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "mythosmod" ],
     "description": "Removes all the zombies (including fungus zombies), cyborgs and robots from the game and replaces them with a variety of Lovecraftian monsters - intended to be part of a total conversion mod but can be used as a standalone if wanted.",
     "category": "creatures",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "ccb" ],
     "obsolete": true,
     "version": "0.1"
   },

--- a/data/mods/No_Hope/modinfo.json
+++ b/data/mods/No_Hope/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "Procyonae" ],
     "description": "Aims to make the world more inhospitable and challenging in as many ways as possible, items needed for survival and vehicles are much harder to obtain, destruction and banditry is prevalent, even the weather has taken a turn for the worse, see in game help menu by pressing 0 once in-game for full feature list and option explanations.",
     "category": "content",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "ccb" ],
     "conflicts": [
       "aftershock_exoplanet",
       "backrooms",

--- a/data/mods/No_NPC_Food/modinfo.json
+++ b/data/mods/No_NPC_Food/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "Coolthulhu" ],
     "description": "Makes NPCs not require food, water or rest.",
     "category": "rebalance",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "ccb" ]
   },
   {
     "type": "EXTERNAL_OPTION",

--- a/data/mods/Only_Wildlife/modinfo.json
+++ b/data/mods/Only_Wildlife/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "Kodi Arfer" ],
     "description": "Removes all monsters from the game, save for those in the WILDLIFE category.",
     "category": "monster_exclude",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "ccb" ]
   },
   {
     "type": "MONSTER_WHITELIST",

--- a/data/mods/PLAYER_MAX_ATTR_VALUE/modinfo.json
+++ b/data/mods/PLAYER_MAX_ATTR_VALUE/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "LunaGlaze" ],
     "description": "This mod adjusts the player's attribute cap to `int.max-2`, effectively removing the attribute cap restriction.  This mod needs to be placed at the bottom of the sorted list for it to work correctly.",
     "category": "rebalance",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "ccb" ]
   },
   {
     "type": "EXTERNAL_OPTION",

--- a/data/mods/Perk_melee/modinfo.json
+++ b/data/mods/Perk_melee/modinfo.json
@@ -7,6 +7,6 @@
     "maintainers": [ "John-Candlebury" ],
     "description": "Fight enemies to level up and build your own fighting style.",
     "category": "misc_additions",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "ccb" ]
   }
 ]

--- a/data/mods/Personal_Portal_Storms/modinfo.json
+++ b/data/mods/Personal_Portal_Storms/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "BombasticSlacks" ],
     "description": "Makes Portal Storm enemies only attack the player.  Without this critical NPCs can die to Portal Storm enemies in very unfair ways.  More work needs to be done on AI and faction base security before it will be safe to disable this.",
     "category": "rebalance",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "ccb" ]
   },
   {
     "type": "EXTERNAL_OPTION",

--- a/data/mods/Rummaging/modinfo.json
+++ b/data/mods/Rummaging/modinfo.json
@@ -7,7 +7,7 @@
     "description": "Some furniture containers need to open the door to scavenge, to enhance the thrill of scavenging.",
     "category": "misc_additions",
     "obsolete": true,
-    "dependencies": [ "dda" ]
+    "dependencies": [ "ccb" ]
   },
   {
     "type": "furniture",

--- a/data/mods/Sky_Island/modinfo.json
+++ b/data/mods/Sky_Island/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "gettingusedto" ],
     "description": "An attempt at an entirely new way to play CDDA, inspired by games like Escape from Tarkov and Dark and Darker.  Begin on a floating island in the sky and warp down to random spots on the earth below to conduct expeditions for items you need.  Permadeath is gone - you will return to the island on death but lose any items you had on you.  Build up your stockpile, carry out missions for unique rewards, customize your home island, unlock upgrades, and be prudent about what you take on any given outing.  Be aware that 'PLAY NOW' will NOT work, you MUST make a custom character.",
     "category": "total_conversion",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "ccb" ],
     "conflicts": [ "MA", "extra_mut_scens" ],
     "version": "0.4.0",
     "loading_images": [ "skyisland1.png" ],

--- a/data/mods/Sorcerer/modinfo.json
+++ b/data/mods/Sorcerer/modinfo.json
@@ -8,7 +8,7 @@
     "description": "A different way to play Magiclysm.  Gain spells and spell levels from killing enemies instead of reading books.",
     "category": "rebalance",
     "conflicts": [ "xedra_evolved" ],
-    "dependencies": [ "dda", "magiclysm" ]
+    "dependencies": [ "ccb", "magiclysm" ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/Standard_Combat_Tests/modinfo.json
+++ b/data/mods/Standard_Combat_Tests/modinfo.json
@@ -8,7 +8,7 @@
     "conflicts": [ "hunvre" ],
     "description": "A set of standard character loadouts to facilitate objective monster testing.  Disables all but the test scenarios.",
     "category": "misc",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "ccb" ]
   },
   {
     "type": "SCENARIO_BLACKLIST",

--- a/data/mods/TEST_DATA/modinfo.json
+++ b/data/mods/TEST_DATA/modinfo.json
@@ -7,6 +7,7 @@
     "category": "content",
     "//": "Not really obsolete! Marked as such to prevent it from showing in the main list",
     "obsolete": true,
-    "dependencies": [ "dda" ]
+    "//2": "Exercise legacy and canonical core dependencies together; discovery must deduplicate them.",
+    "dependencies": [ "dda", "ccb" ]
   }
 ]

--- a/data/mods/Tamable_Wildlife/modinfo.json
+++ b/data/mods/Tamable_Wildlife/modinfo.json
@@ -7,6 +7,6 @@
     "maintainers": [ "Termineitor244" ],
     "description": "Makes a lot of docile, but generally untamable wildlife, tamable.",
     "category": "rebalance",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "ccb" ]
   }
 ]

--- a/data/mods/TropiCataclysm/modinfo.json
+++ b/data/mods/TropiCataclysm/modinfo.json
@@ -8,7 +8,7 @@
     "description": "Changes the setting from New England to an undisclosed region in Brazil.  Initially based out of Desert Region mod.",
     "category": "content",
     "conflicts": [ "aftershock_exoplanet", "backrooms", "desertpack", "classic_zombies", "innawood", "Isolation_Protocol", "no_hope" ],
-    "dependencies": [ "dda" ],
+    "dependencies": [ "ccb" ],
     "version": "0.80"
   },
   {

--- a/data/mods/XedraWood/modinfo.json
+++ b/data/mods/XedraWood/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "StandingStorm" ],
     "description": "Expands on connection between Xedra Evolved and Innawood, turning it into a full-fledged neolithic sword and sorcery setting.",
     "category": "total_conversion",
-    "dependencies": [ "dda", "xedra_evolved", "innawood" ],
+    "dependencies": [ "ccb", "xedra_evolved", "innawood" ],
     "conflicts": [ "magiclysm", "generic_guns", "MA" ]
   }
 ]

--- a/data/mods/Xedra_Evolved/modinfo.json
+++ b/data/mods/Xedra_Evolved/modinfo.json
@@ -8,7 +8,7 @@
     "description": "An urban fantasy content mod for Agent Mulder in the apocalypse.  Creates a multi decade timeline of dimensional spillage prior to the Cataclysm.  This spillage was characterized by thin places appearing where people could step through into another dimension, but things from those dimensions could wander into our world as well.  XEDRA proliferated into an alphabet soup of agencies dedicated to simultaneously stopping, controlling, and utilizing these thin places with varying degrees of success.  Contains monsters of various types, new professions and locations, new uses for existing skills,the new deduction skill, new magic systems, and content of every type that a multidimensional Cataclysm has to offer.  This is a heavily science-fantasy mod where you are as likely to encounter supernatural monsters as you are UFOs, Sasquatch, and Chupacabra.  Please examine the readme.md file for further details.",
     "category": "content",
     "conflicts": [ "sorcerer", "aftershock_exoplanet" ],
-    "dependencies": [ "dda" ],
+    "dependencies": [ "ccb" ],
     "loading_images": [ "xedra1.png", "xedra2.png", "xedra3.png", "xedra4.png", "xedra5.png", "xedra6.png" ]
   },
   {

--- a/data/mods/aftershock_exoplanet/modinfo.json
+++ b/data/mods/aftershock_exoplanet/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "Maleclypse", "Candlebury", "Drew4484" ],
     "description": "In a fateful instant, the dream of interstellar civilization was shattered in what became known as The Discontinuity, and billions were consigned to death in the far reaches of the Orion Arm.  Three hundred years later, the survivors still eke out a meager existence within the ruins of their once-great civilization, scavenging and fighting for scraps of technology they can barely understand.\n\nYou are one of these countless scavengers, come to exploit the frozen ruins of Salus IV for your own benefit.",
     "category": "total_conversion",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "ccb" ],
     "conflicts": [
       "mindovermatter",
       "generic_guns",

--- a/data/mods/alt_map_key/modinfo.json
+++ b/data/mods/alt_map_key/modinfo.json
@@ -7,6 +7,6 @@
     "maintainers": [ "thaelina" ],
     "description": "Standardizes overmap symbols.  Symbols are color coded based on categories and use the first letter of the tile name.  Note: This mod is useless if you use tiles instead of ASCII for the overmap display.",
     "category": "misc_additions",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "ccb" ]
   }
 ]

--- a/data/mods/cbm_slots/modinfo.json
+++ b/data/mods/cbm_slots/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "anothersimulacrum" ],
     "description": "Enables the bionic slots system, which limits the number of CBMs you can install in each bodypart.",
     "category": "rebalance",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "ccb" ],
     "path": ""
   }
 ]

--- a/data/mods/classic_zombies/modinfo.json
+++ b/data/mods/classic_zombies/modinfo.json
@@ -8,7 +8,7 @@
     "description": "Turns the game into a classic Romero zombie game.  You must destroy the brain.  Getting bitten is fatal.  However, zombies don't evolve, and when they're down, they're down.  Removes the sci-fi and interdimensional aspects of CDDA.\n\nDark Days of the Dead is set in Alberta, Canada, sometime during the late 20th century.  Prepare for less advanced technology, rolling plains, and rainier weather.",
     "conflicts": [ "aftershock_exoplanet", "backrooms", "desertpack", "tropicata", "innawood", "Isolation_Protocol", "no_hope" ],
     "category": "total_conversion",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "ccb" ],
     "loading_images": [ "ddotd1.png" ],
     "disable_other_loading_screens": true
   },

--- a/data/mods/dda/modinfo.json
+++ b/data/mods/dda/modinfo.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "MOD_INFO",
-    "id": "dda",
+    "id": "ccb",
     "name": "Catharsis Covenant Basemodule",
     "description": "Core content for Cataclysm-CB",
     "category": "content",

--- a/data/mods/deadly_bites/modinfo.json
+++ b/data/mods/deadly_bites/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "dseguin" ],
     "description": "Bites from zombies have a chance to inflict a permanent fatal illness.  Find and consume antivirals to stave off the disease.",
     "category": "misc_additions",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "ccb" ]
   },
   {
     "type": "monster_adjustment",

--- a/data/mods/default.json
+++ b/data/mods/default.json
@@ -6,6 +6,6 @@
     "description": "contains all the mods recommended by the developers",
     "//": "Not really obsolete! Marked as such to prevent it from showing in the main list",
     "obsolete": true,
-    "dependencies": [ "dda", "no_npc_food", "personal_portal_storms" ]
+    "dependencies": [ "ccb", "no_npc_food", "personal_portal_storms" ]
   }
 ]

--- a/data/mods/desert_region/modinfo.json
+++ b/data/mods/desert_region/modinfo.json
@@ -8,7 +8,7 @@
     "description": "A testbed/WIP mod to showcase regional_map_settings JSON changes.",
     "category": "content",
     "conflicts": [ "aftershock_exoplanet", "backrooms", "tropicata", "classic_zombies", "innawood", "Isolation_Protocol", "no_hope" ],
-    "dependencies": [ "dda" ],
+    "dependencies": [ "ccb" ],
     "version": "0.1",
     "obsolete": false
   },

--- a/data/mods/extra_mut_scen/modinfo.json
+++ b/data/mods/extra_mut_scen/modinfo.json
@@ -6,6 +6,6 @@
     "authors": [ "Saicchi" ],
     "description": "Extra scenarios with all possible mutation traits and thresholds.",
     "category": "misc_additions",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "ccb" ]
   }
 ]

--- a/data/mods/hunvre/modinfo.json
+++ b/data/mods/hunvre/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "BalthazarArgall" ],
     "description": "A sci-fi, claustrophobic spin on DDA.",
     "category": "total_conversion",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "ccb" ],
     "conflicts": [
       "aftershock_exoplanet",
       "backrooms",

--- a/data/mods/immortal_path/modinfo.json
+++ b/data/mods/immortal_path/modinfo.json
@@ -9,7 +9,7 @@
     "description": "在灾变废土上踏上修仙之路。引气入体、炼气化神，于末世中求长生大道。",
     "//en_us_description": "Walk the path of cultivation on the post-cataclysm wasteland. Draw qi into your body, refine it into spirit, and seek the great way of immortality at the end of the world.",
     "category": "content",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "ccb" ],
     "version": "0.0.1"
   }
 ]

--- a/data/mods/innawood/modinfo.json
+++ b/data/mods/innawood/modinfo.json
@@ -8,7 +8,7 @@
     "description": "An untouched land that mankind has yet to reach.  Disables most traces of civilization for that 'innawood' experience.",
     "category": "total_conversion",
     "conflicts": [ "aftershock_exoplanet", "backrooms", "desertpack", "tropicata", "classic_zombies", "Isolation_Protocol", "no_hope" ],
-    "dependencies": [ "dda" ],
+    "dependencies": [ "ccb" ],
     "loading_images": [ "innawoods1.png" ],
     "disable_other_loading_screens": true,
     "obsolete": false

--- a/data/mods/package_bionic_professions/modinfo.json
+++ b/data/mods/package_bionic_professions/modinfo.json
@@ -6,6 +6,6 @@
     "authors": [ "Erk/Everyone" ],
     "description": "Numerous bionic starting professions.",
     "category": "content",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "ccb" ]
   }
 ]

--- a/data/mods/pride_items/modinfo.json
+++ b/data/mods/pride_items/modinfo.json
@@ -6,6 +6,6 @@
     "authors": [ "The Cataclysm: Dark Days Ahead team" ],
     "description": "Adds pride-themed clothing variants and pins.",
     "category": "content",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "ccb" ]
   }
 ]

--- a/data/mods/railroads/modinfo.json
+++ b/data/mods/railroads/modinfo.json
@@ -6,6 +6,6 @@
     "authors": [ "ZhilkinSerg" ],
     "description": "Enables basic railroad network generation in the world.  <color_red>Not intended for regular gameplay, more for development purposes.</color>",
     "category": "buildings",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "ccb" ]
   }
 ]

--- a/data/mods/rural_biome/modinfo.json
+++ b/data/mods/rural_biome/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "I-am-Erk" ],
     "description": "Play in the boonies: nothing but farms, forests, and villages.  Recommended city size set to 1 and spacing set to 8.",
     "category": "content",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "ccb" ],
     "version": "0.1",
     "obsolete": true,
     "//": "should not be deleted until actual biomes exist in the game"

--- a/data/mods/translate-dialogue/modinfo.json
+++ b/data/mods/translate-dialogue/modinfo.json
@@ -7,6 +7,6 @@
     "maintainers": [ "Tektolnes" ],
     "description": "Adds a translation for some of the weirder dialogue in game.  Keeps the original flavor dialogue visible.",
     "category": "accessibility",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "ccb" ]
   }
 ]

--- a/data/mods/vehicle_degradation/modinfo.json
+++ b/data/mods/vehicle_degradation/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "LunaGlaze" ],
     "description": "This mod disables the vehicle degradation mechanism, preventing vehicle parts from losing maximum durability when damaged, thus allowing for full repair.  This mod may affect balance and will not affect vehicle parts that have already experienced durability loss.",
     "category": "rebalance",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "ccb" ]
   },
   {
     "type": "EXTERNAL_OPTION",

--- a/data/reference/json/ccb_eoc_conditions.json
+++ b/data/reference/json/ccb_eoc_conditions.json
@@ -4,7 +4,7 @@
   "inventory_kind": "eoc_conditions",
   "source": {
     "project": "Cataclysm-Cleanwater-Bomb",
-    "source_fingerprint": "sha256:c297767ef67c6073668bd82d32bd8d06d912dae8cdc5b08a7edc6f872ebe1d93",
+    "source_fingerprint": "sha256:b7fe62c8c994763cb903fbec791fb09c134728d3c64b6b64f6d34d8220cb475d",
     "contract_roots": [
       "data/core",
       "data/json",

--- a/data/reference/json/ccb_eoc_conditions.json
+++ b/data/reference/json/ccb_eoc_conditions.json
@@ -4,7 +4,7 @@
   "inventory_kind": "eoc_conditions",
   "source": {
     "project": "Cataclysm-Cleanwater-Bomb",
-    "source_fingerprint": "sha256:3e82cd9f883daf22f8889d57b052eb9c965fa5d4dccd9db80fff05dfe65cb9cb",
+    "source_fingerprint": "sha256:c297767ef67c6073668bd82d32bd8d06d912dae8cdc5b08a7edc6f872ebe1d93",
     "contract_roots": [
       "data/core",
       "data/json",
@@ -67,7 +67,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2696,
+            "line": 2697,
             "symbol": "conditional_t::conditional_t"
           }
         }
@@ -163,7 +163,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2624,
+            "line": 2625,
             "symbol": "parsers_simple"
           }
         }
@@ -256,7 +256,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2586,
+            "line": 2587,
             "symbol": "parsers"
           }
         }
@@ -349,7 +349,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2587,
+            "line": 2588,
             "symbol": "parsers"
           }
         }
@@ -442,7 +442,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2526,
+            "line": 2527,
             "symbol": "parsers"
           }
         }
@@ -535,7 +535,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2541,
+            "line": 2542,
             "symbol": "parsers"
           }
         }
@@ -628,7 +628,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2540,
+            "line": 2541,
             "symbol": "parsers"
           }
         }
@@ -716,7 +716,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2588,
+            "line": 2589,
             "symbol": "parsers"
           }
         }
@@ -809,7 +809,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2661,
+            "line": 2662,
             "symbol": "parsers_simple"
           }
         }
@@ -902,7 +902,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2657,
+            "line": 2658,
             "symbol": "parsers_simple"
           }
         }
@@ -995,7 +995,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2603,
+            "line": 2604,
             "symbol": "parsers_simple"
           }
         }
@@ -1090,7 +1090,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2607,
+            "line": 2608,
             "symbol": "parsers_simple"
           }
         }
@@ -1178,7 +1178,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2662,
+            "line": 2663,
             "symbol": "parsers_simple"
           }
         }
@@ -1271,7 +1271,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2604,
+            "line": 2605,
             "symbol": "parsers_simple"
           }
         }
@@ -1366,7 +1366,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2609,
+            "line": 2610,
             "symbol": "parsers_simple"
           }
         }
@@ -1459,7 +1459,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2602,
+            "line": 2603,
             "symbol": "parsers_simple"
           }
         }
@@ -1549,7 +1549,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2605,
+            "line": 2606,
             "symbol": "parsers_simple"
           }
         }
@@ -1644,7 +1644,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2639,
+            "line": 2640,
             "symbol": "parsers_simple"
           }
         }
@@ -1732,7 +1732,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2642,
+            "line": 2643,
             "symbol": "parsers_simple"
           }
         }
@@ -1825,7 +1825,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2641,
+            "line": 2642,
             "symbol": "parsers_simple"
           }
         }
@@ -1918,7 +1918,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2633,
+            "line": 2634,
             "symbol": "parsers_simple"
           }
         }
@@ -2011,7 +2011,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2525,
+            "line": 2526,
             "symbol": "parsers"
           }
         }
@@ -2104,7 +2104,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2675,
+            "line": 2676,
             "symbol": "parsers_simple"
           }
         }
@@ -2192,7 +2192,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2554,
+            "line": 2555,
             "symbol": "parsers"
           }
         }
@@ -2285,7 +2285,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2574,
+            "line": 2575,
             "symbol": "parsers"
           }
         }
@@ -2378,7 +2378,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2561,
+            "line": 2562,
             "symbol": "parsers"
           }
         }
@@ -2471,7 +2471,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2579,
+            "line": 2580,
             "symbol": "parsers"
           }
         }
@@ -2564,7 +2564,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2578,
+            "line": 2579,
             "symbol": "parsers"
           }
         }
@@ -2657,7 +2657,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2576,
+            "line": 2577,
             "symbol": "parsers"
           }
         }
@@ -2750,7 +2750,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2581,
+            "line": 2582,
             "symbol": "parsers"
           }
         }
@@ -2843,7 +2843,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2580,
+            "line": 2581,
             "symbol": "parsers"
           }
         }
@@ -2936,7 +2936,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2577,
+            "line": 2578,
             "symbol": "parsers"
           }
         }
@@ -3029,7 +3029,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2575,
+            "line": 2576,
             "symbol": "parsers"
           }
         }
@@ -3122,7 +3122,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2584,
+            "line": 2585,
             "symbol": "parsers"
           }
         }
@@ -3217,7 +3217,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2611,
+            "line": 2612,
             "symbol": "parsers_simple"
           }
         }
@@ -3312,7 +3312,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2615,
+            "line": 2616,
             "symbol": "parsers_simple"
           }
         }
@@ -3407,7 +3407,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2555,
+            "line": 2556,
             "symbol": "parsers"
           }
         }
@@ -3500,7 +3500,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2643,
+            "line": 2644,
             "symbol": "parsers_simple"
           }
         }
@@ -3595,7 +3595,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2613,
+            "line": 2614,
             "symbol": "parsers_simple"
           }
         }
@@ -3688,7 +3688,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2582,
+            "line": 2583,
             "symbol": "parsers"
           }
         }
@@ -3781,7 +3781,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2712,
+            "line": 2713,
             "symbol": "conditional_t::conditional_t"
           }
         }
@@ -3877,7 +3877,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2548,
+            "line": 2549,
             "symbol": "parsers"
           }
         }
@@ -3971,7 +3971,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2543,
+            "line": 2544,
             "symbol": "parsers"
           }
         }
@@ -4066,7 +4066,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2544,
+            "line": 2545,
             "symbol": "parsers"
           }
         }
@@ -4162,7 +4162,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2538,
+            "line": 2539,
             "symbol": "parsers"
           }
         }
@@ -4257,7 +4257,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2625,
+            "line": 2626,
             "symbol": "parsers_simple"
           }
         }
@@ -4347,7 +4347,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2617,
+            "line": 2618,
             "symbol": "parsers_simple"
           }
         }
@@ -4442,7 +4442,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2512,
+            "line": 2513,
             "symbol": "parsers"
           }
         }
@@ -4537,7 +4537,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2627,
+            "line": 2628,
             "symbol": "parsers_simple"
           }
         }
@@ -4627,7 +4627,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2667,
+            "line": 2668,
             "symbol": "parsers_simple"
           }
         }
@@ -4717,7 +4717,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2665,
+            "line": 2666,
             "symbol": "parsers_simple"
           }
         }
@@ -4807,7 +4807,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2644,
+            "line": 2645,
             "symbol": "parsers_simple"
           }
         }
@@ -4897,7 +4897,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2573,
+            "line": 2574,
             "symbol": "parsers"
           }
         }
@@ -4992,7 +4992,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2626,
+            "line": 2627,
             "symbol": "parsers_simple"
           }
         }
@@ -5082,7 +5082,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2551,
+            "line": 2552,
             "symbol": "parsers"
           }
         }
@@ -5172,7 +5172,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2550,
+            "line": 2551,
             "symbol": "parsers"
           }
         }
@@ -5262,7 +5262,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2629,
+            "line": 2630,
             "symbol": "parsers_simple"
           }
         }
@@ -5352,7 +5352,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2630,
+            "line": 2631,
             "symbol": "parsers_simple"
           }
         }
@@ -5447,7 +5447,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2549,
+            "line": 2550,
             "symbol": "parsers"
           }
         }
@@ -5542,7 +5542,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2648,
+            "line": 2649,
             "symbol": "parsers_simple"
           }
         }
@@ -5632,7 +5632,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2600,
+            "line": 2601,
             "symbol": "parsers_simple"
           }
         }
@@ -5727,7 +5727,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2618,
+            "line": 2619,
             "symbol": "parsers_simple"
           }
         }
@@ -5822,7 +5822,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2619,
+            "line": 2620,
             "symbol": "parsers_simple"
           }
         }
@@ -5919,7 +5919,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2514,
+            "line": 2515,
             "symbol": "parsers"
           }
         },
@@ -5932,7 +5932,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2631,
+            "line": 2632,
             "symbol": "parsers_simple"
           }
         }
@@ -6028,7 +6028,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2534,
+            "line": 2535,
             "symbol": "parsers"
           }
         }
@@ -6123,7 +6123,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2502,
+            "line": 2503,
             "symbol": "parsers"
           }
         }
@@ -6216,7 +6216,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2638,
+            "line": 2639,
             "symbol": "parsers_simple"
           }
         }
@@ -6306,7 +6306,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2608,
+            "line": 2609,
             "symbol": "parsers_simple"
           }
         }
@@ -6396,7 +6396,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2533,
+            "line": 2534,
             "symbol": "parsers"
           }
         }
@@ -6491,7 +6491,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2513,
+            "line": 2514,
             "symbol": "parsers"
           }
         }
@@ -6587,7 +6587,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2520,
+            "line": 2521,
             "symbol": "parsers"
           }
         }
@@ -6678,7 +6678,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2535,
+            "line": 2536,
             "symbol": "parsers"
           }
         }
@@ -6773,7 +6773,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2510,
+            "line": 2511,
             "symbol": "parsers"
           }
         }
@@ -6869,7 +6869,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2521,
+            "line": 2522,
             "symbol": "parsers"
           }
         }
@@ -6965,7 +6965,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2527,
+            "line": 2528,
             "symbol": "parsers"
           }
         }
@@ -7060,7 +7060,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2531,
+            "line": 2532,
             "symbol": "parsers"
           }
         }
@@ -7150,7 +7150,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2528,
+            "line": 2529,
             "symbol": "parsers"
           }
         }
@@ -7240,7 +7240,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2529,
+            "line": 2530,
             "symbol": "parsers"
           }
         }
@@ -7330,7 +7330,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2530,
+            "line": 2531,
             "symbol": "parsers"
           }
         }
@@ -7420,7 +7420,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2610,
+            "line": 2611,
             "symbol": "parsers_simple"
           }
         }
@@ -7505,7 +7505,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2507,
+            "line": 2508,
             "symbol": "parsers"
           }
         }
@@ -7595,7 +7595,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2572,
+            "line": 2573,
             "symbol": "parsers"
           }
         }
@@ -7680,7 +7680,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2606,
+            "line": 2607,
             "symbol": "parsers_simple"
           }
         }
@@ -7770,7 +7770,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2590,
+            "line": 2591,
             "symbol": "parsers"
           }
         }
@@ -7861,7 +7861,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2523,
+            "line": 2524,
             "symbol": "parsers"
           }
         }
@@ -7953,7 +7953,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2522,
+            "line": 2523,
             "symbol": "parsers"
           }
         }
@@ -8049,7 +8049,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2640,
+            "line": 2641,
             "symbol": "parsers_simple"
           }
         }
@@ -8139,7 +8139,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2506,
+            "line": 2507,
             "symbol": "parsers"
           }
         }
@@ -8229,7 +8229,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2509,
+            "line": 2510,
             "symbol": "parsers"
           }
         }
@@ -8319,7 +8319,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2532,
+            "line": 2533,
             "symbol": "parsers"
           }
         }
@@ -8409,7 +8409,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2511,
+            "line": 2512,
             "symbol": "parsers"
           }
         }
@@ -8504,7 +8504,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2634,
+            "line": 2635,
             "symbol": "parsers_simple"
           }
         }
@@ -8590,7 +8590,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2519,
+            "line": 2520,
             "symbol": "parsers"
           }
         }
@@ -8681,7 +8681,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2503,
+            "line": 2504,
             "symbol": "parsers"
           }
         }
@@ -8776,7 +8776,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2505,
+            "line": 2506,
             "symbol": "parsers"
           }
         }
@@ -8871,7 +8871,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2628,
+            "line": 2629,
             "symbol": "parsers_simple"
           }
         }
@@ -8966,7 +8966,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2566,
+            "line": 2567,
             "symbol": "parsers"
           }
         }
@@ -9056,7 +9056,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2563,
+            "line": 2564,
             "symbol": "parsers"
           }
         }
@@ -9146,7 +9146,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2565,
+            "line": 2566,
             "symbol": "parsers"
           }
         }
@@ -9241,7 +9241,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2564,
+            "line": 2565,
             "symbol": "parsers"
           }
         }
@@ -9331,7 +9331,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2562,
+            "line": 2563,
             "symbol": "parsers"
           }
         }
@@ -9426,7 +9426,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2620,
+            "line": 2621,
             "symbol": "parsers_simple"
           }
         }
@@ -9521,7 +9521,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2646,
+            "line": 2647,
             "symbol": "parsers_simple"
           }
         }
@@ -9616,7 +9616,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2649,
+            "line": 2650,
             "symbol": "parsers_simple"
           }
         }
@@ -9711,7 +9711,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2673,
+            "line": 2674,
             "symbol": "parsers_simple"
           }
         }
@@ -9801,7 +9801,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2651,
+            "line": 2652,
             "symbol": "parsers_simple"
           }
         }
@@ -9896,7 +9896,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2645,
+            "line": 2646,
             "symbol": "parsers_simple"
           }
         }
@@ -9986,7 +9986,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2663,
+            "line": 2664,
             "symbol": "parsers_simple"
           }
         }
@@ -10076,7 +10076,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2669,
+            "line": 2670,
             "symbol": "parsers_simple"
           }
         }
@@ -10166,7 +10166,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2668,
+            "line": 2669,
             "symbol": "parsers_simple"
           }
         }
@@ -10256,7 +10256,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2666,
+            "line": 2667,
             "symbol": "parsers_simple"
           }
         }
@@ -10346,7 +10346,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2654,
+            "line": 2655,
             "symbol": "parsers_simple"
           }
         }
@@ -10436,7 +10436,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2571,
+            "line": 2572,
             "symbol": "parsers"
           }
         }
@@ -10526,7 +10526,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2674,
+            "line": 2675,
             "symbol": "parsers_simple"
           }
         }
@@ -10616,7 +10616,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2653,
+            "line": 2654,
             "symbol": "parsers_simple"
           }
         }
@@ -10706,7 +10706,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2652,
+            "line": 2653,
             "symbol": "parsers_simple"
           }
         }
@@ -10801,7 +10801,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2650,
+            "line": 2651,
             "symbol": "parsers_simple"
           }
         }
@@ -10896,7 +10896,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2569,
+            "line": 2570,
             "symbol": "parsers"
           }
         }
@@ -10986,7 +10986,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2570,
+            "line": 2571,
             "symbol": "parsers"
           }
         }
@@ -11076,7 +11076,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2672,
+            "line": 2673,
             "symbol": "parsers_simple"
           }
         }
@@ -11166,7 +11166,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2567,
+            "line": 2568,
             "symbol": "parsers"
           }
         }
@@ -11261,7 +11261,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2568,
+            "line": 2569,
             "symbol": "parsers"
           }
         }
@@ -11356,7 +11356,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2635,
+            "line": 2636,
             "symbol": "parsers_simple"
           }
         }
@@ -11451,7 +11451,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2664,
+            "line": 2665,
             "symbol": "parsers_simple"
           }
         }
@@ -11543,7 +11543,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2515,
+            "line": 2516,
             "symbol": "parsers"
           }
         },
@@ -11556,7 +11556,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2632,
+            "line": 2633,
             "symbol": "parsers_simple"
           }
         }
@@ -11647,7 +11647,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2671,
+            "line": 2672,
             "symbol": "parsers_simple"
           }
         }
@@ -11737,7 +11737,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2670,
+            "line": 2671,
             "symbol": "parsers_simple"
           }
         }
@@ -11827,7 +11827,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2504,
+            "line": 2505,
             "symbol": "parsers"
           }
         }
@@ -11917,7 +11917,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2601,
+            "line": 2602,
             "symbol": "parsers_simple"
           }
         }
@@ -12012,7 +12012,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2636,
+            "line": 2637,
             "symbol": "parsers_simple"
           }
         }
@@ -12107,7 +12107,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2655,
+            "line": 2656,
             "symbol": "parsers_simple"
           }
         }
@@ -12197,7 +12197,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2647,
+            "line": 2648,
             "symbol": "parsers_simple"
           }
         }
@@ -12292,7 +12292,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2524,
+            "line": 2525,
             "symbol": "parsers"
           }
         }
@@ -12382,7 +12382,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2599,
+            "line": 2600,
             "symbol": "parsers_simple"
           }
         }
@@ -12477,7 +12477,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2612,
+            "line": 2613,
             "symbol": "parsers_simple"
           }
         }
@@ -12567,7 +12567,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2616,
+            "line": 2617,
             "symbol": "parsers_simple"
           }
         }
@@ -12657,7 +12657,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2556,
+            "line": 2557,
             "symbol": "parsers"
           }
         }
@@ -12747,7 +12747,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2614,
+            "line": 2615,
             "symbol": "parsers_simple"
           }
         }
@@ -12837,7 +12837,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2539,
+            "line": 2540,
             "symbol": "parsers"
           }
         }
@@ -12932,7 +12932,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2536,
+            "line": 2537,
             "symbol": "parsers"
           }
         }
@@ -13027,7 +13027,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2553,
+            "line": 2554,
             "symbol": "parsers"
           }
         }
@@ -13117,7 +13117,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2537,
+            "line": 2538,
             "symbol": "parsers"
           }
         }
@@ -13205,7 +13205,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2542,
+            "line": 2543,
             "symbol": "parsers"
           }
         }
@@ -13300,7 +13300,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2552,
+            "line": 2553,
             "symbol": "parsers"
           }
         }
@@ -13395,7 +13395,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2659,
+            "line": 2660,
             "symbol": "parsers_simple"
           }
         }
@@ -13480,7 +13480,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2660,
+            "line": 2661,
             "symbol": "parsers_simple"
           }
         }
@@ -13565,7 +13565,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2545,
+            "line": 2546,
             "symbol": "parsers"
           }
         }
@@ -13660,7 +13660,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2621,
+            "line": 2622,
             "symbol": "parsers_simple"
           }
         }
@@ -13755,7 +13755,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2623,
+            "line": 2624,
             "symbol": "parsers_simple"
           }
         }
@@ -13840,7 +13840,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2622,
+            "line": 2623,
             "symbol": "parsers_simple"
           }
         }
@@ -13935,7 +13935,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2508,
+            "line": 2509,
             "symbol": "parsers"
           }
         }
@@ -14025,7 +14025,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2656,
+            "line": 2657,
             "symbol": "parsers_simple"
           }
         }
@@ -14114,7 +14114,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2559,
+            "line": 2560,
             "symbol": "parsers"
           }
         }
@@ -14208,7 +14208,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2704,
+            "line": 2705,
             "symbol": "conditional_t::conditional_t"
           }
         }
@@ -14302,7 +14302,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2585,
+            "line": 2586,
             "symbol": "parsers"
           }
         }
@@ -14392,7 +14392,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2658,
+            "line": 2659,
             "symbol": "parsers_simple"
           }
         }
@@ -14487,7 +14487,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2658,
+            "line": 2659,
             "symbol": "parsers_simple"
           }
         }
@@ -14580,7 +14580,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2557,
+            "line": 2558,
             "symbol": "parsers"
           }
         }
@@ -14673,7 +14673,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2589,
+            "line": 2590,
             "symbol": "parsers"
           }
         }
@@ -14768,7 +14768,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2548,
+            "line": 2549,
             "symbol": "parsers"
           }
         }
@@ -14857,7 +14857,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2547,
+            "line": 2548,
             "symbol": "parsers"
           }
         }
@@ -14953,7 +14953,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2538,
+            "line": 2539,
             "symbol": "parsers"
           }
         }
@@ -15049,7 +15049,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2624,
+            "line": 2625,
             "symbol": "parsers_simple"
           }
         },
@@ -15062,7 +15062,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2625,
+            "line": 2626,
             "symbol": "parsers_simple"
           }
         }
@@ -15152,7 +15152,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2617,
+            "line": 2618,
             "symbol": "parsers_simple"
           }
         }
@@ -15242,7 +15242,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2512,
+            "line": 2513,
             "symbol": "parsers"
           }
         }
@@ -15332,7 +15332,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2627,
+            "line": 2628,
             "symbol": "parsers_simple"
           }
         }
@@ -15427,7 +15427,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2667,
+            "line": 2668,
             "symbol": "parsers_simple"
           }
         }
@@ -15517,7 +15517,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2665,
+            "line": 2666,
             "symbol": "parsers_simple"
           }
         }
@@ -15607,7 +15607,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2644,
+            "line": 2645,
             "symbol": "parsers_simple"
           }
         }
@@ -15702,7 +15702,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2573,
+            "line": 2574,
             "symbol": "parsers"
           }
         }
@@ -15797,7 +15797,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2626,
+            "line": 2627,
             "symbol": "parsers_simple"
           }
         }
@@ -15892,7 +15892,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2551,
+            "line": 2552,
             "symbol": "parsers"
           }
         }
@@ -15982,7 +15982,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2550,
+            "line": 2551,
             "symbol": "parsers"
           }
         }
@@ -16072,7 +16072,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2629,
+            "line": 2630,
             "symbol": "parsers_simple"
           }
         }
@@ -16167,7 +16167,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2630,
+            "line": 2631,
             "symbol": "parsers_simple"
           }
         }
@@ -16262,7 +16262,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2549,
+            "line": 2550,
             "symbol": "parsers"
           }
         }
@@ -16352,7 +16352,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2648,
+            "line": 2649,
             "symbol": "parsers_simple"
           }
         }
@@ -16447,7 +16447,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2600,
+            "line": 2601,
             "symbol": "parsers_simple"
           }
         }
@@ -16542,7 +16542,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2618,
+            "line": 2619,
             "symbol": "parsers_simple"
           }
         }
@@ -16637,7 +16637,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2619,
+            "line": 2620,
             "symbol": "parsers_simple"
           }
         }
@@ -16729,7 +16729,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2514,
+            "line": 2515,
             "symbol": "parsers"
           }
         },
@@ -16742,7 +16742,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2631,
+            "line": 2632,
             "symbol": "parsers_simple"
           }
         }
@@ -16833,7 +16833,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2534,
+            "line": 2535,
             "symbol": "parsers"
           }
         }
@@ -16928,7 +16928,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2502,
+            "line": 2503,
             "symbol": "parsers"
           }
         }
@@ -17024,7 +17024,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2607,
+            "line": 2608,
             "symbol": "parsers_simple"
           }
         },
@@ -17037,7 +17037,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2608,
+            "line": 2609,
             "symbol": "parsers_simple"
           }
         }
@@ -17127,7 +17127,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2533,
+            "line": 2534,
             "symbol": "parsers"
           }
         }
@@ -17220,7 +17220,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2637,
+            "line": 2638,
             "symbol": "parsers_simple"
           }
         }
@@ -17314,7 +17314,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2546,
+            "line": 2547,
             "symbol": "parsers"
           }
         }
@@ -17410,7 +17410,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2513,
+            "line": 2514,
             "symbol": "parsers"
           }
         }
@@ -17501,7 +17501,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2520,
+            "line": 2521,
             "symbol": "parsers"
           }
         }
@@ -17597,7 +17597,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2535,
+            "line": 2536,
             "symbol": "parsers"
           }
         }
@@ -17691,7 +17691,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2583,
+            "line": 2584,
             "symbol": "parsers"
           }
         }
@@ -17787,7 +17787,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2510,
+            "line": 2511,
             "symbol": "parsers"
           }
         }
@@ -17883,7 +17883,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2521,
+            "line": 2522,
             "symbol": "parsers"
           }
         }
@@ -17979,7 +17979,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2527,
+            "line": 2528,
             "symbol": "parsers"
           }
         }
@@ -18074,7 +18074,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2531,
+            "line": 2532,
             "symbol": "parsers"
           }
         }
@@ -18169,7 +18169,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2528,
+            "line": 2529,
             "symbol": "parsers"
           }
         }
@@ -18264,7 +18264,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2529,
+            "line": 2530,
             "symbol": "parsers"
           }
         }
@@ -18359,7 +18359,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2530,
+            "line": 2531,
             "symbol": "parsers"
           }
         }
@@ -18455,7 +18455,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2609,
+            "line": 2610,
             "symbol": "parsers_simple"
           }
         },
@@ -18468,7 +18468,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2610,
+            "line": 2611,
             "symbol": "parsers_simple"
           }
         }
@@ -18553,7 +18553,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2507,
+            "line": 2508,
             "symbol": "parsers"
           }
         }
@@ -18646,7 +18646,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2516,
+            "line": 2517,
             "symbol": "parsers"
           }
         }
@@ -18741,7 +18741,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2572,
+            "line": 2573,
             "symbol": "parsers"
           }
         }
@@ -18832,7 +18832,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2605,
+            "line": 2606,
             "symbol": "parsers_simple"
           }
         },
@@ -18845,7 +18845,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2606,
+            "line": 2607,
             "symbol": "parsers_simple"
           }
         }
@@ -18935,7 +18935,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2590,
+            "line": 2591,
             "symbol": "parsers"
           }
         }
@@ -19026,7 +19026,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2523,
+            "line": 2524,
             "symbol": "parsers"
           }
         }
@@ -19118,7 +19118,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2522,
+            "line": 2523,
             "symbol": "parsers"
           }
         }
@@ -19215,7 +19215,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2639,
+            "line": 2640,
             "symbol": "parsers_simple"
           }
         },
@@ -19228,7 +19228,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2640,
+            "line": 2641,
             "symbol": "parsers_simple"
           }
         }
@@ -19318,7 +19318,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2506,
+            "line": 2507,
             "symbol": "parsers"
           }
         }
@@ -19413,7 +19413,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2509,
+            "line": 2510,
             "symbol": "parsers"
           }
         }
@@ -19508,7 +19508,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2532,
+            "line": 2533,
             "symbol": "parsers"
           }
         }
@@ -19603,7 +19603,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2511,
+            "line": 2512,
             "symbol": "parsers"
           }
         }
@@ -19698,7 +19698,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2634,
+            "line": 2635,
             "symbol": "parsers_simple"
           }
         }
@@ -19789,7 +19789,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2519,
+            "line": 2520,
             "symbol": "parsers"
           }
         }
@@ -19885,7 +19885,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2503,
+            "line": 2504,
             "symbol": "parsers"
           }
         }
@@ -19980,7 +19980,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2505,
+            "line": 2506,
             "symbol": "parsers"
           }
         }
@@ -20070,7 +20070,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2628,
+            "line": 2629,
             "symbol": "parsers_simple"
           }
         }
@@ -20165,7 +20165,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2566,
+            "line": 2567,
             "symbol": "parsers"
           }
         }
@@ -20260,7 +20260,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2563,
+            "line": 2564,
             "symbol": "parsers"
           }
         }
@@ -20355,7 +20355,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2565,
+            "line": 2566,
             "symbol": "parsers"
           }
         }
@@ -20450,7 +20450,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2564,
+            "line": 2565,
             "symbol": "parsers"
           }
         }
@@ -20545,7 +20545,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2562,
+            "line": 2563,
             "symbol": "parsers"
           }
         }
@@ -20640,7 +20640,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2620,
+            "line": 2621,
             "symbol": "parsers_simple"
           }
         }
@@ -20730,7 +20730,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2646,
+            "line": 2647,
             "symbol": "parsers_simple"
           }
         }
@@ -20825,7 +20825,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2649,
+            "line": 2650,
             "symbol": "parsers_simple"
           }
         }
@@ -20920,7 +20920,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2673,
+            "line": 2674,
             "symbol": "parsers_simple"
           }
         }
@@ -21010,7 +21010,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2651,
+            "line": 2652,
             "symbol": "parsers_simple"
           }
         }
@@ -21105,7 +21105,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2645,
+            "line": 2646,
             "symbol": "parsers_simple"
           }
         }
@@ -21200,7 +21200,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2663,
+            "line": 2664,
             "symbol": "parsers_simple"
           }
         }
@@ -21290,7 +21290,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2669,
+            "line": 2670,
             "symbol": "parsers_simple"
           }
         }
@@ -21380,7 +21380,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2668,
+            "line": 2669,
             "symbol": "parsers_simple"
           }
         }
@@ -21470,7 +21470,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2666,
+            "line": 2667,
             "symbol": "parsers_simple"
           }
         }
@@ -21560,7 +21560,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2654,
+            "line": 2655,
             "symbol": "parsers_simple"
           }
         }
@@ -21655,7 +21655,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2571,
+            "line": 2572,
             "symbol": "parsers"
           }
         }
@@ -21750,7 +21750,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2674,
+            "line": 2675,
             "symbol": "parsers_simple"
           }
         }
@@ -21845,7 +21845,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2653,
+            "line": 2654,
             "symbol": "parsers_simple"
           }
         }
@@ -21940,7 +21940,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2652,
+            "line": 2653,
             "symbol": "parsers_simple"
           }
         }
@@ -22035,7 +22035,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2650,
+            "line": 2651,
             "symbol": "parsers_simple"
           }
         }
@@ -22130,7 +22130,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2569,
+            "line": 2570,
             "symbol": "parsers"
           }
         }
@@ -22225,7 +22225,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2570,
+            "line": 2571,
             "symbol": "parsers"
           }
         }
@@ -22315,7 +22315,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2672,
+            "line": 2673,
             "symbol": "parsers_simple"
           }
         }
@@ -22405,7 +22405,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2567,
+            "line": 2568,
             "symbol": "parsers"
           }
         }
@@ -22500,7 +22500,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2568,
+            "line": 2569,
             "symbol": "parsers"
           }
         }
@@ -22595,7 +22595,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2635,
+            "line": 2636,
             "symbol": "parsers_simple"
           }
         }
@@ -22690,7 +22690,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2664,
+            "line": 2665,
             "symbol": "parsers_simple"
           }
         }
@@ -22782,7 +22782,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2515,
+            "line": 2516,
             "symbol": "parsers"
           }
         },
@@ -22795,7 +22795,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2632,
+            "line": 2633,
             "symbol": "parsers_simple"
           }
         }
@@ -22881,7 +22881,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2671,
+            "line": 2672,
             "symbol": "parsers_simple"
           }
         }
@@ -22971,7 +22971,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2670,
+            "line": 2671,
             "symbol": "parsers_simple"
           }
         }
@@ -23061,7 +23061,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2504,
+            "line": 2505,
             "symbol": "parsers"
           }
         }
@@ -23151,7 +23151,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2601,
+            "line": 2602,
             "symbol": "parsers_simple"
           }
         }
@@ -23241,7 +23241,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2636,
+            "line": 2637,
             "symbol": "parsers_simple"
           }
         }
@@ -23336,7 +23336,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2655,
+            "line": 2656,
             "symbol": "parsers_simple"
           }
         }
@@ -23426,7 +23426,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2647,
+            "line": 2648,
             "symbol": "parsers_simple"
           }
         }
@@ -23516,7 +23516,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2524,
+            "line": 2525,
             "symbol": "parsers"
           }
         }
@@ -23609,7 +23609,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2558,
+            "line": 2559,
             "symbol": "parsers"
           }
         }
@@ -23704,7 +23704,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2599,
+            "line": 2600,
             "symbol": "parsers_simple"
           }
         }
@@ -23800,7 +23800,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2611,
+            "line": 2612,
             "symbol": "parsers_simple"
           }
         },
@@ -23813,7 +23813,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2612,
+            "line": 2613,
             "symbol": "parsers_simple"
           }
         }
@@ -23904,7 +23904,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2615,
+            "line": 2616,
             "symbol": "parsers_simple"
           }
         },
@@ -23917,7 +23917,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2616,
+            "line": 2617,
             "symbol": "parsers_simple"
           }
         }
@@ -24008,7 +24008,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2555,
+            "line": 2556,
             "symbol": "parsers"
           }
         },
@@ -24021,7 +24021,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2556,
+            "line": 2557,
             "symbol": "parsers"
           }
         }
@@ -24112,7 +24112,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2613,
+            "line": 2614,
             "symbol": "parsers_simple"
           }
         },
@@ -24125,7 +24125,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2614,
+            "line": 2615,
             "symbol": "parsers_simple"
           }
         }
@@ -24213,7 +24213,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2517,
+            "line": 2518,
             "symbol": "parsers"
           }
         }
@@ -24303,7 +24303,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2539,
+            "line": 2540,
             "symbol": "parsers"
           }
         }
@@ -24398,7 +24398,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2536,
+            "line": 2537,
             "symbol": "parsers"
           }
         }
@@ -24483,7 +24483,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2553,
+            "line": 2554,
             "symbol": "parsers"
           }
         }
@@ -24573,7 +24573,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2537,
+            "line": 2538,
             "symbol": "parsers"
           }
         }
@@ -24668,7 +24668,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2552,
+            "line": 2553,
             "symbol": "parsers"
           }
         }
@@ -24756,7 +24756,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2518,
+            "line": 2519,
             "symbol": "parsers"
           }
         }
@@ -24846,7 +24846,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2659,
+            "line": 2660,
             "symbol": "parsers_simple"
           }
         }
@@ -24936,7 +24936,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2660,
+            "line": 2661,
             "symbol": "parsers_simple"
           }
         }
@@ -25031,7 +25031,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2545,
+            "line": 2546,
             "symbol": "parsers"
           }
         }
@@ -25116,7 +25116,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2621,
+            "line": 2622,
             "symbol": "parsers_simple"
           }
         }
@@ -25206,7 +25206,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2623,
+            "line": 2624,
             "symbol": "parsers_simple"
           }
         }
@@ -25291,7 +25291,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2622,
+            "line": 2623,
             "symbol": "parsers_simple"
           }
         }
@@ -25381,7 +25381,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2508,
+            "line": 2509,
             "symbol": "parsers"
           }
         }
@@ -25476,7 +25476,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2656,
+            "line": 2657,
             "symbol": "parsers_simple"
           }
         }
@@ -25564,7 +25564,7 @@
           ],
           "source": {
             "path": "src/condition.cpp",
-            "line": 2560,
+            "line": 2561,
             "symbol": "parsers"
           }
         }

--- a/data/reference/json/ccb_eoc_conditions.json
+++ b/data/reference/json/ccb_eoc_conditions.json
@@ -4,7 +4,7 @@
   "inventory_kind": "eoc_conditions",
   "source": {
     "project": "Cataclysm-Cleanwater-Bomb",
-    "source_fingerprint": "sha256:b7fe62c8c994763cb903fbec791fb09c134728d3c64b6b64f6d34d8220cb475d",
+    "source_fingerprint": "sha256:ac64490ef82dfeb84676692b4f0ce3e7aa39311d5d75cb6456f99256c472014a",
     "contract_roots": [
       "data/core",
       "data/json",

--- a/data/reference/json/ccb_eoc_effects.json
+++ b/data/reference/json/ccb_eoc_effects.json
@@ -4,7 +4,7 @@
   "inventory_kind": "eoc_effects",
   "source": {
     "project": "Cataclysm-Cleanwater-Bomb",
-    "source_fingerprint": "sha256:3e82cd9f883daf22f8889d57b052eb9c965fa5d4dccd9db80fff05dfe65cb9cb",
+    "source_fingerprint": "sha256:c297767ef67c6073668bd82d32bd8d06d912dae8cdc5b08a7edc6f872ebe1d93",
     "contract_roots": [
       "data/core",
       "data/json",

--- a/data/reference/json/ccb_eoc_effects.json
+++ b/data/reference/json/ccb_eoc_effects.json
@@ -4,7 +4,7 @@
   "inventory_kind": "eoc_effects",
   "source": {
     "project": "Cataclysm-Cleanwater-Bomb",
-    "source_fingerprint": "sha256:b7fe62c8c994763cb903fbec791fb09c134728d3c64b6b64f6d34d8220cb475d",
+    "source_fingerprint": "sha256:ac64490ef82dfeb84676692b4f0ce3e7aa39311d5d75cb6456f99256c472014a",
     "contract_roots": [
       "data/core",
       "data/json",

--- a/data/reference/json/ccb_eoc_effects.json
+++ b/data/reference/json/ccb_eoc_effects.json
@@ -4,7 +4,7 @@
   "inventory_kind": "eoc_effects",
   "source": {
     "project": "Cataclysm-Cleanwater-Bomb",
-    "source_fingerprint": "sha256:c297767ef67c6073668bd82d32bd8d06d912dae8cdc5b08a7edc6f872ebe1d93",
+    "source_fingerprint": "sha256:b7fe62c8c994763cb903fbec791fb09c134728d3c64b6b64f6d34d8220cb475d",
     "contract_roots": [
       "data/core",
       "data/json",

--- a/data/reference/json/ccb_json_object_types.json
+++ b/data/reference/json/ccb_json_object_types.json
@@ -4,7 +4,7 @@
   "inventory_kind": "json_object_types",
   "source": {
     "project": "Cataclysm-Cleanwater-Bomb",
-    "source_fingerprint": "sha256:c297767ef67c6073668bd82d32bd8d06d912dae8cdc5b08a7edc6f872ebe1d93",
+    "source_fingerprint": "sha256:b7fe62c8c994763cb903fbec791fb09c134728d3c64b6b64f6d34d8220cb475d",
     "contract_roots": [
       "data/core",
       "data/json",

--- a/data/reference/json/ccb_json_object_types.json
+++ b/data/reference/json/ccb_json_object_types.json
@@ -4,7 +4,7 @@
   "inventory_kind": "json_object_types",
   "source": {
     "project": "Cataclysm-Cleanwater-Bomb",
-    "source_fingerprint": "sha256:3e82cd9f883daf22f8889d57b052eb9c965fa5d4dccd9db80fff05dfe65cb9cb",
+    "source_fingerprint": "sha256:c297767ef67c6073668bd82d32bd8d06d912dae8cdc5b08a7edc6f872ebe1d93",
     "contract_roots": [
       "data/core",
       "data/json",
@@ -30,7 +30,7 @@
     ],
     "observed_not_registered": [],
     "tracked_json_files": 6769,
-    "top_level_objects": 94745,
+    "top_level_objects": 94746,
     "top_level_objects_without_string_type": 0,
     "schema_complete_types": 0
   },
@@ -52,7 +52,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 283,
+            "line": 284,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -106,7 +106,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 380,
+            "line": 381,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -165,7 +165,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 462,
+            "line": 463,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -219,7 +219,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 381,
+            "line": 382,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -273,7 +273,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 399,
+            "line": 400,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -332,7 +332,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 383,
+            "line": 384,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -391,7 +391,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 476,
+            "line": 477,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -450,7 +450,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 391,
+            "line": 392,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -509,7 +509,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 330,
+            "line": 331,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -563,7 +563,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 484,
+            "line": 485,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -622,7 +622,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 331,
+            "line": 332,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -676,7 +676,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 336,
+            "line": 337,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -730,7 +730,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 394,
+            "line": 395,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -789,7 +789,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 510,
+            "line": 511,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -848,7 +848,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 465,
+            "line": 466,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -897,7 +897,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 469,
+            "line": 470,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -956,7 +956,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 282,
+            "line": 283,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -1005,7 +1005,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 518,
+            "line": 519,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -1064,7 +1064,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 303,
+            "line": 304,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -1123,7 +1123,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 304,
+            "line": 305,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -1182,7 +1182,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 299,
+            "line": 300,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -1241,7 +1241,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 333,
+            "line": 334,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -1300,7 +1300,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 508,
+            "line": 509,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -1359,7 +1359,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 344,
+            "line": 345,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -1418,7 +1418,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 413,
+            "line": 414,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -1477,7 +1477,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 308,
+            "line": 309,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -1536,7 +1536,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 482,
+            "line": 483,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -1595,7 +1595,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 309,
+            "line": 310,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -1654,7 +1654,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 310,
+            "line": 311,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -1713,7 +1713,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 507,
+            "line": 508,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -1772,7 +1772,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 505,
+            "line": 506,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -1831,7 +1831,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 495,
+            "line": 496,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -1885,7 +1885,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 417,
+            "line": 418,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -1939,7 +1939,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 504,
+            "line": 505,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -1998,7 +1998,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 387,
+            "line": 388,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -2057,7 +2057,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 427,
+            "line": 428,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -2116,7 +2116,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 430,
+            "line": 431,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -2175,7 +2175,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 412,
+            "line": 413,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -2234,7 +2234,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 513,
+            "line": 514,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -2293,7 +2293,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 474,
+            "line": 475,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -2342,7 +2342,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 519,
+            "line": 520,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -2401,7 +2401,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 288,
+            "line": 289,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -2460,7 +2460,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 422,
+            "line": 423,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -2519,7 +2519,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 420,
+            "line": 421,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -2573,7 +2573,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 421,
+            "line": 422,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -2627,7 +2627,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 523,
+            "line": 524,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -2686,7 +2686,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 522,
+            "line": 523,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -2745,7 +2745,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 459,
+            "line": 460,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -2804,7 +2804,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 460,
+            "line": 461,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -2863,7 +2863,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 343,
+            "line": 344,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -2922,7 +2922,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 322,
+            "line": 323,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -2981,7 +2981,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 415,
+            "line": 416,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -3040,7 +3040,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 294,
+            "line": 295,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -3209,7 +3209,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 414,
+            "line": 415,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -3268,7 +3268,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 301,
+            "line": 302,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -3327,7 +3327,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 340,
+            "line": 341,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -3386,7 +3386,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 345,
+            "line": 346,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -3445,7 +3445,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 516,
+            "line": 517,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -3504,7 +3504,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 515,
+            "line": 516,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -3563,7 +3563,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 300,
+            "line": 301,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -3617,7 +3617,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 478,
+            "line": 479,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -3676,7 +3676,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 527,
+            "line": 528,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -3735,7 +3735,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 289,
+            "line": 290,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -3794,7 +3794,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 291,
+            "line": 292,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -3853,7 +3853,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 292,
+            "line": 293,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -3912,7 +3912,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 295,
+            "line": 296,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -3971,7 +3971,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 296,
+            "line": 297,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -4030,7 +4030,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 452,
+            "line": 453,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -4089,7 +4089,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 454,
+            "line": 455,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -4148,7 +4148,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 326,
+            "line": 327,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -4207,7 +4207,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 490,
+            "line": 491,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -4266,7 +4266,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 497,
+            "line": 498,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -4325,7 +4325,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 496,
+            "line": 497,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -4384,7 +4384,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 302,
+            "line": 303,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -4443,7 +4443,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 341,
+            "line": 342,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -4497,7 +4497,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 358,
+            "line": 359,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -4551,7 +4551,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 352,
+            "line": 353,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -4610,7 +4610,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 286,
+            "line": 287,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -4669,7 +4669,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 285,
+            "line": 286,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -4728,7 +4728,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 503,
+            "line": 504,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -4787,7 +4787,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 512,
+            "line": 513,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -4846,7 +4846,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 431,
+            "line": 432,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -4905,7 +4905,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 456,
+            "line": 457,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -4964,7 +4964,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 423,
+            "line": 424,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -5023,7 +5023,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 411,
+            "line": 412,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -5082,7 +5082,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 307,
+            "line": 308,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -5141,7 +5141,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 492,
+            "line": 493,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -5200,14 +5200,14 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 526,
+            "line": 527,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
       ],
       "compile_conditional_variants": false,
       "instance_evidence": {
-        "occurrences": 10,
+        "occurrences": 11,
         "examples": [
           {
             "path": "data/core/mod_migrations.json",
@@ -5261,7 +5261,7 @@
           ],
           "source": {
             "path": "src/init.cpp",
-            "line": 529,
+            "line": 530,
             "symbol": "DynamicDataLoader::initialize"
           }
         },
@@ -5276,7 +5276,7 @@
           ],
           "source": {
             "path": "src/init.cpp",
-            "line": 532,
+            "line": 533,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -5335,7 +5335,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 400,
+            "line": 401,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -5389,7 +5389,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 498,
+            "line": 499,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -5448,7 +5448,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 397,
+            "line": 398,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -5507,7 +5507,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 329,
+            "line": 330,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -5566,7 +5566,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 319,
+            "line": 320,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -5625,7 +5625,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 509,
+            "line": 510,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -5684,7 +5684,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 305,
+            "line": 306,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -5743,7 +5743,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 325,
+            "line": 326,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -5802,7 +5802,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 323,
+            "line": 324,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -5861,7 +5861,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 324,
+            "line": 325,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -5915,7 +5915,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 372,
+            "line": 373,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -5969,7 +5969,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 405,
+            "line": 406,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -6028,7 +6028,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 479,
+            "line": 480,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -6087,7 +6087,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 480,
+            "line": 481,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -6146,7 +6146,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 432,
+            "line": 433,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -6200,7 +6200,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 284,
+            "line": 285,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -6259,7 +6259,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 416,
+            "line": 417,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -6318,7 +6318,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 419,
+            "line": 420,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -6377,7 +6377,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 491,
+            "line": 492,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -6436,7 +6436,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 425,
+            "line": 426,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -6495,7 +6495,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 424,
+            "line": 425,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -6549,7 +6549,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 426,
+            "line": 427,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -6608,7 +6608,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 428,
+            "line": 429,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -6667,7 +6667,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 429,
+            "line": 430,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -6726,7 +6726,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 418,
+            "line": 419,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -6785,7 +6785,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 501,
+            "line": 502,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -6844,7 +6844,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 488,
+            "line": 489,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -6898,7 +6898,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 290,
+            "line": 291,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -6957,7 +6957,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 404,
+            "line": 405,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -7016,7 +7016,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 311,
+            "line": 312,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -7075,7 +7075,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 312,
+            "line": 313,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -7129,7 +7129,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 313,
+            "line": 314,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -7188,7 +7188,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 314,
+            "line": 315,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -7247,7 +7247,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 315,
+            "line": 316,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -7306,7 +7306,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 316,
+            "line": 317,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -7365,7 +7365,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 317,
+            "line": 318,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -7424,7 +7424,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 402,
+            "line": 403,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -7483,7 +7483,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 401,
+            "line": 402,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -7537,7 +7537,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 406,
+            "line": 407,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -7596,7 +7596,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 458,
+            "line": 459,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -7655,7 +7655,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 442,
+            "line": 443,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -7714,7 +7714,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 438,
+            "line": 439,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -7773,7 +7773,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 448,
+            "line": 449,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -7832,7 +7832,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 440,
+            "line": 441,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -7891,7 +7891,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 439,
+            "line": 440,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -7950,7 +7950,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 435,
+            "line": 436,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -8009,7 +8009,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 450,
+            "line": 451,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -8068,7 +8068,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 436,
+            "line": 437,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -8127,7 +8127,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 437,
+            "line": 438,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -8186,7 +8186,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 434,
+            "line": 435,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -8245,7 +8245,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 444,
+            "line": 445,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -8304,7 +8304,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 446,
+            "line": 447,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -8363,7 +8363,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 293,
+            "line": 294,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -8422,7 +8422,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 374,
+            "line": 375,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -8481,7 +8481,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 502,
+            "line": 503,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -8535,7 +8535,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 335,
+            "line": 336,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -8594,7 +8594,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 342,
+            "line": 343,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -8653,7 +8653,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 517,
+            "line": 518,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -8712,7 +8712,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 337,
+            "line": 338,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -8771,7 +8771,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 339,
+            "line": 340,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -8830,7 +8830,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 338,
+            "line": 339,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -8889,7 +8889,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 320,
+            "line": 321,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -8948,7 +8948,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 321,
+            "line": 322,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -9002,7 +9002,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 349,
+            "line": 350,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -9061,7 +9061,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 486,
+            "line": 487,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -9120,7 +9120,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 487,
+            "line": 488,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -9169,7 +9169,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 332,
+            "line": 333,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -9228,7 +9228,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 318,
+            "line": 319,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -9287,7 +9287,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 511,
+            "line": 512,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -9341,7 +9341,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 334,
+            "line": 335,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -9400,7 +9400,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 506,
+            "line": 507,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -9459,7 +9459,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 481,
+            "line": 482,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -9518,7 +9518,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 409,
+            "line": 410,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -9577,7 +9577,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 388,
+            "line": 389,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -9636,7 +9636,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 328,
+            "line": 329,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -9695,7 +9695,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 514,
+            "line": 515,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -9754,7 +9754,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 327,
+            "line": 328,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -9813,7 +9813,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 389,
+            "line": 390,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -9867,7 +9867,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 408,
+            "line": 409,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -9926,7 +9926,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 355,
+            "line": 356,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -9980,7 +9980,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 377,
+            "line": 378,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -10039,7 +10039,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 378,
+            "line": 379,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -10098,7 +10098,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 403,
+            "line": 404,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -10157,7 +10157,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 287,
+            "line": 288,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -10216,7 +10216,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 366,
+            "line": 367,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -10275,7 +10275,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 371,
+            "line": 372,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -10329,7 +10329,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 367,
+            "line": 368,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -10388,7 +10388,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 362,
+            "line": 363,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -10447,7 +10447,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 363,
+            "line": 364,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -10501,7 +10501,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 364,
+            "line": 365,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -10560,7 +10560,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 365,
+            "line": 366,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -10619,7 +10619,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 368,
+            "line": 369,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -10678,7 +10678,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 369,
+            "line": 370,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -10737,7 +10737,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 306,
+            "line": 307,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -10796,7 +10796,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 521,
+            "line": 522,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -10855,7 +10855,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 410,
+            "line": 411,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -10914,7 +10914,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 298,
+            "line": 299,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -10973,7 +10973,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 297,
+            "line": 298,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -11032,7 +11032,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 520,
+            "line": 521,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -11086,7 +11086,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 524,
+            "line": 525,
             "symbol": "DynamicDataLoader::initialize"
           }
         }
@@ -11140,7 +11140,7 @@
           "compile_context": [],
           "source": {
             "path": "src/init.cpp",
-            "line": 525,
+            "line": 526,
             "symbol": "DynamicDataLoader::initialize"
           }
         }

--- a/data/reference/json/ccb_json_object_types.json
+++ b/data/reference/json/ccb_json_object_types.json
@@ -4,7 +4,7 @@
   "inventory_kind": "json_object_types",
   "source": {
     "project": "Cataclysm-Cleanwater-Bomb",
-    "source_fingerprint": "sha256:b7fe62c8c994763cb903fbec791fb09c134728d3c64b6b64f6d34d8220cb475d",
+    "source_fingerprint": "sha256:ac64490ef82dfeb84676692b4f0ce3e7aa39311d5d75cb6456f99256c472014a",
     "contract_roots": [
       "data/core",
       "data/json",

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -55,6 +55,7 @@
 #include "memory_fast.h"
 #include "messages.h"
 #include "mission.h"
+#include "mod_id_compat.h"
 #include "mtype.h"
 #include "mutation.h"
 #include "npc.h"
@@ -1789,9 +1790,9 @@ conditional_t::func f_mod_is_loaded( const JsonObject &jo, std::string_view memb
 {
     str_or_var compared_mod = get_str_or_var( jo.get_member( member ), member, true );
     return [compared_mod]( const_dialogue const & d ) {
-        mod_id comp_mod = mod_id( compared_mod.evaluate( d ) );
+        const mod_id comp_mod = canonical_mod_id( mod_id( compared_mod.evaluate( d ) ) );
         for( const mod_id &mod : world_generator->active_world->active_mod_order ) {
-            if( comp_mod == mod ) {
+            if( comp_mod == canonical_mod_id( mod ) ) {
                 return true;
             }
         }

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -1993,7 +1993,7 @@ std::string game_info::mods_loaded()
     mod_names.reserve( mod_ids.size() );
     std::transform( mod_ids.begin(), mod_ids.end(),
     std::back_inserter( mod_names ), []( const mod_id & mod ) -> std::string {
-        // e.g. "Catharsis Covenant Basemodule [dda] (95c4e03)".
+        // e.g. "Catharsis Covenant Basemodule [ccb] (95c4e03)".
         return string_format( "%s [%s] (%s)", mod->name(), mod->ident.str(), mod->version );
     } );
 

--- a/src/debug.h
+++ b/src/debug.h
@@ -146,7 +146,7 @@ std::string game_version();
 /** Return the underlying graphics version used by the game; either Tiles or Curses.
 */
 std::string graphics_version();
-/** Return a list of the loaded mods, including the mod full name and its id name in brackets, e.g. "Catharsis Covenant Basemodule [dda]".
+/** Return a list of the loaded mods, including the mod full name and its id name in brackets, e.g. "Catharsis Covenant Basemodule [ccb]".
 */
 std::string mods_loaded();
 /** Generate a game report, including the information returned by all of the other functions.

--- a/src/game_io.cpp
+++ b/src/game_io.cpp
@@ -66,6 +66,7 @@
 #include "mapbuffer.h"
 #include "memorial_logger.h"
 #include "messages.h"
+#include "mod_id_compat.h"
 #include "mod_manager.h"
 #include "mp_gamestate.h"
 #include "options.h"
@@ -100,7 +101,7 @@
 
 static const dimension_id dimension_world_default( "default" );
 
-static const mod_id MOD_INFORMATION_dda( "dda" );
+static const mod_id MOD_INFORMATION_ccb( "ccb" );
 
 #define dbg(x) DebugLog((x),D_GAME) << __FILE__ << ":" << __LINE__ << ": "
 
@@ -569,22 +570,13 @@ void game::load_world_modfiles()
 {
     auto &mods = world_generator->active_world->active_mod_order;
 
-    // remove any duplicates whilst preserving order (fixes #19385)
-    std::set<mod_id> found;
-    mods.erase( std::remove_if( mods.begin(), mods.end(), [&found]( const mod_id & e ) {
-        if( found.count( e ) ) {
-            return true;
-        } else {
-            found.insert( e );
-            return false;
-        }
-    } ), mods.end() );
+    canonicalize_mod_list( mods );
 
     // require at least one core mod (saves before version 6 may implicitly require dda pack)
     if( std::none_of( mods.begin(), mods.end(), []( const mod_id & e ) {
     return e->core;
 } ) ) {
-        mods.insert( mods.begin(), MOD_INFORMATION_dda );
+        mods.insert( mods.begin(), MOD_INFORMATION_ccb );
     }
 
     // this code does not care about mod dependencies,
@@ -623,7 +615,9 @@ void game::load_world_modfiles()
 
 void game::load_packs( const std::string &msg, const std::vector<mod_id> &packs )
 {
-    for( const auto &mod : packs ) {
+    auto canonical_packs = packs;
+    canonicalize_mod_list( canonical_packs );
+    for( const auto &mod : canonical_packs ) {
         // Suppress missing mods the player chose to leave in the modlist
         if( !mod.is_valid() ) {
             continue;
@@ -638,7 +632,7 @@ void game::load_packs( const std::string &msg, const std::vector<mod_id> &packs 
     }
     cata_timer::print_stats();
 
-    for( const auto &mod : packs ) {
+    for( const auto &mod : canonical_packs ) {
         if( !mod.is_valid() ) {
             continue;
         }

--- a/src/help.cpp
+++ b/src/help.cpp
@@ -28,6 +28,7 @@
 #include "flexbuffer_json.h"
 #include "input_context.h"
 #include "input_enums.h"
+#include "mod_id_compat.h"
 #include "output.h"
 #include "path_info.h"
 #include "point.h"
@@ -250,7 +251,7 @@ std::optional<int> help::platform_topic_order( const std::string &id ) const
 
 void help::load_object( const JsonObject &jo, const std::string &src )
 {
-    if( src == "dda" ) {
+    if( is_core_data_source( src ) ) {
         jo.throw_error( string_format( "Vanilla help must be located in %s",
                                        PATH_INFO::jsondir().generic_u8string() ) );
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -81,6 +81,7 @@
 #include "material.h"
 #include "math_parser_jmath.h"
 #include "mission.h"
+#include "mod_id_compat.h"
 #include "mod_manager.h"
 #include "mod_tileset.h"
 #include "monfaction.h"
@@ -617,7 +618,8 @@ void DynamicDataLoader::load_mod_interaction_files_from_path( const cata_path &p
         const std::vector<cata_path> interaction_folders = get_directories( path, false );
 
         for( const cata_path &f : interaction_folders ) {
-            const mod_id associated_mod = mod_id( f.get_unrelative_path().filename().string() );
+            const mod_id associated_mod = canonical_mod_id( mod_id(
+                    f.get_unrelative_path().filename().string() ) );
             bool is_mod_loaded = std::find( loaded_mods.begin(), loaded_mods.end(),
                                             associated_mod ) != loaded_mods.end();
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -619,7 +619,7 @@ void DynamicDataLoader::load_mod_interaction_files_from_path( const cata_path &p
 
         for( const cata_path &f : interaction_folders ) {
             const mod_id associated_mod = canonical_mod_id( mod_id(
-                    f.get_unrelative_path().filename().string() ) );
+                                              f.get_unrelative_path().filename().string() ) );
             bool is_mod_loaded = std::find( loaded_mods.begin(), loaded_mods.end(),
                                             associated_mod ) != loaded_mods.end();
 

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -3847,7 +3847,7 @@ class vitamins_reader : public generic_typed_reader<vitamins_reader>
 
 void islot_comestible::deserialize( const JsonObject &jo )
 {
-    std::string src = "dda";
+    std::string src = "ccb";
 
     mandatory( jo, was_loaded, "comestible_type", comesttype );
     optional( jo, was_loaded, "tool", tool, itype_id::NULL_ID() );

--- a/src/lua_platform_runtime_services.cpp
+++ b/src/lua_platform_runtime_services.cpp
@@ -96,6 +96,7 @@ extern "C" {
 #include "mapgendata.h"
 #include "math_parser.h"
 #include "messages.h"
+#include "mod_id_compat.h"
 #include "mod_tileset.h"
 #include "npc.h"
 #include "options.h"
@@ -3104,7 +3105,7 @@ void install_runtime_api( const std::shared_ptr<runtime> &value,
         if( !world_generator || world_generator->active_world == nullptr ) {
             return false;
         }
-        const mod_id requested( id );
+        const mod_id requested = canonical_mod_id( mod_id( id ) );
         const std::vector<mod_id> &order = world_generator->active_world->active_mod_order;
         return std::find( order.begin(), order.end(), requested ) != order.end();
     } );
@@ -3117,7 +3118,7 @@ void install_runtime_api( const std::shared_ptr<runtime> &value,
         if( !world_generator || world_generator->active_world == nullptr ) {
             return -1;
         }
-        const mod_id requested( id );
+        const mod_id requested = canonical_mod_id( mod_id( id ) );
         const std::vector<mod_id> &order =
             world_generator->active_world->active_mod_order;
         const auto found = std::find(

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -84,8 +84,8 @@
 #include "wcwidth.h"
 #include "worldfactory.h"
 
-static const mod_id MOD_INFORMATION_dda( "dda" );
-static const mod_id MOD_INFORMATION_dda_tutorial( "dda_tutorial" );
+static const mod_id MOD_INFORMATION_ccb( "ccb" );
+static const mod_id MOD_INFORMATION_ccb_tutorial( "dda_tutorial" );
 
 namespace
 {
@@ -1198,8 +1198,8 @@ bool main_menu::start_tutorial()
         return false;
     }
     world->active_mod_order.clear();
-    world->active_mod_order.emplace_back( MOD_INFORMATION_dda );
-    world->active_mod_order.emplace_back( MOD_INFORMATION_dda_tutorial );
+    world->active_mod_order.emplace_back( MOD_INFORMATION_ccb );
+    world->active_mod_order.emplace_back( MOD_INFORMATION_ccb_tutorial );
     world_generator->set_active_world( world );
     try {
         g->setup();

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -79,6 +79,7 @@
 #include "memory_fast.h"
 #include "messages.h"
 #include "mission.h"
+#include "mod_id_compat.h"
 #include "mongroup.h"
 #include "npc.h"
 #include "omdata.h"
@@ -4638,7 +4639,8 @@ mapgen_palette mapgen_palette::load_internal( const JsonObject &jo, std::string_
         const std::string &context, bool require_id, bool allow_recur )
 {
     mapgen_palette new_pal;
-    bool extending = src != "dda" && jo.has_bool( "extending" ) && jo.get_bool( "extending" );
+    bool extending = !is_core_data_source( src ) && jo.has_bool( "extending" ) &&
+                     jo.get_bool( "extending" );
     require_id |= extending;
     mapgen_palette::placing_map &format_placings = new_pal.format_placings;
     auto &keys_with_terrain = new_pal.keys_with_terrain;
@@ -4883,7 +4885,7 @@ bool mapgen_function_json_base::setup_common( const JsonObject &jo )
     }
 
     // just like mapf::basic_bind("stuff",blargle("foo", etc) ), only json input and faster when applying
-    mapgen_palette palette = mapgen_palette::load_temp( jo, "dda", context_ );
+    mapgen_palette palette = mapgen_palette::load_temp( jo, "ccb", context_ );
     auto &keys_with_terrain = palette.keys_with_terrain;
     mapgen_palette::placing_map &format_placings = palette.format_placings;
 

--- a/src/mod_id_compat.h
+++ b/src/mod_id_compat.h
@@ -1,0 +1,38 @@
+#pragma once
+#ifndef CATA_SRC_MOD_ID_COMPAT_H
+#define CATA_SRC_MOD_ID_COMPAT_H
+
+#include <algorithm>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "type_id.h"
+
+// Keep the former core ID readable without registering a second core pack.
+inline mod_id canonical_mod_id( const mod_id &id )
+{
+    return id.str() == "dda" ? mod_id( "ccb" ) : id;
+}
+
+inline bool is_core_data_source( std::string_view id )
+{
+    return id == "ccb" || id == "dda";
+}
+
+// Canonicalize before deduplicating so worlds containing both IDs load core once.
+inline void canonicalize_mod_list( std::vector<mod_id> &mods )
+{
+    std::vector<mod_id> canonical;
+    canonical.reserve( mods.size() );
+    for( const mod_id &id : mods ) {
+        const mod_id resolved = canonical_mod_id( id );
+        if( std::find( canonical.begin(), canonical.end(), resolved ) == canonical.end() ) {
+            canonical.push_back( resolved );
+        }
+    }
+    mods = std::move( canonical );
+}
+
+#endif // CATA_SRC_MOD_ID_COMPAT_H

--- a/src/mod_manager.cpp
+++ b/src/mod_manager.cpp
@@ -1,3 +1,4 @@
+#include "mod_id_compat.h"
 #include "mod_manager.h"
 
 #include <cata_path.h>
@@ -138,9 +139,9 @@ mod_id get_mod_base_id_from_src( mod_id src )
     mod_id base_mod_id;
     size_t split_loc = src.str().find( '#' );
     if( split_loc == std::string::npos ) {
-        return src;
+        return canonical_mod_id( src );
     } else {
-        return mod_id( src.str().substr( 0, split_loc ) );
+        return canonical_mod_id( mod_id( src.str().substr( 0, split_loc ) ) );
     }
 }
 
@@ -160,7 +161,7 @@ const MOD_INFORMATION &string_id<MOD_INFORMATION>::obj() const
 template<>
 bool string_id<MOD_INFORMATION>::is_valid() const
 {
-    return world_generator->get_mod_manager().mod_map.count( *this ) > 0;
+    return world_generator->get_mod_manager().mod_map.count( canonical_mod_id( *this ) ) > 0;
 }
 
 std::string MOD_INFORMATION::name() const
@@ -325,6 +326,13 @@ void mod_manager::refresh_mod_list()
     }
     if( file_exist( PATH_INFO::mods_user_default() ) ) {
         load_mod_info( PATH_INFO::mods_user_default() );
+    }
+
+    // Apply aliases after both JSON and Lua metadata have been discovered,
+    // before default lists and the dependency graph consume their IDs.
+    for( auto &entry : mod_map ) {
+        canonicalize_mod_list( entry.second.dependencies );
+        canonicalize_mod_list( entry.second.conflicts );
     }
 
     if( !set_default_mods( MOD_INFORMATION_user_default ) ) {
@@ -701,6 +709,8 @@ void mod_manager::load_modfile( const JsonObject &jo, const cata_path &path )
     optional( jo, false, "version", modfile.version );
     optional( jo, false, "dependencies", modfile.dependencies );
     optional( jo, false, "conflicts", modfile.conflicts );
+    canonicalize_mod_list( modfile.dependencies );
+    canonicalize_mod_list( modfile.conflicts );
     optional( jo, false, "core", modfile.core, false );
     optional( jo, false, "obsolete", modfile.obsolete, false );
     optional( jo, false, "loading_images", modfile.loading_images );
@@ -724,6 +734,7 @@ void mod_manager::load_modfile( const JsonObject &jo, const cata_path &path )
 bool mod_manager::set_default_mods( const t_mod_list &mods )
 {
     default_mods = mods;
+    canonicalize_mod_list( default_mods );
     return write_to_file( PATH_INFO::mods_user_default(), [&]( std::ostream & fout ) {
         JsonOut json( fout, true ); // pretty-print
         json.start_object();
@@ -731,7 +742,7 @@ bool mod_manager::set_default_mods( const t_mod_list &mods )
         json.member( "id", "user:default" );
         json.member( "conflicts", std::vector<std::string>() );
         json.member( "dependencies" );
-        json.write( mods );
+        json.write( default_mods );
         json.member( "//",
                      "Not really obsolete!  Marked as such to prevent it from showing in the main list" );
         json.member( "obsolete", true );
@@ -855,7 +866,9 @@ void mod_manager::save_mods_list( const WORLD *world ) const
     }
     write_to_file( path, [&]( std::ostream & fout ) {
         JsonOut json( fout, true ); // pretty-print
-        json.write( world->active_mod_order );
+        auto mods = world->active_mod_order;
+        canonicalize_mod_list( mods );
+        json.write( mods );
     }, _( "list of mods" ) );
 }
 
@@ -868,7 +881,7 @@ void mod_manager::load_mods_list( WORLD *world ) const
     amo.clear();
     read_from_file_optional_json( get_mods_list_file( world ), [&]( const JsonArray & jsin ) {
         for( const std::string line : jsin ) {
-            const mod_id mod( line );
+            const mod_id mod = canonical_mod_id( mod_id( line ) );
             if( std::find( amo.begin(), amo.end(), mod ) != amo.end() ) {
                 continue;
             }
@@ -883,7 +896,9 @@ bool mod_manager::check_mods_list( WORLD *world ) const
         return true;
     }
     std::vector<mod_id> &amo = world->active_mod_order;
-    bool changed = false;
+    const auto original_mods = amo;
+    canonicalize_mod_list( amo );
+    bool changed = amo != original_mods;
 
     const auto is_virtual_mod = []( const mod_id & mod ) {
         return mod.str().find( '#' ) != std::string::npos;

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -1,4 +1,5 @@
 #include "mattack_common.h" // IWYU pragma: associated
+#include "mod_id_compat.h"
 #include "monstergenerator.h" // IWYU pragma: associated
 
 #include <clone_ptr.h>
@@ -1534,7 +1535,7 @@ void MonsterGenerator::load_monster_attack( const JsonObject &jo, const std::str
 void MonsterGenerator::check_monster_definitions() const
 {
     for( const mtype &mon : mon_templates->get_all() ) {
-        if( !mon.src.empty() && mon.src.back().second.str() == "dda" ) {
+        if( !mon.src.empty() && is_core_data_source( mon.src.back().second.str() ) ) {
             std::string mon_id = mon.id.str();
             std::string suffix_id = mon_id.substr( 0, mon_id.find( '_' ) );
             if( suffix_id != "mon" && suffix_id != "pseudo" ) {

--- a/src/mp_gamestate.cpp
+++ b/src/mp_gamestate.cpp
@@ -5899,7 +5899,7 @@ WORLD *mp_ensure_client_scratch_world()
     if( world_generator->has_world( SCRATCH_NAME ) ) {
         return world_generator->get_world( SCRATCH_NAME );
     }
-    const std::vector<mod_id> default_mods = { mod_id( "dda" ) };
+    const std::vector<mod_id> default_mods = { mod_id( "ccb" ) };
     WORLD *neww = world_generator->make_new_world( SCRATCH_NAME, default_mods );
     if( neww ) {
         mp_log( "[cdda-mp] MENU: created client scratch world '" + SCRATCH_NAME + "'" );

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -1,3 +1,4 @@
+#include "mod_id_compat.h"
 #include "mutation.h" // IWYU pragma: associated
 
 #include <bodypart.h>
@@ -737,7 +738,7 @@ void mutation_branch::check_consistency()
     for( const mutation_branch &mdata : get_all() ) {
         const trait_id &mid = mdata.id;
         const mod_id &trait_source = mdata.src.back().second;
-        const bool basegame_trait = trait_source.str() == "dda";
+        const bool basegame_trait = is_core_data_source( trait_source.str() );
         const std::optional<scenttype_id> &s_id = mdata.scent_typeid;
         const std::map<species_id, int> &an_id = mdata.anger_relations;
         for( const auto &style : mdata.initial_ma_styles ) {

--- a/src/rotatable_symbols.cpp
+++ b/src/rotatable_symbols.cpp
@@ -1,3 +1,4 @@
+#include "mod_id_compat.h"
 #include "rotatable_symbols.h"
 
 #include <algorithm>
@@ -97,7 +98,7 @@ namespace rotatable_symbols
 void load( const JsonObject &jo, const std::string &src )
 {
     const std::string tuple_key = "tuple";
-    const bool strict = src == "dda";
+    const bool strict = is_core_data_source( src );
 
     std::vector<std::string> tuple_temp;
 

--- a/tests/battery_density_test.cpp
+++ b/tests/battery_density_test.cpp
@@ -113,11 +113,11 @@ static const std::map<std::string, battery_chemistry_family> chemistries = {
 
 static bool is_battery( const itype &type )
 {
-    // We're only making assertions about the "dda" mod,
+    // We're only making assertions about the "ccb" mod,
     // ignore items from elsewhere, including the test mod.
     if( type.has_flag( json_flag_DEBUG_ONLY ) ||
         type.src.size() > 1 ||
-        ( type.src.size() == 1 && type.src.back().second.str() != std::string( "dda" ) ) ) {
+        ( type.src.size() == 1 && type.src.back().second.str() != std::string( "ccb" ) ) ) {
         return false;
     }
     if( !!type.magazine && type.magazine->type.count( ammo_battery ) > 0 ) {

--- a/tests/comestible_test.cpp
+++ b/tests/comestible_test.cpp
@@ -196,7 +196,7 @@ TEST_CASE( "comestible_health_bounds", "[comestible]" )
         if( ( comest_type != "FOOD" && comest_type != "DRINK" ) || has_mutagen_vit( comest ) ) {
             continue;
         }
-        if( it->src.back().second.str() != "dda" ) {
+        if( it->src.back().second.str() != "ccb" ) {
             continue;
         }
 

--- a/tests/effective_dps_test.cpp
+++ b/tests/effective_dps_test.cpp
@@ -300,7 +300,7 @@ TEST_CASE( "expected_weapon_dps", "[expected][dps]" )
 
     std::unordered_set<itype_id> tested;
     for( std::pair<const itype_id, double> &weap : test_data::expected_dps ) {
-        if( weap.first->src.empty() || weap.first->src.back().second.str() != "dda" ) {
+        if( weap.first->src.empty() || weap.first->src.back().second.str() != "ccb" ) {
             continue;
         }
         tested.emplace( weap.first );
@@ -310,7 +310,7 @@ TEST_CASE( "expected_weapon_dps", "[expected][dps]" )
     }
 
     for( const itype *it : item_controller->all() ) {
-        if( it->src.empty() || it->src.back().second.str() != "dda" ) {
+        if( it->src.empty() || it->src.back().second.str() != "ccb" ) {
             continue;
         }
         if( it->has_flag( flag_PSEUDO ) ) {

--- a/tests/lua_platform_tonic_lifecycle_test.cpp
+++ b/tests/lua_platform_tonic_lifecycle_test.cpp
@@ -40,7 +40,7 @@ static const itype_id itype_lua_first_cleanwater_cell( "lua_first_cleanwater_cel
 static const itype_id itype_lua_first_nano_tonic( "lua_first_nano_tonic" );
 
 static const mod_id MOD_INFORMATION_Lua_First_Example( "Lua_First_Example" );
-static const mod_id MOD_INFORMATION_dda( "dda" );
+static const mod_id MOD_INFORMATION_ccb( "ccb" );
 
 TEST_CASE( "lua_platform_tonic_survives_character_and_runtime_reload",
            "[lua][platform][playable_mvp][persistence][mod_manager]" )
@@ -79,7 +79,7 @@ TEST_CASE( "lua_platform_tonic_survives_character_and_runtime_reload",
     REQUIRE( info.lua_platform_version == platform::platform_version );
     REQUIRE( info.lua_platform_error.empty() );
     REQUIRE( info.version == "0.1.0" );
-    REQUIRE( info.dependencies == std::vector<mod_id> { MOD_INFORMATION_dda } );
+    REQUIRE( info.dependencies == std::vector<mod_id> { MOD_INFORMATION_ccb } );
     const std::filesystem::path root = PATH_INFO::moddir().get_unrelative_path() /
                                        std::filesystem::u8path( "Lua_First_Example" );
     REQUIRE( info.mod_root_path.get_unrelative_path() == root );

--- a/tests/mod_id_compat_test.cpp
+++ b/tests/mod_id_compat_test.cpp
@@ -1,0 +1,37 @@
+#include <vector>
+
+#include "cata_catch.h"
+#include "mod_id_compat.h"
+#include "type_id.h"
+
+TEST_CASE( "legacy_core_mod_id_is_an_alias", "[mod_manager][core_id]" )
+{
+    CHECK( bool( canonical_mod_id( mod_id( "dda" ) ) == mod_id( "ccb" ) ) );
+    CHECK( bool( canonical_mod_id( mod_id( "ccb" ) ) == mod_id( "ccb" ) ) );
+    CHECK( bool( canonical_mod_id( mod_id( "aftershock" ) ) == mod_id( "aftershock" ) ) );
+    CHECK( bool( canonical_mod_id( mod_id( "mod#dda" ) ) == mod_id( "mod#dda" ) ) );
+    CHECK( is_core_data_source( "dda" ) );
+    CHECK( is_core_data_source( "ccb" ) );
+    CHECK_FALSE( is_core_data_source( "aftershock" ) );
+}
+
+TEST_CASE( "core_mod_aliases_are_deduplicated_in_order", "[mod_manager][core_id]" )
+{
+    std::vector<mod_id> mods = { mod_id( "dda" ), mod_id( "magiclysm" ), mod_id( "ccb" ),
+                                 mod_id( "magiclysm" ), mod_id( "test_data" )
+                               };
+    const std::vector<mod_id> expected = { mod_id( "ccb" ), mod_id( "magiclysm" ),
+                                           mod_id( "test_data" )
+                                         };
+    canonicalize_mod_list( mods );
+    CHECK( bool( mods == expected ) );
+    canonicalize_mod_list( mods );
+    CHECK( bool( mods == expected ) );
+    mods = { mod_id( "ccb" ), mod_id( "dda" ) };
+    canonicalize_mod_list( mods );
+    REQUIRE( mods.size() == 1 );
+    CHECK( bool( mods.front() == mod_id( "ccb" ) ) );
+    mods.clear();
+    canonicalize_mod_list( mods );
+    CHECK( mods.empty() );
+}

--- a/tests/mod_manager_test.cpp
+++ b/tests/mod_manager_test.cpp
@@ -1,22 +1,23 @@
+#include <algorithm>
+#include <memory>
 #if !defined(CATA_ENABLE_LUA_PLATFORM) || !CATA_ENABLE_LUA_PLATFORM
     #include <filesystem>
-    #include <memory>
     #include <string>
     #include "lua_platform_loader.h"
-    #include "worldfactory.h"
 #endif
 
 #include <cata_path.h>
 #include <type_id.h>
-#include <algorithm>
 #include <functional>
 #include <vector>
 
 #include "cached_options.h"
 #include "cata_catch.h"
 #include "cata_scope_helpers.h"
+#include "mod_id_compat.h"
 #include "mod_manager.h"
 #include "path_info.h"
+#include "worldfactory.h"
 
 static const mod_id MOD_INFORMATION_Lua_First_Example( "Lua_First_Example" );
 static const mod_id MOD_INFORMATION_dda( "dda" );
@@ -117,3 +118,22 @@ TEST_CASE( "lua_mod_discovery_notifies_once_across_catalog_refreshes",
     CHECK( notices == 1 );
 }
 #endif
+
+TEST_CASE( "core_pack_is_registered_once_with_legacy_lookup", "[mod_manager][core_id]" )
+{
+    REQUIRE( world_generator != nullptr );
+    const mod_id core( "ccb" );
+    const mod_id legacy( "dda" );
+    REQUIRE( core.is_valid() );
+    REQUIRE( legacy.is_valid() );
+    CHECK( &core.obj() == &legacy.obj() );
+    CHECK( core->core );
+    CHECK( core->ident == core );
+    const auto available = world_generator->get_mod_manager().all_mods();
+    CHECK( std::count( available.begin(), available.end(), core ) == 1 );
+    CHECK( std::count( available.begin(), available.end(), legacy ) == 0 );
+    // TEST_DATA deliberately declares both names, like a transitional external Mod.
+    const mod_id fixture( "test_data" );
+    REQUIRE( fixture.is_valid() );
+    CHECK( fixture->dependencies == std::vector<mod_id> { core } );
+}

--- a/tests/monster_test.cpp
+++ b/tests/monster_test.cpp
@@ -404,7 +404,7 @@ static void monster_check()
 TEST_CASE( "check_mon_id" )
 {
     for( const mtype &mon : MonsterGenerator::generator().get_all_mtypes() ) {
-        if( !mon.src.empty() && mon.src.back().second.str() != "dda" ) {
+        if( !mon.src.empty() && mon.src.back().second.str() != "ccb" ) {
             continue;
         }
         std::string mon_id = mon.id.str();

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -25,6 +25,7 @@
 #endif
 
 #include "cata_catch.h"
+#include "mod_id_compat.h"
 
 #include "avatar.h"
 #include "cached_options.h"
@@ -56,7 +57,7 @@
 #include "weather_type.h"
 #include "worldfactory.h"
 
-static const mod_id MOD_INFORMATION_dda( "dda" );
+static const mod_id MOD_INFORMATION_ccb( "ccb" );
 
 using name_value_pair_t = std::pair<std::string, std::string>;
 using option_overrides_t = std::vector<name_value_pair_t>;
@@ -399,8 +400,9 @@ int main( int argc, const char *argv[] )
 
     // Validate CDDA arguments
     mods = extract_mod_selection( mods_string );
-    if( std::find( mods.begin(), mods.end(), MOD_INFORMATION_dda ) == mods.end() ) {
-        mods.insert( mods.begin(), MOD_INFORMATION_dda ); // @todo move unit test items to core
+    canonicalize_mod_list( mods );
+    if( std::find( mods.begin(), mods.end(), MOD_INFORMATION_ccb ) == mods.end() ) {
+        mods.insert( mods.begin(), MOD_INFORMATION_ccb ); // @todo move unit test items to core
     }
 
     if( user_dir.empty() ) {

--- a/tools/auto_doc_mutations.py
+++ b/tools/auto_doc_mutations.py
@@ -110,7 +110,7 @@ def write_mutations(mutations: list[Mutation], filename: Path) -> None:
             fd.write("\n\n")
 
 
-def extract_mutations(file: Path, mod: str = "dda") -> list[Mutation]:
+def extract_mutations(file: Path, mod: str = "ccb") -> list[Mutation]:
     """Extract mutations from :file:."""
 
     with open(file, "rb") as fd:
@@ -203,9 +203,9 @@ def cli(paths, outfile, include_mods) -> None:
         write_mutations(mutations, outfile)
         click.echo(f"Mutations written to {outfile}")
     else:
-        dda = Mod("dda", [], [])
+        dda = Mod("ccb", [], [])
         mod_stack: list[tuple[Mod, str]] = [(dda, "PLACEHOLDER")]
-        mods: dict[str, Mod] = {"dda": dda}
+        mods: dict[str, Mod] = {"ccb": dda}
 
         def move_stack(
             file, mod_stack: list[tuple[Mod, str]]
@@ -245,7 +245,10 @@ def cli(paths, outfile, include_mods) -> None:
                 if isinstance(mod_info, dict) and all(
                     (mod_info.get("id"), mod_info.get("dependencies"))
                 ):
-                    new_mod = Mod(mod_info["id"], [], mod_info["dependencies"])
+                    new_mod = Mod(mod_info["id"], [], [
+                        "ccb" if dep == "dda" else dep
+                        for dep in mod_info["dependencies"]
+                    ])
                     mod_stack.append((new_mod, Path(os.path.dirname(file))))
                     mods[new_mod.id_] = new_mod
                 else:
@@ -285,7 +288,7 @@ def cli(paths, outfile, include_mods) -> None:
             except AttributeError:
                 breakpoint()
 
-            if mod.id_ == "dda":
+            if mod.id_ == "ccb":
                 writepath = outfile
             else:
                 writepath = outfile.parent.joinpath(mod.id_ + ".md")


### PR DESCRIPTION
#### Summary
Interface "核心包 ID 改为 ccb，兼容旧 dda 依赖与世界列表"

#### Responsible human
@LYHGLYTX

#### Purpose of change
核心包仍显示 [dda]。迁移为 [ccb] 时必须保留旧世界和外部 Mod 的兼容性，避免重复加载核心或跳过核心数据校验。

#### Describe the solution
仅注册 ccb 核心，dda 作为读取别名。规范化 JSON/Lua 依赖、冲突、默认列表、世界列表及直接加载入口，并保持顺序去重。旧来源记录、Mod 联动目录、JSON 条件和 Lua is_loaded/load_order 查询保留兼容。内置声明和核心来源判断同步更新；显示名称和 data/mods/dda 目录保持原样。

#### Describe alternatives you've considered
不注册第二个虚拟核心包，以避免重复加载。只改显示文本不能完成核心 ID 迁移。

#### Testing
- 14 个受影响引擎文件本地 SDL2/C++17 对象编译通过，最终版本另做语法检查通过。
- 实际别名实现的独立 Catch2：2 个测试、12 个断言通过。
- Mod 发现集成测试及测试入口编译检查通过；TEST_DATA 故意声明 dda、ccb 双依赖检查实际发现时去重。
- make -j2 json-check、更新后的 chkjson 及 51 个改动 JSON 解析通过。
- Lua 合同工具测试：77 项，2 项跳过，其余通过；生成清单和合同由对应生成器刷新。
- JSON/EOC 生成清单已刷新，对应 15 项工具测试通过。
- Agent 元数据工具测试 99 项、上下文基准 9 项全部通过。
- git diff --check 和 Python 文档工具语法检查通过。
- 尚未运行完整游戏数据加载、Mod 发现集成测试、旧世界读档或 Android 实测，已按维护者要求转为正式 PR；这些设备/读档实测仍未完成。

#### Documentation impact
更新 cpp.lua-bridge 中英说明，解释新 ID 和旧依赖/查询的兼容方向。

#### Related CCB-Docs PR
https://github.com/CrimsonCrossBunker/CCB-Docs/pull/48

#### Affected documentation IDs
cpp.lua-bridge, mods.complete-json-eoc-mod

#### Generated reference impact
Lua 原生清单、JSON/EOC 来源位置与指纹及迁移台账均通过生成器更新。JSON/EOC 语法未变；mods.complete-json-eoc-mod 所涉及的依赖 ID 兼容规则统一在 cpp.lua-bridge 配套说明中记录。

#### Additional context
7 个提交（包含 CI 生成清单与格式修正）；兼容方向为旧数据读取到新版本，不保证新版保存结果可由旧版游戏读取。