### PR TITLE
补齐 Lua 特征查询中间接变量的双方归属与短路验证

### DIFF
--- a/tools/migrate_lua_first.py
+++ b/tools/migrate_lua_first.py
@@ -25708,19 +25708,11 @@ def render_trait_condition(
         return None
 
     def query(identifier: Any) -> str | None:
-        variable_actor = target
         if isinstance(identifier, dict):
-            if "u_val" in identifier:
-                variable_actor = alpha
-            elif "npc_val" in identifier:
-                variable_actor = beta
-            elif "var_val" in identifier:
-                # An indirect reference can switch owners at runtime. The
-                # single-owner resolver cannot prove that participant yet.
-                return None
-        if variable_actor is None:
-            return None
-        value = _dynamic_id_expression(identifier, "mutation", variable_actor)
+            raw_id = render_participant_string_expression(identifier, target, alpha, beta)
+            value = None if raw_id is None else f'services.types.id("mutation", {raw_id})'
+        else:
+            value = _dynamic_id_expression(identifier, "mutation", target)
         if value is None:
             return None
         participants = f"{target}, {observer}" if method == "is_visible_to" else target

--- a/tools/test_migrate_lua_first.py
+++ b/tools/test_migrate_lua_first.py
@@ -15,6 +15,75 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
 
 class LuaFirstMigrationTest(unittest.TestCase):
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_trait_indirect_ids_resolve_the_dialogue_owner(self) -> None:
+        for prefix, target, observer in (("u_", "actor", "partner"), ("npc_", "partner", "actor")):
+            for query in ("has_trait", "has_any_trait", "is_trait_purifiable", "has_visible_trait"):
+                for reference, identifier in (("u_selected", "QUICK"), ("n_selected", "FELINE_EARS")):
+                    with self.subTest(prefix=prefix, query=query, reference=reference):
+                        value = {"var_val": "selected_ref"}
+                        if query == "has_any_trait":
+                            value = [value]
+                        expression = migrate_lua_first.render_eoc_condition_expression(
+                            {prefix + query: value}, avatar_actor_proven=True,
+                            npc_actor_expression="partner")
+                        self.assertIsNotNone(expression)
+                        script = """
+local actor, partner = {selected='QUICK'}, {selected='FELINE_EARS'}
+local context = {data={selected_ref=REFERENCE}}
+local function service_value(result) assert(result.ok); return result.value end
+local called = false
+local function query(character, id)
+ assert(character == TARGET and id == IDENTIFIER)
+ called = true
+ return {ok=true,value=true}
+end
+local services = {
+ variables={resolve=function(data, owner, scope, key)
+   return {ok=true,value={value=owner[key]}}
+ end},
+ types={id=function(kind,id) assert(kind=='mutation'); return id end},
+ mutations={has=query,is_purifiable=query,is_visible_to=function(character,viewer,id)
+   assert(viewer == OBSERVER)
+   return query(character,id)
+ end}
+}
+assert(EXPRESSION)
+assert(called)
+""".replace("REFERENCE", json.dumps(reference)).replace("IDENTIFIER", json.dumps(identifier)).replace("TARGET", target).replace("OBSERVER", observer).replace("EXPRESSION", expression)
+                        result = subprocess.run([shutil.which("lua"), "-"], input=script,
+                                                text=True, capture_output=True, timeout=10)
+                        self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_trait_indirect_any_list_keeps_short_circuit(self) -> None:
+        expression = migrate_lua_first.render_eoc_condition_expression(
+            {"u_has_any_trait": ["QUICK", {"var_val": "missing"}]},
+            avatar_actor_proven=True, npc_actor_expression="partner")
+        self.assertIsNotNone(expression)
+        script = """
+local actor, partner = {}, {}
+local context = {data={}}
+local function service_value(r) return r.value end
+local calls = 0
+local services = {
+ types={id=function(kind,id) assert(id == 'QUICK'); return id end},
+ variables={resolve=function() error('short-circuited variable was read') end},
+ mutations={has=function(character,id)
+   assert(character == actor and id == 'QUICK')
+   calls = calls + 1
+   return {ok=true,value=true}
+ end}
+}
+assert(EXPRESSION)
+assert(calls == 1)
+""".replace("EXPRESSION", expression)
+        result = subprocess.run([shutil.which("lua"), "-"], input=script,
+                                text=True, capture_output=True, timeout=10)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIsNone(migrate_lua_first.render_eoc_condition_expression(
+            {"u_has_trait": {"var_val": "selected"}}, avatar_actor_proven=True))
+
     def test_skill_teaching_requires_two_proven_participants(self) -> None:
         for selector, expected in (
             ("u_train_skills", "services.skills.offered(actor, partner)"),


### PR DESCRIPTION
#### Summary
Bugfixes "迁移特征查询中的间接变量引用"

#### Responsible human
@LYHGLYTX

#### Purpose of change
has_trait、has_any_trait、has_visible_trait、is_trait_purifiable 的 u/npc 形状此前遇到 var_val 一律保留 TODO，即使双方参与者明确，也无法迁移。

#### Describe the solution
复用 #770 的内部参与者字符串解析器，为 8 个选择器保留间接变量的最终归属，查询目标与可见性观察者保持独立。列表仍使用 Lua 短路求值，参与者无法证明时继续保留 TODO。

#### Describe alternatives you've considered
不通过当前查询对象猜测变量主人；不新增公开 EOC 兼容执行入口。

#### Testing
- 16 个双方查询场景修复前因无法迁移失败，修复后执行生成的 Lua 通过。
- 新增短路验证：前项命中后不读取后面的缺失间接变量；未证明参与者仍拒绝转换。
- python3 tools/test_migrate_lua_first.py：367 项通过；flake8、git diff --check 通过。
- 只修改迁移工具与其测试，不涉及 C++。复用主线原生 269 项、32199 条断言及既有特征语义测试证据。
- 不将此批次等同于特征领域或全部 586 项完成，未提升账本状态。

#### Documentation impact
None：补齐已有领域服务的迁移支持，公共契约不变。

#### Related CCB-Docs PR
None

#### Affected documentation IDs
None

#### Generated reference impact
None

#### Additional context
依赖 #770，当前 PR 以其分支为基线；#770 合并后应重新对齐 master 再验收最终合并状态。
本批 2 个文件，73 行新增、12 行删除，1 个完整提交，符合小于 1000 行最多 15 个提交的参考范围。