### PR TITLE
修复 Lua 效果添加的负数和长持续时间语义

### DIFF
--- a/ai/lua-first-replacement-ledger.yml
+++ b/ai/lua-first-replacement-ledger.yml
@@ -45,10 +45,10 @@ sources:
   entry_count: 311
 summary:
   total: 776
-  implemented_verified: 0
+  implemented_verified: 1
   implemented_unverified: 89
   bounded_implemented_verified: 0
-  bounded_implemented_unverified: 662
+  bounded_implemented_unverified: 661
   primitive_available_unverified: 8
   planned: 0
   private_adapter: 0
@@ -331,16 +331,16 @@ entries:
   selector: is_day
   target_kind: shared_service
   target: services.gameplay.environment
-  status: bounded_implemented_unverified
+  status: implemented_verified
   legacy_dependency: none
   evidence:
   - data/lua/types/ccb_platform_v1.d.lua
   - data/reference/json/ccb_eoc_conditions.json
-  - src/lua_platform_runtime.cpp
-  - tests/lua_platform_test.cpp
+  - src/lua_platform_runtime_services.cpp
+  - tests/lua_platform_day_semantic_test.cpp
   - tools/migrate_lua_first.py
   - tools/test_migrate_lua_first.py
-  verification: source_only
+  verification: final_semantic_gate
 - inventory: eoc-conditions
   selector: is_outside
   target_kind: shared_service

--- a/data/lua/reference/ccb_platform_api_v1.json
+++ b/data/lua/reference/ccb_platform_api_v1.json
@@ -7,7 +7,7 @@
     "root_class": "CcbPlatformV1"
   },
   "lua_luals": {
-    "class_count": 698,
+    "class_count": 700,
     "classes": [
       {
         "fields": [
@@ -1101,42 +1101,42 @@
       {
         "fields": [
           {
-            "line": 6974,
+            "line": 6985,
             "name": "camp_identity_generation",
             "type": "integer"
           },
           {
-            "line": 6973,
+            "line": 6984,
             "name": "camp_stable_id",
             "type": "integer"
           },
           {
-            "line": 6969,
+            "line": 6980,
             "name": "expansion_id",
             "type": "integer"
           },
           {
-            "line": 6970,
+            "line": 6981,
             "name": "identity_generation",
             "type": "integer"
           },
           {
-            "line": 6976,
+            "line": 6987,
             "name": "is_valid",
             "type": "fun(self:"
           },
           {
-            "line": 6975,
+            "line": 6986,
             "name": "owner_faction",
             "type": "string"
           },
           {
-            "line": 6971,
+            "line": 6982,
             "name": "runtime_generation",
             "type": "integer"
           },
           {
-            "line": 6972,
+            "line": 6983,
             "name": "world_generation",
             "type": "integer"
           }
@@ -1146,57 +1146,57 @@
       {
         "fields": [
           {
-            "line": 7109,
+            "line": 7120,
             "name": "camp_identity_generation",
             "type": "integer"
           },
           {
-            "line": 7108,
+            "line": 7119,
             "name": "camp_stable_id",
             "type": "integer"
           },
           {
-            "line": 7105,
+            "line": 7116,
             "name": "identity_generation",
             "type": "integer"
           },
           {
-            "line": 7114,
+            "line": 7125,
             "name": "is_valid",
             "type": "fun(self:"
           },
           {
-            "line": 7112,
+            "line": 7123,
             "name": "manager_identity_generation",
             "type": "integer"
           },
           {
-            "line": 7110,
+            "line": 7121,
             "name": "manager_stable_id",
             "type": "integer"
           },
           {
-            "line": 7106,
+            "line": 7117,
             "name": "runtime_generation",
             "type": "integer"
           },
           {
-            "line": 7104,
+            "line": 7115,
             "name": "task_id",
             "type": "integer"
           },
           {
-            "line": 7113,
+            "line": 7124,
             "name": "worker_identity_generation",
             "type": "integer"
           },
           {
-            "line": 7111,
+            "line": 7122,
             "name": "worker_stable_id",
             "type": "integer"
           },
           {
-            "line": 7107,
+            "line": 7118,
             "name": "world_generation",
             "type": "integer"
           }
@@ -1210,7 +1210,7 @@
       {
         "fields": [
           {
-            "line": 7406,
+            "line": 7417,
             "name": "value",
             "type": "GameId|nil"
           }
@@ -1220,7 +1220,7 @@
       {
         "fields": [
           {
-            "line": 7409,
+            "line": 7420,
             "name": "value",
             "type": "GameId[]|nil"
           }
@@ -1230,27 +1230,27 @@
       {
         "fields": [
           {
-            "line": 10590,
+            "line": 10601,
             "name": "items",
             "type": "table"
           },
           {
-            "line": 10593,
+            "line": 10604,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 10592,
+            "line": 10603,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 10591,
+            "line": 10602,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 10594,
+            "line": 10605,
             "name": "truncated",
             "type": "boolean"
           }
@@ -1260,7 +1260,7 @@
       {
         "fields": [
           {
-            "line": 7348,
+            "line": 7359,
             "name": "type",
             "type": "string"
           }
@@ -1270,12 +1270,12 @@
       {
         "fields": [
           {
-            "line": 7233,
+            "line": 7244,
             "name": "x",
             "type": "integer"
           },
           {
-            "line": 7234,
+            "line": 7245,
             "name": "y",
             "type": "integer"
           }
@@ -1285,42 +1285,42 @@
       {
         "fields": [
           {
-            "line": 7254,
+            "line": 7265,
             "name": "camp",
             "type": "GameHandle"
           },
           {
-            "line": 7260,
+            "line": 7271,
             "name": "complete",
             "type": "boolean"
           },
           {
-            "line": 7255,
+            "line": 7266,
             "name": "items",
             "type": "CcbCampExpansionSnapshot[]"
           },
           {
-            "line": 7258,
+            "line": 7269,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7257,
+            "line": 7268,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 7259,
+            "line": 7270,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 7256,
+            "line": 7267,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 7261,
+            "line": 7272,
             "name": "truncated",
             "type": "boolean"
           }
@@ -1330,12 +1330,12 @@
       {
         "fields": [
           {
-            "line": 7251,
+            "line": 7262,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7250,
+            "line": 7261,
             "name": "offset",
             "type": "integer"
           }
@@ -1345,57 +1345,57 @@
       {
         "fields": [
           {
-            "line": 7240,
+            "line": 7251,
             "name": "camp",
             "type": "GameHandle"
           },
           {
-            "line": 7241,
+            "line": 7252,
             "name": "camp_stable_id",
             "type": "integer"
           },
           {
-            "line": 7242,
+            "line": 7253,
             "name": "direction",
             "type": "CcbCampExpansionDirection"
           },
           {
-            "line": 7238,
+            "line": 7249,
             "name": "expansion_id",
             "type": "integer"
           },
           {
-            "line": 7239,
+            "line": 7250,
             "name": "identity_generation",
             "type": "integer"
           },
           {
-            "line": 7245,
+            "line": 7256,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 7246,
+            "line": 7257,
             "name": "owner",
             "type": "GameId"
           },
           {
-            "line": 7243,
+            "line": 7254,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 7237,
+            "line": 7248,
             "name": "token",
             "type": "CampExpansionToken"
           },
           {
-            "line": 7244,
+            "line": 7255,
             "name": "type",
             "type": "string"
           },
           {
-            "line": 7247,
+            "line": 7258,
             "name": "work_in_progress",
             "type": "boolean"
           }
@@ -1413,37 +1413,37 @@
       {
         "fields": [
           {
-            "line": 6949,
+            "line": 6960,
             "name": "added",
             "type": "boolean"
           },
           {
-            "line": 6947,
+            "line": 6958,
             "name": "after_kcal",
             "type": "integer"
           },
           {
-            "line": 6948,
+            "line": 6959,
             "name": "amount_kcal",
             "type": "integer"
           },
           {
-            "line": 6946,
+            "line": 6957,
             "name": "before_kcal",
             "type": "integer"
           },
           {
-            "line": 6945,
+            "line": 6956,
             "name": "camp",
             "type": "GameHandle"
           },
           {
-            "line": 6951,
+            "line": 6962,
             "name": "changed",
             "type": "boolean"
           },
           {
-            "line": 6950,
+            "line": 6961,
             "name": "consumed",
             "type": "boolean"
           }
@@ -1453,12 +1453,12 @@
       {
         "fields": [
           {
-            "line": 6902,
+            "line": 6913,
             "name": "consumes_food",
             "type": "boolean"
           },
           {
-            "line": 6901,
+            "line": 6912,
             "name": "kcal",
             "type": "integer"
           }
@@ -1472,12 +1472,12 @@
       {
         "fields": [
           {
-            "line": 7317,
+            "line": 7328,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7316,
+            "line": 7327,
             "name": "radius_omt",
             "type": "integer"
           }
@@ -1487,32 +1487,32 @@
       {
         "fields": [
           {
-            "line": 7333,
+            "line": 7344,
             "name": "center",
             "type": "TripointCoord"
           },
           {
-            "line": 7337,
+            "line": 7348,
             "name": "complete",
             "type": "boolean"
           },
           {
-            "line": 7332,
+            "line": 7343,
             "name": "items",
             "type": "CcbCampSnapshot[]"
           },
           {
-            "line": 7336,
+            "line": 7347,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7334,
+            "line": 7345,
             "name": "radius_omt",
             "type": "integer"
           },
           {
-            "line": 7335,
+            "line": 7346,
             "name": "returned",
             "type": "integer"
           }
@@ -1522,42 +1522,42 @@
       {
         "fields": [
           {
-            "line": 7082,
+            "line": 7093,
             "name": "charges",
             "type": "integer"
           },
           {
-            "line": 7086,
+            "line": 7097,
             "name": "error",
             "type": "string"
           },
           {
-            "line": 7081,
+            "line": 7092,
             "name": "identity_generation",
             "type": "integer"
           },
           {
-            "line": 7085,
+            "line": 7096,
             "name": "item",
             "type": "table<string,"
           },
           {
-            "line": 7087,
+            "line": 7098,
             "name": "source_holder",
             "type": "CcbCampRecipeHolderSnapshot"
           },
           {
-            "line": 7083,
+            "line": 7094,
             "name": "tool",
             "type": "boolean"
           },
           {
-            "line": 7080,
+            "line": 7091,
             "name": "uid",
             "type": "integer"
           },
           {
-            "line": 7084,
+            "line": 7095,
             "name": "valid",
             "type": "boolean"
           }
@@ -1567,32 +1567,32 @@
       {
         "fields": [
           {
-            "line": 7094,
+            "line": 7105,
             "name": "complete",
             "type": "boolean"
           },
           {
-            "line": 7090,
+            "line": 7101,
             "name": "items",
             "type": "CcbCampRecipeEscrowItemSnapshot[]"
           },
           {
-            "line": 7093,
+            "line": 7104,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7092,
+            "line": 7103,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 7091,
+            "line": 7102,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 7095,
+            "line": 7106,
             "name": "truncated",
             "type": "boolean"
           }
@@ -1602,17 +1602,17 @@
       {
         "fields": [
           {
-            "line": 6995,
+            "line": 7006,
             "name": "character",
             "type": "GameHandle"
           },
           {
-            "line": 6994,
+            "line": 7005,
             "name": "kind",
             "type": "'character'"
           },
           {
-            "line": 6996,
+            "line": 7007,
             "name": "slot",
             "type": "'inventory'|'worn'|'wielded'"
           }
@@ -1622,22 +1622,22 @@
       {
         "fields": [
           {
-            "line": 7075,
+            "line": 7086,
             "name": "character_id",
             "type": "integer"
           },
           {
-            "line": 7076,
+            "line": 7087,
             "name": "identity_generation",
             "type": "integer"
           },
           {
-            "line": 7074,
+            "line": 7085,
             "name": "kind",
             "type": "'character'"
           },
           {
-            "line": 7077,
+            "line": 7088,
             "name": "slot",
             "type": "'inventory'|'worn'|'wielded'"
           }
@@ -1647,22 +1647,22 @@
       {
         "fields": [
           {
-            "line": 7068,
+            "line": 7079,
             "name": "item",
             "type": "GameHandle"
           },
           {
-            "line": 7070,
+            "line": 7081,
             "name": "quantity",
             "type": "integer"
           },
           {
-            "line": 7069,
+            "line": 7080,
             "name": "source_holder",
             "type": "CcbCampRecipeHolder"
           },
           {
-            "line": 7071,
+            "line": 7082,
             "name": "tool",
             "type": "boolean"
           }
@@ -1672,27 +1672,27 @@
       {
         "fields": [
           {
-            "line": 7000,
+            "line": 7011,
             "name": "batch",
             "type": "integer"
           },
           {
-            "line": 7003,
+            "line": 7014,
             "name": "destination_holder",
             "type": "CcbCampRecipeHolder"
           },
           {
-            "line": 7001,
+            "line": 7012,
             "name": "duration_turns",
             "type": "integer"
           },
           {
-            "line": 6999,
+            "line": 7010,
             "name": "recipe_id",
             "type": "GameId"
           },
           {
-            "line": 7002,
+            "line": 7013,
             "name": "source_holders",
             "type": "CcbCampRecipeHolder[]"
           }
@@ -1702,27 +1702,27 @@
       {
         "fields": [
           {
-            "line": 7037,
+            "line": 7048,
             "name": "batch",
             "type": "integer"
           },
           {
-            "line": 7040,
+            "line": 7051,
             "name": "destination_holder",
             "type": "CcbCampRecipeHolderSnapshot"
           },
           {
-            "line": 7038,
+            "line": 7049,
             "name": "duration_turns",
             "type": "integer"
           },
           {
-            "line": 7036,
+            "line": 7047,
             "name": "recipe_id",
             "type": "GameId"
           },
           {
-            "line": 7039,
+            "line": 7050,
             "name": "source_holders",
             "type": "CcbCampRecipeHolderSnapshot[]"
           }
@@ -1732,12 +1732,12 @@
       {
         "fields": [
           {
-            "line": 6898,
+            "line": 6909,
             "name": "delta",
             "type": "integer"
           },
           {
-            "line": 6897,
+            "line": 6908,
             "name": "id",
             "type": "GameId"
           }
@@ -1747,22 +1747,22 @@
       {
         "fields": [
           {
-            "line": 6892,
+            "line": 6903,
             "name": "ammo_id",
             "type": "GameId"
           },
           {
-            "line": 6893,
+            "line": 6904,
             "name": "available",
             "type": "integer"
           },
           {
-            "line": 6894,
+            "line": 6905,
             "name": "consumed",
             "type": "integer"
           },
           {
-            "line": 6891,
+            "line": 6902,
             "name": "id",
             "type": "GameId"
           }
@@ -1772,47 +1772,47 @@
       {
         "fields": [
           {
-            "line": 6905,
+            "line": 6916,
             "name": "camp",
             "type": "GameHandle"
           },
           {
-            "line": 6912,
+            "line": 6923,
             "name": "complete",
             "type": "boolean"
           },
           {
-            "line": 6907,
+            "line": 6918,
             "name": "food",
             "type": "CcbCampFoodSnapshot"
           },
           {
-            "line": 6910,
+            "line": 6921,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 6909,
+            "line": 6920,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 6906,
+            "line": 6917,
             "name": "resources",
             "type": "CcbCampResourceEntry[]"
           },
           {
-            "line": 6911,
+            "line": 6922,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 6908,
+            "line": 6919,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 6913,
+            "line": 6924,
             "name": "truncated",
             "type": "boolean"
           }
@@ -1822,12 +1822,12 @@
       {
         "fields": [
           {
-            "line": 6984,
+            "line": 6995,
             "name": "amount",
             "type": "integer"
           },
           {
-            "line": 6983,
+            "line": 6994,
             "name": "id",
             "type": "GameId"
           }
@@ -1837,27 +1837,27 @@
       {
         "fields": [
           {
-            "line": 6991,
+            "line": 7002,
             "name": "duration_turns",
             "type": "integer"
           },
           {
-            "line": 6989,
+            "line": 7000,
             "name": "food_input_kcal",
             "type": "integer"
           },
           {
-            "line": 6990,
+            "line": 7001,
             "name": "food_output_kcal",
             "type": "integer"
           },
           {
-            "line": 6987,
+            "line": 6998,
             "name": "resource_inputs",
             "type": "CcbCampResourceWorkChange[]"
           },
           {
-            "line": 6988,
+            "line": 6999,
             "name": "resource_outputs",
             "type": "CcbCampResourceWorkChange[]"
           }
@@ -1871,52 +1871,52 @@
       {
         "fields": [
           {
-            "line": 7329,
+            "line": 7340,
             "name": "assigned_worker_count",
             "type": "integer"
           },
           {
-            "line": 7324,
+            "line": 7335,
             "name": "board_name",
             "type": "string"
           },
           {
-            "line": 7327,
+            "line": 7338,
             "name": "board_position",
             "type": "TripointCoord"
           },
           {
-            "line": 7320,
+            "line": 7331,
             "name": "handle",
             "type": "GameHandle"
           },
           {
-            "line": 7322,
+            "line": 7333,
             "name": "identity_generation",
             "type": "integer"
           },
           {
-            "line": 7323,
+            "line": 7334,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 7328,
+            "line": 7339,
             "name": "owner",
             "type": "GameId"
           },
           {
-            "line": 7326,
+            "line": 7337,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 7321,
+            "line": 7332,
             "name": "stable_id",
             "type": "integer"
           },
           {
-            "line": 7325,
+            "line": 7336,
             "name": "valid",
             "type": "boolean"
           }
@@ -1926,7 +1926,7 @@
       {
         "fields": [
           {
-            "line": 7293,
+            "line": 7304,
             "name": "holder",
             "type": "CcbItemHolder"
           }
@@ -1936,47 +1936,47 @@
       {
         "fields": [
           {
-            "line": 7296,
+            "line": 7307,
             "name": "camp",
             "type": "GameHandle"
           },
           {
-            "line": 7302,
+            "line": 7313,
             "name": "complete",
             "type": "boolean"
           },
           {
-            "line": 7297,
+            "line": 7308,
             "name": "items",
             "type": "CcbCampStorageTile[]"
           },
           {
-            "line": 7300,
+            "line": 7311,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7299,
+            "line": 7310,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 7304,
+            "line": 7315,
             "name": "page_api",
             "type": "string"
           },
           {
-            "line": 7301,
+            "line": 7312,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 7298,
+            "line": 7309,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 7303,
+            "line": 7314,
             "name": "truncated",
             "type": "boolean"
           }
@@ -1986,52 +1986,52 @@
       {
         "fields": [
           {
-            "line": 7142,
+            "line": 7153,
             "name": "camp",
             "type": "GameHandle"
           },
           {
-            "line": 7150,
+            "line": 7161,
             "name": "complete",
             "type": "boolean"
           },
           {
-            "line": 7148,
+            "line": 7159,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7143,
+            "line": 7154,
             "name": "manager",
             "type": "GameHandle"
           },
           {
-            "line": 7147,
+            "line": 7158,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 7149,
+            "line": 7160,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 7145,
+            "line": 7156,
             "name": "tasks",
             "type": "CcbCampTaskSnapshot[]"
           },
           {
-            "line": 7146,
+            "line": 7157,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 7151,
+            "line": 7162,
             "name": "truncated",
             "type": "boolean"
           },
           {
-            "line": 7144,
+            "line": 7155,
             "name": "worker",
             "type": "GameHandle"
           }
@@ -2041,22 +2041,22 @@
       {
         "fields": [
           {
-            "line": 7100,
+            "line": 7111,
             "name": "active",
             "type": "boolean"
           },
           {
-            "line": 7101,
+            "line": 7112,
             "name": "discarded",
             "type": "boolean"
           },
           {
-            "line": 7099,
+            "line": 7110,
             "name": "food_kcal",
             "type": "integer"
           },
           {
-            "line": 7098,
+            "line": 7109,
             "name": "resources",
             "type": "CcbCampResourceWorkChange[]"
           }
@@ -2066,117 +2066,117 @@
       {
         "fields": [
           {
-            "line": 7119,
+            "line": 7130,
             "name": "camp",
             "type": "GameHandle"
           },
           {
-            "line": 7136,
+            "line": 7147,
             "name": "due_at",
             "type": "TimePoint"
           },
           {
-            "line": 7137,
+            "line": 7148,
             "name": "finished_at",
             "type": "TimePoint"
           },
           {
-            "line": 7118,
+            "line": 7129,
             "name": "identity_generation",
             "type": "integer"
           },
           {
-            "line": 7123,
+            "line": 7134,
             "name": "kind",
             "type": "CcbCampTaskKind"
           },
           {
-            "line": 7121,
+            "line": 7132,
             "name": "manager",
             "type": "GameHandle"
           },
           {
-            "line": 7120,
+            "line": 7131,
             "name": "owner",
             "type": "GameId"
           },
           {
-            "line": 7124,
+            "line": 7135,
             "name": "parameter_schema",
             "type": "string"
           },
           {
-            "line": 7129,
+            "line": 7140,
             "name": "recipe_commit_marker",
             "type": "integer"
           },
           {
-            "line": 7128,
+            "line": 7139,
             "name": "recipe_escrow",
             "type": "CcbCampRecipeEscrowPage"
           },
           {
-            "line": 7132,
+            "line": 7143,
             "name": "recipe_recovery_required",
             "type": "boolean"
           },
           {
-            "line": 7126,
+            "line": 7137,
             "name": "recipe_work",
             "type": "CcbCampRecipeWorkSnapshot"
           },
           {
-            "line": 7133,
+            "line": 7144,
             "name": "reservation",
             "type": "CcbCampTaskReservation"
           },
           {
-            "line": 7138,
+            "line": 7149,
             "name": "reservation_active",
             "type": "boolean"
           },
           {
-            "line": 7125,
+            "line": 7136,
             "name": "resource_work",
             "type": "CcbCampResourceWorkDescriptor"
           },
           {
-            "line": 7135,
+            "line": 7146,
             "name": "started_at",
             "type": "TimePoint"
           },
           {
-            "line": 7134,
+            "line": 7145,
             "name": "state",
             "type": "CcbCampTaskState"
           },
           {
-            "line": 7117,
+            "line": 7128,
             "name": "task_id",
             "type": "integer"
           },
           {
-            "line": 7139,
+            "line": 7150,
             "name": "token",
             "type": "CampTaskToken"
           },
           {
-            "line": 7131,
+            "line": 7142,
             "name": "upgrade_applying_marker",
             "type": "integer"
           },
           {
-            "line": 7130,
+            "line": 7141,
             "name": "upgrade_commit_marker",
             "type": "integer"
           },
           {
-            "line": 7127,
+            "line": 7138,
             "name": "upgrade_work",
             "type": "CcbCampUpgradeWorkSnapshot"
           },
           {
-            "line": 7122,
+            "line": 7133,
             "name": "worker",
             "type": "GameHandle"
           }
@@ -2190,27 +2190,27 @@
       {
         "fields": [
           {
-            "line": 7013,
+            "line": 7024,
             "name": "generation",
             "type": "integer"
           },
           {
-            "line": 7012,
+            "line": 7023,
             "name": "kind",
             "type": "'camp_core'"
           },
           {
-            "line": 7016,
+            "line": 7027,
             "name": "mapgen_args",
             "type": "CcbCampUpgradeMapgenArguments"
           },
           {
-            "line": 7014,
+            "line": 7025,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 7015,
+            "line": 7026,
             "name": "terrain",
             "type": "string"
           }
@@ -2220,27 +2220,27 @@
       {
         "fields": [
           {
-            "line": 7044,
+            "line": 7055,
             "name": "generation",
             "type": "integer"
           },
           {
-            "line": 7043,
+            "line": 7054,
             "name": "kind",
             "type": "'camp_core'"
           },
           {
-            "line": 7047,
+            "line": 7058,
             "name": "mapgen_args",
             "type": "CcbCampUpgradeMapgenArguments"
           },
           {
-            "line": 7045,
+            "line": 7056,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 7046,
+            "line": 7057,
             "name": "terrain",
             "type": "string"
           }
@@ -2250,27 +2250,27 @@
       {
         "fields": [
           {
-            "line": 7020,
+            "line": 7031,
             "name": "expansion",
             "type": "CampExpansionToken"
           },
           {
-            "line": 7019,
+            "line": 7030,
             "name": "kind",
             "type": "'expansion'"
           },
           {
-            "line": 7023,
+            "line": 7034,
             "name": "mapgen_args",
             "type": "CcbCampUpgradeMapgenArguments"
           },
           {
-            "line": 7021,
+            "line": 7032,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 7022,
+            "line": 7033,
             "name": "terrain",
             "type": "string"
           }
@@ -2280,32 +2280,32 @@
       {
         "fields": [
           {
-            "line": 7052,
+            "line": 7063,
             "name": "expansion_generation",
             "type": "integer"
           },
           {
-            "line": 7051,
+            "line": 7062,
             "name": "expansion_id",
             "type": "integer"
           },
           {
-            "line": 7050,
+            "line": 7061,
             "name": "kind",
             "type": "'expansion'"
           },
           {
-            "line": 7055,
+            "line": 7066,
             "name": "mapgen_args",
             "type": "CcbCampUpgradeMapgenArguments"
           },
           {
-            "line": 7053,
+            "line": 7064,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 7054,
+            "line": 7065,
             "name": "terrain",
             "type": "string"
           }
@@ -2315,12 +2315,12 @@
       {
         "fields": [
           {
-            "line": 7006,
+            "line": 7017,
             "name": "type",
             "type": "'int'|'bool'|'string'"
           },
           {
-            "line": 7007,
+            "line": 7018,
             "name": "value",
             "type": "integer|boolean|string"
           }
@@ -2330,32 +2330,32 @@
       {
         "fields": [
           {
-            "line": 7029,
+            "line": 7040,
             "name": "blueprint_id",
             "type": "string"
           },
           {
-            "line": 7033,
+            "line": 7044,
             "name": "destination_holder",
             "type": "CcbCampRecipeHolder"
           },
           {
-            "line": 7031,
+            "line": 7042,
             "name": "duration_turns",
             "type": "integer"
           },
           {
-            "line": 7032,
+            "line": 7043,
             "name": "source_holders",
             "type": "CcbCampRecipeHolder[]"
           },
           {
-            "line": 7030,
+            "line": 7041,
             "name": "target",
             "type": "CcbCampUpgradeTarget"
           },
           {
-            "line": 7028,
+            "line": 7039,
             "name": "upgrade_id",
             "type": "GameId"
           }
@@ -2365,32 +2365,32 @@
       {
         "fields": [
           {
-            "line": 7061,
+            "line": 7072,
             "name": "blueprint_id",
             "type": "string"
           },
           {
-            "line": 7065,
+            "line": 7076,
             "name": "destination_holder",
             "type": "CcbCampRecipeHolderSnapshot"
           },
           {
-            "line": 7063,
+            "line": 7074,
             "name": "duration_turns",
             "type": "integer"
           },
           {
-            "line": 7064,
+            "line": 7075,
             "name": "source_holders",
             "type": "CcbCampRecipeHolderSnapshot[]"
           },
           {
-            "line": 7062,
+            "line": 7073,
             "name": "target",
             "type": "CcbCampUpgradeTargetSnapshot"
           },
           {
-            "line": 7060,
+            "line": 7071,
             "name": "upgrade_id",
             "type": "GameId"
           }
@@ -2400,27 +2400,27 @@
       {
         "fields": [
           {
-            "line": 7344,
+            "line": 7355,
             "name": "expansions",
             "type": "CcbCampExpansionsApi"
           },
           {
-            "line": 7341,
+            "line": 7352,
             "name": "food",
             "type": "CcbCampFoodApi"
           },
           {
-            "line": 7342,
+            "line": 7353,
             "name": "inventory",
             "type": "CcbCampInventoryApi"
           },
           {
-            "line": 7340,
+            "line": 7351,
             "name": "resources",
             "type": "CcbCampResourcesApi"
           },
           {
-            "line": 7343,
+            "line": 7354,
             "name": "tasks",
             "type": "CcbCampTasksApi"
           }
@@ -2450,67 +2450,67 @@
       {
         "fields": [
           {
-            "line": 10577,
+            "line": 10588,
             "name": "focus",
             "type": "integer"
           },
           {
-            "line": 10579,
+            "line": 10590,
             "name": "hunger",
             "type": "integer"
           },
           {
-            "line": 10573,
+            "line": 10584,
             "name": "moves",
             "type": "integer"
           },
           {
-            "line": 10569,
+            "line": 10580,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 10576,
+            "line": 10587,
             "name": "pain",
             "type": "integer"
           },
           {
-            "line": 10581,
+            "line": 10592,
             "name": "sleepiness",
             "type": "integer"
           },
           {
-            "line": 10578,
+            "line": 10589,
             "name": "speed",
             "type": "integer"
           },
           {
-            "line": 10574,
+            "line": 10585,
             "name": "stamina",
             "type": "integer"
           },
           {
-            "line": 10575,
+            "line": 10586,
             "name": "stamina_max",
             "type": "integer"
           },
           {
-            "line": 10580,
+            "line": 10591,
             "name": "thirst",
             "type": "integer"
           },
           {
-            "line": 10570,
+            "line": 10581,
             "name": "x",
             "type": "integer"
           },
           {
-            "line": 10571,
+            "line": 10582,
             "name": "y",
             "type": "integer"
           },
           {
-            "line": 10572,
+            "line": 10583,
             "name": "z",
             "type": "integer"
           }
@@ -2544,52 +2544,52 @@
       {
         "fields": [
           {
-            "line": 10603,
+            "line": 10614,
             "name": "attitude",
             "type": "string"
           },
           {
-            "line": 10604,
+            "line": 10615,
             "name": "dead",
             "type": "boolean"
           },
           {
-            "line": 10599,
+            "line": 10610,
             "name": "display_name",
             "type": "string"
           },
           {
-            "line": 10602,
+            "line": 10613,
             "name": "distance",
             "type": "integer"
           },
           {
-            "line": 10605,
+            "line": 10616,
             "name": "hp",
             "type": "integer"
           },
           {
-            "line": 10606,
+            "line": 10617,
             "name": "hp_max",
             "type": "integer"
           },
           {
-            "line": 10597,
+            "line": 10608,
             "name": "kind",
             "type": "'avatar'|'npc'|'monster'|'creature'"
           },
           {
-            "line": 10598,
+            "line": 10609,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 10600,
+            "line": 10611,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 10601,
+            "line": 10612,
             "name": "visible",
             "type": "boolean"
           }
@@ -2623,22 +2623,22 @@
       {
         "fields": [
           {
-            "line": 9911,
+            "line": 9922,
             "name": "body_part",
             "type": "GameId"
           },
           {
-            "line": 9914,
+            "line": 9925,
             "name": "force",
             "type": "boolean"
           },
           {
-            "line": 9913,
+            "line": 9924,
             "name": "intensity",
             "type": "integer"
           },
           {
-            "line": 9912,
+            "line": 9923,
             "name": "permanent",
             "type": "boolean"
           }
@@ -2648,22 +2648,22 @@
       {
         "fields": [
           {
-            "line": 10050,
+            "line": 10061,
             "name": "items",
             "type": "GameId[]"
           },
           {
-            "line": 10052,
+            "line": 10063,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 10051,
+            "line": 10062,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 10053,
+            "line": 10064,
             "name": "truncated",
             "type": "boolean"
           }
@@ -2673,12 +2673,12 @@
       {
         "fields": [
           {
-            "line": 10057,
+            "line": 10068,
             "name": "effects",
             "type": "CcbEffectRelatedIdPage"
           },
           {
-            "line": 10056,
+            "line": 10067,
             "name": "mutations",
             "type": "CcbEffectRelatedIdPage"
           }
@@ -2688,112 +2688,112 @@
       {
         "fields": [
           {
-            "line": 10081,
+            "line": 10092,
             "name": "blocks_effects",
             "type": "CcbEffectRelatedIdPage"
           },
           {
-            "line": 10079,
+            "line": 10090,
             "name": "body_part",
             "type": "GameId"
           },
           {
-            "line": 10062,
+            "line": 10073,
             "name": "description",
             "type": "string"
           },
           {
-            "line": 10066,
+            "line": 10077,
             "name": "duration",
             "type": "TimeDuration"
           },
           {
-            "line": 10076,
+            "line": 10087,
             "name": "duration_add_percent",
             "type": "integer"
           },
           {
-            "line": 10072,
+            "line": 10083,
             "name": "effective_intensity",
             "type": "integer"
           },
           {
-            "line": 10075,
+            "line": 10086,
             "name": "harmful_cough",
             "type": "boolean"
           },
           {
-            "line": 10060,
+            "line": 10071,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 10074,
+            "line": 10085,
             "name": "impairs_movement",
             "type": "boolean"
           },
           {
-            "line": 10069,
+            "line": 10080,
             "name": "intensity",
             "type": "integer"
           },
           {
-            "line": 10077,
+            "line": 10088,
             "name": "intensity_add",
             "type": "integer"
           },
           {
-            "line": 10078,
+            "line": 10089,
             "name": "intensity_duration",
             "type": "TimeDuration"
           },
           {
-            "line": 10067,
+            "line": 10078,
             "name": "maximum_duration",
             "type": "TimeDuration"
           },
           {
-            "line": 10071,
+            "line": 10082,
             "name": "maximum_effective_intensity",
             "type": "integer"
           },
           {
-            "line": 10070,
+            "line": 10081,
             "name": "maximum_intensity",
             "type": "integer"
           },
           {
-            "line": 10064,
+            "line": 10075,
             "name": "mod_source",
             "type": "string"
           },
           {
-            "line": 10061,
+            "line": 10072,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 10073,
+            "line": 10084,
             "name": "permanent",
             "type": "boolean"
           },
           {
-            "line": 10080,
+            "line": 10091,
             "name": "resisted_by",
             "type": "CcbEffectResistanceIds"
           },
           {
-            "line": 10063,
+            "line": 10074,
             "name": "short_description",
             "type": "string"
           },
           {
-            "line": 10068,
+            "line": 10079,
             "name": "start_time",
             "type": "TimePoint"
           },
           {
-            "line": 10065,
+            "line": 10076,
             "name": "uses_body_part_description",
             "type": "boolean"
           }
@@ -2803,7 +2803,7 @@
       {
         "fields": [
           {
-            "line": 10084,
+            "line": 10095,
             "name": "value",
             "type": "CcbEffectSnapshot"
           }
@@ -2821,22 +2821,22 @@
       {
         "fields": [
           {
-            "line": 9174,
+            "line": 9185,
             "name": "handle",
             "type": "GameHandle"
           },
           {
-            "line": 9175,
+            "line": 9186,
             "name": "item",
             "type": "table<string,"
           },
           {
-            "line": 9173,
+            "line": 9184,
             "name": "source_handle_stale",
             "type": "boolean"
           },
           {
-            "line": 9172,
+            "line": 9183,
             "name": "source_uid",
             "type": "integer"
           }
@@ -2846,7 +2846,7 @@
       {
         "fields": [
           {
-            "line": 9169,
+            "line": 9180,
             "name": "code",
             "type": "CcbEquipmentErrorCode"
           }
@@ -2856,12 +2856,12 @@
       {
         "fields": [
           {
-            "line": 9193,
+            "line": 9204,
             "name": "error",
             "type": "CcbEquipmentError"
           },
           {
-            "line": 9192,
+            "line": 9203,
             "name": "value",
             "type": "CcbEquipmentValue"
           }
@@ -2871,62 +2871,62 @@
       {
         "fields": [
           {
-            "line": 9178,
+            "line": 9189,
             "name": "accepted",
             "type": "true"
           },
           {
-            "line": 9179,
+            "line": 9190,
             "name": "changed",
             "type": "boolean"
           },
           {
-            "line": 9185,
+            "line": 9196,
             "name": "destination_holder",
             "type": "CcbItemHolder"
           },
           {
-            "line": 9188,
+            "line": 9199,
             "name": "displaced",
             "type": "CcbEquipmentDisplacedItem[]"
           },
           {
-            "line": 9189,
+            "line": 9200,
             "name": "displaced_count",
             "type": "integer"
           },
           {
-            "line": 9186,
+            "line": 9197,
             "name": "handle",
             "type": "GameHandle"
           },
           {
-            "line": 9187,
+            "line": 9198,
             "name": "item",
             "type": "table<string,"
           },
           {
-            "line": 9183,
+            "line": 9194,
             "name": "old_handle_stale",
             "type": "boolean"
           },
           {
-            "line": 9180,
+            "line": 9191,
             "name": "operation",
             "type": "CcbEquipmentOperation"
           },
           {
-            "line": 9182,
+            "line": 9193,
             "name": "source_handle_stale",
             "type": "boolean"
           },
           {
-            "line": 9184,
+            "line": 9195,
             "name": "source_holder",
             "type": "CcbItemHolder"
           },
           {
-            "line": 9181,
+            "line": 9192,
             "name": "source_uid",
             "type": "integer"
           }
@@ -2936,32 +2936,32 @@
       {
         "fields": [
           {
-            "line": 8737,
+            "line": 8748,
             "name": "has_more",
             "type": "boolean"
           },
           {
-            "line": 8732,
+            "line": 8743,
             "name": "items",
             "type": "CcbFactionSnapshot[]"
           },
           {
-            "line": 8734,
+            "line": 8745,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 8733,
+            "line": 8744,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 8736,
+            "line": 8747,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 8735,
+            "line": 8746,
             "name": "total",
             "type": "integer"
           }
@@ -2971,22 +2971,22 @@
       {
         "fields": [
           {
-            "line": 8712,
+            "line": 8723,
             "name": "consumes_food",
             "type": "boolean"
           },
           {
-            "line": 8714,
+            "line": 8725,
             "name": "limited_area_claim",
             "type": "boolean"
           },
           {
-            "line": 8713,
+            "line": 8724,
             "name": "lone_wolf",
             "type": "boolean"
           },
           {
-            "line": 8715,
+            "line": 8726,
             "name": "stealing",
             "type": "'ask'|'always'|'never'"
           }
@@ -3061,27 +3061,27 @@
       {
         "fields": [
           {
-            "line": 8697,
+            "line": 8708,
             "name": "likes",
             "type": "integer"
           },
           {
-            "line": 8700,
+            "line": 8711,
             "name": "ranking",
             "type": "string"
           },
           {
-            "line": 8701,
+            "line": 8712,
             "name": "respect",
             "type": "string"
           },
           {
-            "line": 8698,
+            "line": 8709,
             "name": "respects",
             "type": "integer"
           },
           {
-            "line": 8699,
+            "line": 8710,
             "name": "trusts",
             "type": "integer"
           }
@@ -3091,32 +3091,32 @@
       {
         "fields": [
           {
-            "line": 8709,
+            "line": 8720,
             "name": "combat_ability",
             "type": "string"
           },
           {
-            "line": 8707,
+            "line": 8718,
             "name": "food_kcal",
             "type": "integer"
           },
           {
-            "line": 8705,
+            "line": 8716,
             "name": "power",
             "type": "integer"
           },
           {
-            "line": 8704,
+            "line": 8715,
             "name": "size",
             "type": "integer"
           },
           {
-            "line": 8706,
+            "line": 8717,
             "name": "wealth",
             "type": "integer"
           },
           {
-            "line": 8708,
+            "line": 8719,
             "name": "wealth_description",
             "type": "string"
           }
@@ -3126,62 +3126,62 @@
       {
         "fields": [
           {
-            "line": 8726,
+            "line": 8737,
             "name": "currency",
             "type": "GameId"
           },
           {
-            "line": 8720,
+            "line": 8731,
             "name": "description",
             "type": "string"
           },
           {
-            "line": 8718,
+            "line": 8729,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 8722,
+            "line": 8733,
             "name": "known_by_player",
             "type": "boolean"
           },
           {
-            "line": 8728,
+            "line": 8739,
             "name": "members",
             "type": "integer"
           },
           {
-            "line": 8727,
+            "line": 8738,
             "name": "monster_faction",
             "type": "GameId"
           },
           {
-            "line": 8719,
+            "line": 8730,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 8725,
+            "line": 8736,
             "name": "policy",
             "type": "CcbFactionPolicy"
           },
           {
-            "line": 8729,
+            "line": 8740,
             "name": "relationship_targets",
             "type": "integer"
           },
           {
-            "line": 8723,
+            "line": 8734,
             "name": "reputation",
             "type": "CcbFactionReputation"
           },
           {
-            "line": 8724,
+            "line": 8735,
             "name": "resources",
             "type": "CcbFactionResources"
           },
           {
-            "line": 8721,
+            "line": 8732,
             "name": "summary",
             "type": "string"
           }
@@ -3254,17 +3254,17 @@
       {
         "fields": [
           {
-            "line": 8076,
+            "line": 8087,
             "name": "after",
             "type": "CcbHordeEntitySnapshot"
           },
           {
-            "line": 8075,
+            "line": 8086,
             "name": "before",
             "type": "CcbHordeEntitySnapshot"
           },
           {
-            "line": 8074,
+            "line": 8085,
             "name": "status",
             "type": "\"committed\""
           }
@@ -3274,47 +3274,47 @@
       {
         "fields": [
           {
-            "line": 8142,
+            "line": 8153,
             "name": "default_monster",
             "type": "GameId|nil"
           },
           {
-            "line": 8149,
+            "line": 8160,
             "name": "entries",
             "type": "CcbHordeDefinitionEntryPage"
           },
           {
-            "line": 8148,
+            "line": 8159,
             "name": "frequency_total",
             "type": "integer"
           },
           {
-            "line": 8141,
+            "line": 8152,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 8143,
+            "line": 8154,
             "name": "is_animal",
             "type": "boolean"
           },
           {
-            "line": 8145,
+            "line": 8156,
             "name": "new_monster_group",
             "type": "GameId|nil"
           },
           {
-            "line": 8144,
+            "line": 8155,
             "name": "replace_monster_group",
             "type": "boolean"
           },
           {
-            "line": 8146,
+            "line": 8157,
             "name": "replacement_time",
             "type": "TimeDuration"
           },
           {
-            "line": 8147,
+            "line": 8158,
             "name": "safe",
             "type": "boolean"
           }
@@ -3324,57 +3324,57 @@
       {
         "fields": [
           {
-            "line": 8122,
+            "line": 8133,
             "name": "conditions",
             "type": "CcbHordeStringPage"
           },
           {
-            "line": 8115,
+            "line": 8126,
             "name": "cost_multiplier",
             "type": "number"
           },
           {
-            "line": 8119,
+            "line": 8130,
             "name": "ends",
             "type": "TimeDuration"
           },
           {
-            "line": 8121,
+            "line": 8132,
             "name": "event",
             "type": "string"
           },
           {
-            "line": 8114,
+            "line": 8125,
             "name": "frequency",
             "type": "integer"
           },
           {
-            "line": 8113,
+            "line": 8124,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 8112,
+            "line": 8123,
             "name": "kind",
             "type": "\"group\"|\"monster\""
           },
           {
-            "line": 8120,
+            "line": 8131,
             "name": "lasts_forever",
             "type": "boolean"
           },
           {
-            "line": 8117,
+            "line": 8128,
             "name": "pack_maximum",
             "type": "integer"
           },
           {
-            "line": 8116,
+            "line": 8127,
             "name": "pack_minimum",
             "type": "integer"
           },
           {
-            "line": 8118,
+            "line": 8129,
             "name": "starts",
             "type": "TimeDuration"
           }
@@ -3384,32 +3384,32 @@
       {
         "fields": [
           {
-            "line": 8130,
+            "line": 8141,
             "name": "has_more",
             "type": "boolean"
           },
           {
-            "line": 8125,
+            "line": 8136,
             "name": "items",
             "type": "CcbHordeDefinitionEntry[]"
           },
           {
-            "line": 8128,
+            "line": 8139,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 8127,
+            "line": 8138,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 8129,
+            "line": 8140,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 8126,
+            "line": 8137,
             "name": "total",
             "type": "integer"
           }
@@ -3419,32 +3419,32 @@
       {
         "fields": [
           {
-            "line": 8138,
+            "line": 8149,
             "name": "has_more",
             "type": "boolean"
           },
           {
-            "line": 8133,
+            "line": 8144,
             "name": "items",
             "type": "CcbHordeDefinitionSummary[]"
           },
           {
-            "line": 8135,
+            "line": 8146,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 8134,
+            "line": 8145,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 8137,
+            "line": 8148,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 8136,
+            "line": 8147,
             "name": "total",
             "type": "integer"
           }
@@ -3454,27 +3454,27 @@
       {
         "fields": [
           {
-            "line": 8099,
+            "line": 8110,
             "name": "default_monster",
             "type": "GameId|nil"
           },
           {
-            "line": 8100,
+            "line": 8111,
             "name": "entries",
             "type": "integer"
           },
           {
-            "line": 8098,
+            "line": 8109,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 8101,
+            "line": 8112,
             "name": "is_animal",
             "type": "boolean"
           },
           {
-            "line": 8102,
+            "line": 8113,
             "name": "safe",
             "type": "boolean"
           }
@@ -3484,7 +3484,7 @@
       {
         "fields": [
           {
-            "line": 8079,
+            "line": 8090,
             "name": "status",
             "type": "\"committed\""
           }
@@ -3494,57 +3494,57 @@
       {
         "fields": [
           {
-            "line": 8014,
+            "line": 8025,
             "name": "existing_only",
             "type": "boolean"
           },
           {
-            "line": 8013,
+            "line": 8024,
             "name": "existing_overmaps",
             "type": "integer"
           },
           {
-            "line": 8015,
+            "line": 8026,
             "name": "flavors",
             "type": "integer"
           },
           {
-            "line": 8010,
+            "line": 8021,
             "name": "has_more",
             "type": "boolean"
           },
           {
-            "line": 8005,
+            "line": 8016,
             "name": "items",
             "type": "CcbHordeEntitySnapshot[]"
           },
           {
-            "line": 8008,
+            "line": 8019,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 8007,
+            "line": 8018,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 8011,
+            "line": 8022,
             "name": "radius",
             "type": "integer"
           },
           {
-            "line": 8012,
+            "line": 8023,
             "name": "radius_z",
             "type": "integer"
           },
           {
-            "line": 8009,
+            "line": 8020,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 8006,
+            "line": 8017,
             "name": "total",
             "type": "integer"
           }
@@ -3554,22 +3554,22 @@
       {
         "fields": [
           {
-            "line": 7962,
+            "line": 7973,
             "name": "flavors",
             "type": "string[]"
           },
           {
-            "line": 7963,
+            "line": 7974,
             "name": "monster",
             "type": "GameId"
           },
           {
-            "line": 7960,
+            "line": 7971,
             "name": "radius",
             "type": "integer"
           },
           {
-            "line": 7961,
+            "line": 7972,
             "name": "radius_z",
             "type": "integer"
           }
@@ -3579,12 +3579,12 @@
       {
         "fields": [
           {
-            "line": 8091,
+            "line": 8102,
             "name": "removed",
             "type": "boolean"
           },
           {
-            "line": 8090,
+            "line": 8101,
             "name": "status",
             "type": "\"committed\""
           }
@@ -3594,62 +3594,62 @@
       {
         "fields": [
           {
-            "line": 7997,
+            "line": 8008,
             "name": "active",
             "type": "boolean"
           },
           {
-            "line": 7999,
+            "line": 8010,
             "name": "destination",
             "type": "TripointCoord"
           },
           {
-            "line": 7996,
+            "line": 8007,
             "name": "flavor",
             "type": "\"active\"|\"idle\"|\"dormant\"|\"immobile\""
           },
           {
-            "line": 7998,
+            "line": 8009,
             "name": "heavy",
             "type": "boolean"
           },
           {
-            "line": 8002,
+            "line": 8013,
             "name": "last_processed",
             "type": "TimePoint"
           },
           {
-            "line": 7994,
+            "line": 8005,
             "name": "monster",
             "type": "GameId"
           },
           {
-            "line": 8001,
+            "line": 8012,
             "name": "moves",
             "type": "integer"
           },
           {
-            "line": 7995,
+            "line": 8006,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 7993,
+            "line": 8004,
             "name": "overmap_position",
             "type": "TripointCoord"
           },
           {
-            "line": 7992,
+            "line": 8003,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 7991,
+            "line": 8002,
             "name": "token",
             "type": "HordeEntityToken"
           },
           {
-            "line": 8000,
+            "line": 8011,
             "name": "tracking_intensity",
             "type": "integer"
           }
@@ -3659,7 +3659,7 @@
       {
         "fields": [
           {
-            "line": 8087,
+            "line": 8098,
             "name": "status",
             "type": "\"committed\""
           }
@@ -3669,47 +3669,47 @@
       {
         "fields": [
           {
-            "line": 7977,
+            "line": 7988,
             "name": "behavior",
             "type": "\"none\"|\"city\"|\"roam\"|\"nemesis\""
           },
           {
-            "line": 7975,
+            "line": 7986,
             "name": "dying",
             "type": "boolean"
           },
           {
-            "line": 7971,
+            "line": 7982,
             "name": "group",
             "type": "GameId"
           },
           {
-            "line": 7976,
+            "line": 7987,
             "name": "horde",
             "type": "boolean"
           },
           {
-            "line": 7974,
+            "line": 7985,
             "name": "interest",
             "type": "integer"
           },
           {
-            "line": 7979,
+            "line": 7990,
             "name": "nemesis_target",
             "type": "TripointCoord"
           },
           {
-            "line": 7973,
+            "line": 7984,
             "name": "population",
             "type": "integer"
           },
           {
-            "line": 7972,
+            "line": 7983,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 7978,
+            "line": 7989,
             "name": "target",
             "type": "TripointCoord"
           }
@@ -3719,57 +3719,57 @@
       {
         "fields": [
           {
-            "line": 8058,
+            "line": 8069,
             "name": "existing_only",
             "type": "boolean"
           },
           {
-            "line": 8057,
+            "line": 8068,
             "name": "existing_overmaps",
             "type": "integer"
           },
           {
-            "line": 8053,
+            "line": 8064,
             "name": "has_more",
             "type": "boolean"
           },
           {
-            "line": 8056,
+            "line": 8067,
             "name": "horde_only",
             "type": "boolean"
           },
           {
-            "line": 8048,
+            "line": 8059,
             "name": "items",
             "type": "CcbHordeLegacyGroupSnapshot[]"
           },
           {
-            "line": 8050,
+            "line": 8061,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 8049,
+            "line": 8060,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 8054,
+            "line": 8065,
             "name": "radius",
             "type": "integer"
           },
           {
-            "line": 8055,
+            "line": 8066,
             "name": "radius_z",
             "type": "integer"
           },
           {
-            "line": 8052,
+            "line": 8063,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 8051,
+            "line": 8062,
             "name": "total",
             "type": "integer"
           }
@@ -3779,12 +3779,12 @@
       {
         "fields": [
           {
-            "line": 8095,
+            "line": 8106,
             "name": "removed",
             "type": "boolean"
           },
           {
-            "line": 8094,
+            "line": 8105,
             "name": "status",
             "type": "\"committed\""
           }
@@ -3794,82 +3794,82 @@
       {
         "fields": [
           {
-            "line": 8044,
+            "line": 8055,
             "name": "average_speed",
             "type": "number"
           },
           {
-            "line": 8041,
+            "line": 8052,
             "name": "behavior",
             "type": "\"none\"|\"city\"|\"roam\"|\"nemesis\""
           },
           {
-            "line": 8039,
+            "line": 8050,
             "name": "dying",
             "type": "boolean"
           },
           {
-            "line": 8042,
+            "line": 8053,
             "name": "empty",
             "type": "boolean"
           },
           {
-            "line": 8031,
+            "line": 8042,
             "name": "group",
             "type": "GameId"
           },
           {
-            "line": 8040,
+            "line": 8051,
             "name": "horde",
             "type": "boolean"
           },
           {
-            "line": 8038,
+            "line": 8049,
             "name": "interest",
             "type": "integer"
           },
           {
-            "line": 8045,
+            "line": 8056,
             "name": "monsters",
             "type": "CcbHordeLegacyMonsterPage"
           },
           {
-            "line": 8035,
+            "line": 8046,
             "name": "nemesis_target",
             "type": "TripointCoord"
           },
           {
-            "line": 8033,
+            "line": 8044,
             "name": "overmap_position",
             "type": "TripointCoord"
           },
           {
-            "line": 8036,
+            "line": 8047,
             "name": "population",
             "type": "integer"
           },
           {
-            "line": 8032,
+            "line": 8043,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 8043,
+            "line": 8054,
             "name": "safe",
             "type": "boolean"
           },
           {
-            "line": 8034,
+            "line": 8045,
             "name": "target",
             "type": "TripointCoord"
           },
           {
-            "line": 8030,
+            "line": 8041,
             "name": "token",
             "type": "LegacyHordeToken"
           },
           {
-            "line": 8037,
+            "line": 8048,
             "name": "tracked_monsters",
             "type": "integer"
           }
@@ -3879,37 +3879,37 @@
       {
         "fields": [
           {
-            "line": 7986,
+            "line": 7997,
             "name": "behavior",
             "type": "\"none\"|\"city\"|\"roam\"|\"nemesis\""
           },
           {
-            "line": 7984,
+            "line": 7995,
             "name": "dying",
             "type": "boolean"
           },
           {
-            "line": 7985,
+            "line": 7996,
             "name": "horde",
             "type": "boolean"
           },
           {
-            "line": 7983,
+            "line": 7994,
             "name": "interest",
             "type": "integer"
           },
           {
-            "line": 7988,
+            "line": 7999,
             "name": "nemesis_target",
             "type": "TripointCoord"
           },
           {
-            "line": 7982,
+            "line": 7993,
             "name": "population",
             "type": "integer"
           },
           {
-            "line": 7987,
+            "line": 7998,
             "name": "target",
             "type": "TripointCoord"
           }
@@ -3919,17 +3919,17 @@
       {
         "fields": [
           {
-            "line": 8084,
+            "line": 8095,
             "name": "after",
             "type": "CcbHordeLegacyGroupSnapshot"
           },
           {
-            "line": 8083,
+            "line": 8094,
             "name": "before",
             "type": "CcbHordeLegacyGroupSnapshot"
           },
           {
-            "line": 8082,
+            "line": 8093,
             "name": "status",
             "type": "\"committed\""
           }
@@ -3939,27 +3939,27 @@
       {
         "fields": [
           {
-            "line": 8023,
+            "line": 8034,
             "name": "items",
             "type": "CcbHordeLegacyMonsterSnapshot[]"
           },
           {
-            "line": 8025,
+            "line": 8036,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 8026,
+            "line": 8037,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 8024,
+            "line": 8035,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 8027,
+            "line": 8038,
             "name": "truncated",
             "type": "boolean"
           }
@@ -3969,17 +3969,17 @@
       {
         "fields": [
           {
-            "line": 8018,
+            "line": 8029,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 8019,
+            "line": 8030,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 8020,
+            "line": 8031,
             "name": "position",
             "type": "TripointCoord"
           }
@@ -3989,17 +3989,17 @@
       {
         "fields": [
           {
-            "line": 7968,
+            "line": 7979,
             "name": "horde_only",
             "type": "boolean"
           },
           {
-            "line": 7966,
+            "line": 7977,
             "name": "radius",
             "type": "integer"
           },
           {
-            "line": 7967,
+            "line": 7978,
             "name": "radius_z",
             "type": "integer"
           }
@@ -4009,42 +4009,42 @@
       {
         "fields": [
           {
-            "line": 7931,
+            "line": 7942,
             "name": "existing_only",
             "type": "boolean"
           },
           {
-            "line": 7930,
+            "line": 7941,
             "name": "flavors",
             "type": "string[]"
           },
           {
-            "line": 7929,
+            "line": 7940,
             "name": "maximum_legacy_population",
             "type": "integer"
           },
           {
-            "line": 7926,
+            "line": 7937,
             "name": "maximum_limit",
             "type": "integer"
           },
           {
-            "line": 7927,
+            "line": 7938,
             "name": "maximum_offset",
             "type": "integer"
           },
           {
-            "line": 7924,
+            "line": 7935,
             "name": "maximum_radius",
             "type": "integer"
           },
           {
-            "line": 7925,
+            "line": 7936,
             "name": "maximum_radius_z",
             "type": "integer"
           },
           {
-            "line": 7928,
+            "line": 7939,
             "name": "maximum_tracking_intensity",
             "type": "integer"
           }
@@ -4054,42 +4054,42 @@
       {
         "fields": [
           {
-            "line": 8153,
+            "line": 8164,
             "name": "group",
             "type": "GameId"
           },
           {
-            "line": 8159,
+            "line": 8170,
             "name": "has_more",
             "type": "boolean"
           },
           {
-            "line": 8152,
+            "line": 8163,
             "name": "items",
             "type": "GameId[]"
           },
           {
-            "line": 8156,
+            "line": 8167,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 8155,
+            "line": 8166,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 8154,
+            "line": 8165,
             "name": "recursive",
             "type": "boolean"
           },
           {
-            "line": 8158,
+            "line": 8169,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 8157,
+            "line": 8168,
             "name": "total",
             "type": "integer"
           }
@@ -4099,12 +4099,12 @@
       {
         "fields": [
           {
-            "line": 7957,
+            "line": 7968,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7956,
+            "line": 7967,
             "name": "offset",
             "type": "integer"
           }
@@ -4114,27 +4114,27 @@
       {
         "fields": [
           {
-            "line": 8105,
+            "line": 8116,
             "name": "items",
             "type": "string[]"
           },
           {
-            "line": 8107,
+            "line": 8118,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 8108,
+            "line": 8119,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 8106,
+            "line": 8117,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 8109,
+            "line": 8120,
             "name": "truncated",
             "type": "boolean"
           }
@@ -4144,57 +4144,57 @@
       {
         "fields": [
           {
-            "line": 8063,
+            "line": 8074,
             "name": "active",
             "type": "integer"
           },
           {
-            "line": 8065,
+            "line": 8076,
             "name": "dormant",
             "type": "integer"
           },
           {
-            "line": 8062,
+            "line": 8073,
             "name": "entities",
             "type": "integer"
           },
           {
-            "line": 8069,
+            "line": 8080,
             "name": "estimated_size",
             "type": "integer"
           },
           {
-            "line": 8071,
+            "line": 8082,
             "name": "existing_only",
             "type": "boolean"
           },
           {
-            "line": 8070,
+            "line": 8081,
             "name": "has_horde",
             "type": "boolean"
           },
           {
-            "line": 8064,
+            "line": 8075,
             "name": "idle",
             "type": "integer"
           },
           {
-            "line": 8066,
+            "line": 8077,
             "name": "immobile",
             "type": "integer"
           },
           {
-            "line": 8067,
+            "line": 8078,
             "name": "legacy_hordes",
             "type": "integer"
           },
           {
-            "line": 8068,
+            "line": 8079,
             "name": "legacy_population",
             "type": "integer"
           },
           {
-            "line": 8061,
+            "line": 8072,
             "name": "position",
             "type": "TripointCoord"
           }
@@ -4242,7 +4242,7 @@
       {
         "fields": [
           {
-            "line": 8861,
+            "line": 8872,
             "name": "target",
             "type": "TripointCoord"
           }
@@ -4252,32 +4252,32 @@
       {
         "fields": [
           {
-            "line": 8864,
+            "line": 8875,
             "name": "accepted",
             "type": "boolean"
           },
           {
-            "line": 8865,
+            "line": 8876,
             "name": "destroyed",
             "type": "boolean"
           },
           {
-            "line": 8869,
+            "line": 8880,
             "name": "handle",
             "type": "GameHandle"
           },
           {
-            "line": 8868,
+            "line": 8879,
             "name": "item",
             "type": "table<string,"
           },
           {
-            "line": 8867,
+            "line": 8878,
             "name": "method",
             "type": "string"
           },
           {
-            "line": 8866,
+            "line": 8877,
             "name": "stale",
             "type": "boolean"
           }
@@ -4287,22 +4287,22 @@
       {
         "fields": [
           {
-            "line": 8875,
+            "line": 8886,
             "name": "activity",
             "type": "table<string,"
           },
           {
-            "line": 8874,
+            "line": 8885,
             "name": "input_handle_retired",
             "type": "boolean"
           },
           {
-            "line": 8873,
+            "line": 8884,
             "name": "item_uid",
             "type": "integer"
           },
           {
-            "line": 8872,
+            "line": 8883,
             "name": "quantity",
             "type": "integer"
           }
@@ -4316,12 +4316,12 @@
       {
         "fields": [
           {
-            "line": 8907,
+            "line": 8918,
             "name": "count",
             "type": "integer"
           },
           {
-            "line": 8906,
+            "line": 8917,
             "name": "items",
             "type": "CcbItemCategorySpawnRateResult[]"
           }
@@ -4331,12 +4331,12 @@
       {
         "fields": [
           {
-            "line": 8896,
+            "line": 8907,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 8897,
+            "line": 8908,
             "name": "spawn_rate",
             "type": "number"
           }
@@ -4346,22 +4346,22 @@
       {
         "fields": [
           {
-            "line": 8902,
+            "line": 8913,
             "name": "after",
             "type": "number"
           },
           {
-            "line": 8901,
+            "line": 8912,
             "name": "before",
             "type": "number"
           },
           {
-            "line": 8903,
+            "line": 8914,
             "name": "changed",
             "type": "boolean"
           },
           {
-            "line": 8900,
+            "line": 8911,
             "name": "id",
             "type": "GameId"
           }
@@ -4371,17 +4371,17 @@
       {
         "fields": [
           {
-            "line": 8889,
+            "line": 8900,
             "name": "force",
             "type": "boolean"
           },
           {
-            "line": 8891,
+            "line": 8902,
             "name": "holder",
             "type": "GameHandle"
           },
           {
-            "line": 8890,
+            "line": 8901,
             "name": "message",
             "type": "boolean"
           }
@@ -4391,42 +4391,42 @@
       {
         "fields": [
           {
-            "line": 8808,
+            "line": 8819,
             "name": "character",
             "type": "GameHandle"
           },
           {
-            "line": 8811,
+            "line": 8822,
             "name": "container",
             "type": "GameHandle"
           },
           {
-            "line": 8807,
+            "line": 8818,
             "name": "kind",
             "type": "'character'|'map_tile'|'container_pocket'|'vehicle_cargo'"
           },
           {
-            "line": 8814,
+            "line": 8825,
             "name": "part",
             "type": "GameHandle"
           },
           {
-            "line": 8812,
+            "line": 8823,
             "name": "pocket_index",
             "type": "integer"
           },
           {
-            "line": 8809,
+            "line": 8820,
             "name": "slot",
             "type": "'inventory'|'worn'|'wielded'"
           },
           {
-            "line": 8810,
+            "line": 8821,
             "name": "tile",
             "type": "MapTileToken"
           },
           {
-            "line": 8813,
+            "line": 8824,
             "name": "vehicle",
             "type": "GameHandle"
           }
@@ -4436,37 +4436,37 @@
       {
         "fields": [
           {
-            "line": 8798,
+            "line": 8809,
             "name": "continuation_id",
             "type": "integer"
           },
           {
-            "line": 8799,
+            "line": 8810,
             "name": "holder",
             "type": "CcbItemHolder"
           },
           {
-            "line": 8801,
+            "line": 8812,
             "name": "max_depth",
             "type": "integer"
           },
           {
-            "line": 8800,
+            "line": 8811,
             "name": "page_size",
             "type": "integer"
           },
           {
-            "line": 8804,
+            "line": 8815,
             "name": "reason",
             "type": "'page'|'node_budget'"
           },
           {
-            "line": 8802,
+            "line": 8813,
             "name": "recursive",
             "type": "boolean"
           },
           {
-            "line": 8803,
+            "line": 8814,
             "name": "same_runtime_world_holder",
             "type": "boolean"
           }
@@ -4476,32 +4476,32 @@
       {
         "fields": [
           {
-            "line": 8820,
+            "line": 8831,
             "name": "depth",
             "type": "integer"
           },
           {
-            "line": 8817,
+            "line": 8828,
             "name": "handle",
             "type": "GameHandle"
           },
           {
-            "line": 8819,
+            "line": 8830,
             "name": "holder",
             "type": "CcbItemHolder"
           },
           {
-            "line": 8822,
+            "line": 8833,
             "name": "parent_uid",
             "type": "integer"
           },
           {
-            "line": 8818,
+            "line": 8829,
             "name": "snapshot",
             "type": "table<string,"
           },
           {
-            "line": 8821,
+            "line": 8832,
             "name": "uid",
             "type": "integer"
           }
@@ -4511,57 +4511,57 @@
       {
         "fields": [
           {
-            "line": 8829,
+            "line": 8840,
             "name": "complete",
             "type": "boolean"
           },
           {
-            "line": 8834,
+            "line": 8845,
             "name": "continuation",
             "type": "CcbItemPageContinuation"
           },
           {
-            "line": 8826,
+            "line": 8837,
             "name": "holder",
             "type": "CcbItemHolder"
           },
           {
-            "line": 8825,
+            "line": 8836,
             "name": "items",
             "type": "CcbItemPageEntry[]"
           },
           {
-            "line": 8832,
+            "line": 8843,
             "name": "max_depth",
             "type": "integer"
           },
           {
-            "line": 8835,
+            "line": 8846,
             "name": "next",
             "type": "CcbItemPageContinuation"
           },
           {
-            "line": 8827,
+            "line": 8838,
             "name": "page_size",
             "type": "integer"
           },
           {
-            "line": 8833,
+            "line": 8844,
             "name": "recursive",
             "type": "boolean"
           },
           {
-            "line": 8828,
+            "line": 8839,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 8831,
+            "line": 8842,
             "name": "stop_reason",
             "type": "'empty'|'complete'|'page'|'node_budget'|'max_depth'|'cycle'|'repeated_item'|'invalid_pocket'|'stale_cursor'"
           },
           {
-            "line": 8830,
+            "line": 8841,
             "name": "truncated",
             "type": "boolean"
           }
@@ -4571,47 +4571,47 @@
       {
         "fields": [
           {
-            "line": 8878,
+            "line": 8889,
             "name": "accepted",
             "type": "boolean"
           },
           {
-            "line": 8879,
+            "line": 8890,
             "name": "changed",
             "type": "boolean"
           },
           {
-            "line": 8883,
+            "line": 8894,
             "name": "handle",
             "type": "GameHandle"
           },
           {
-            "line": 8885,
+            "line": 8896,
             "name": "holder",
             "type": "CcbItemHolder"
           },
           {
-            "line": 8886,
+            "line": 8897,
             "name": "item",
             "type": "table<string,"
           },
           {
-            "line": 8882,
+            "line": 8893,
             "name": "old_handle_stale",
             "type": "boolean"
           },
           {
-            "line": 8880,
+            "line": 8891,
             "name": "quantity",
             "type": "integer"
           },
           {
-            "line": 8881,
+            "line": 8892,
             "name": "source_handle_stale",
             "type": "boolean"
           },
           {
-            "line": 8884,
+            "line": 8895,
             "name": "source_holder",
             "type": "CcbItemHolder"
           }
@@ -4621,17 +4621,17 @@
       {
         "fields": [
           {
-            "line": 8850,
+            "line": 8861,
             "name": "active",
             "type": "boolean"
           },
           {
-            "line": 8851,
+            "line": 8862,
             "name": "browsed",
             "type": "boolean"
           },
           {
-            "line": 8849,
+            "line": 8860,
             "name": "carrier",
             "type": "GameHandle"
           }
@@ -4641,27 +4641,27 @@
       {
         "fields": [
           {
-            "line": 8855,
+            "line": 8866,
             "name": "after",
             "type": "table<string,"
           },
           {
-            "line": 8854,
+            "line": 8865,
             "name": "before",
             "type": "table<string,"
           },
           {
-            "line": 8856,
+            "line": 8867,
             "name": "changed",
             "type": "boolean"
           },
           {
-            "line": 8858,
+            "line": 8869,
             "name": "handle",
             "type": "GameHandle"
           },
           {
-            "line": 8857,
+            "line": 8868,
             "name": "old_handle_stale",
             "type": "boolean"
           }
@@ -4671,47 +4671,47 @@
       {
         "fields": [
           {
-            "line": 8843,
+            "line": 8854,
             "name": "active",
             "type": "boolean"
           },
           {
-            "line": 8844,
+            "line": 8855,
             "name": "browsed",
             "type": "boolean"
           },
           {
-            "line": 8841,
+            "line": 8852,
             "name": "burnt",
             "type": "integer"
           },
           {
-            "line": 8838,
+            "line": 8849,
             "name": "charges",
             "type": "integer"
           },
           {
-            "line": 8839,
+            "line": 8850,
             "name": "damage",
             "type": "integer"
           },
           {
-            "line": 8840,
+            "line": 8851,
             "name": "degradation",
             "type": "integer"
           },
           {
-            "line": 8842,
+            "line": 8853,
             "name": "favorite",
             "type": "boolean"
           },
           {
-            "line": 8845,
+            "line": 8856,
             "name": "relative_rot",
             "type": "number"
           },
           {
-            "line": 8846,
+            "line": 8857,
             "name": "rot",
             "type": "TimeDuration"
           }
@@ -4898,7 +4898,7 @@
       {
         "fields": [
           {
-            "line": 6865,
+            "line": 6876,
             "name": "cancel_on_collision",
             "type": "true"
           }
@@ -4908,32 +4908,32 @@
       {
         "fields": [
           {
-            "line": 6852,
+            "line": 6863,
             "name": "code",
             "type": "string"
           },
           {
-            "line": 6854,
+            "line": 6865,
             "name": "footprint",
             "type": "MapgenTransactionFootprint"
           },
           {
-            "line": 6853,
+            "line": 6864,
             "name": "message",
             "type": "string"
           },
           {
-            "line": 6851,
+            "line": 6862,
             "name": "state",
             "type": "'rejected'|'rolled_back'|'rollback_failed'"
           },
           {
-            "line": 6855,
+            "line": 6866,
             "name": "target",
             "type": "OvermapTileToken"
           },
           {
-            "line": 6856,
+            "line": 6867,
             "name": "update",
             "type": "MapgenUpdateToken"
           }
@@ -4943,12 +4943,12 @@
       {
         "fields": [
           {
-            "line": 6860,
+            "line": 6871,
             "name": "error",
             "type": "CcbMapgenTransactionError"
           },
           {
-            "line": 6859,
+            "line": 6870,
             "name": "value",
             "type": "MapgenTransactionResult"
           }
@@ -4958,47 +4958,47 @@
       {
         "fields": [
           {
-            "line": 8614,
+            "line": 8625,
             "name": "abandoned",
             "type": "CcbMissionSnapshot"
           },
           {
-            "line": 8612,
+            "line": 8623,
             "name": "after",
             "type": "CcbMissionSnapshot"
           },
           {
-            "line": 8611,
+            "line": 8622,
             "name": "before",
             "type": "CcbMissionSnapshot"
           },
           {
-            "line": 8613,
+            "line": 8624,
             "name": "cancelled",
             "type": "CcbMissionSnapshot"
           },
           {
-            "line": 8617,
+            "line": 8628,
             "name": "changed",
             "type": "boolean"
           },
           {
-            "line": 8616,
+            "line": 8627,
             "name": "cleared",
             "type": "boolean"
           },
           {
-            "line": 8619,
+            "line": 8630,
             "name": "forced",
             "type": "boolean"
           },
           {
-            "line": 8615,
+            "line": 8626,
             "name": "removed",
             "type": "boolean"
           },
           {
-            "line": 8618,
+            "line": 8629,
             "name": "step",
             "type": "integer"
           }
@@ -5008,42 +5008,42 @@
       {
         "fields": [
           {
-            "line": 8606,
+            "line": 8617,
             "name": "has_more",
             "type": "boolean"
           },
           {
-            "line": 8601,
+            "line": 8612,
             "name": "items",
             "type": "CcbMissionSnapshot[]"
           },
           {
-            "line": 8604,
+            "line": 8615,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 8603,
+            "line": 8614,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 8607,
+            "line": 8618,
             "name": "owner",
             "type": "GameHandle"
           },
           {
-            "line": 8605,
+            "line": 8616,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 8608,
+            "line": 8619,
             "name": "status",
             "type": "'all'|'reserved'|'active'|'success'|'failure'"
           },
           {
-            "line": 8602,
+            "line": 8613,
             "name": "total",
             "type": "integer"
           }
@@ -5073,107 +5073,107 @@
       {
         "fields": [
           {
-            "line": 8584,
+            "line": 8595,
             "name": "assigned",
             "type": "boolean"
           },
           {
-            "line": 8596,
+            "line": 8607,
             "name": "assigned_player_id",
             "type": "integer"
           },
           {
-            "line": 8589,
+            "line": 8600,
             "name": "deadline",
             "type": "TimePoint"
           },
           {
-            "line": 8582,
+            "line": 8593,
             "name": "description",
             "type": "string"
           },
           {
-            "line": 8586,
+            "line": 8597,
             "name": "failed",
             "type": "boolean"
           },
           {
-            "line": 8592,
+            "line": 8603,
             "name": "follow_up",
             "type": "GameId"
           },
           {
-            "line": 8588,
+            "line": 8599,
             "name": "has_deadline",
             "type": "boolean"
           },
           {
-            "line": 8598,
+            "line": 8609,
             "name": "has_generic_rewards",
             "type": "boolean"
           },
           {
-            "line": 8590,
+            "line": 8601,
             "name": "has_target",
             "type": "boolean"
           },
           {
-            "line": 8580,
+            "line": 8591,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 8585,
+            "line": 8596,
             "name": "in_progress",
             "type": "boolean"
           },
           {
-            "line": 8594,
+            "line": 8605,
             "name": "item",
             "type": "GameId"
           },
           {
-            "line": 8597,
+            "line": 8608,
             "name": "likely_rewards",
             "type": "table"
           },
           {
-            "line": 8581,
+            "line": 8592,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 8595,
+            "line": 8606,
             "name": "npc_id",
             "type": "integer"
           },
           {
-            "line": 8587,
+            "line": 8598,
             "name": "selected",
             "type": "boolean"
           },
           {
-            "line": 8583,
+            "line": 8594,
             "name": "status",
             "type": "'reserved'|'active'|'success'|'failure'"
           },
           {
-            "line": 8591,
+            "line": 8602,
             "name": "target",
             "type": "TripointCoord"
           },
           {
-            "line": 8578,
+            "line": 8589,
             "name": "token",
             "type": "MissionToken"
           },
           {
-            "line": 8579,
+            "line": 8590,
             "name": "uid",
             "type": "integer"
           },
           {
-            "line": 8593,
+            "line": 8604,
             "name": "value",
             "type": "integer"
           }
@@ -5187,17 +5187,17 @@
       {
         "fields": [
           {
-            "line": 9919,
+            "line": 9930,
             "name": "capped",
             "type": "boolean"
           },
           {
-            "line": 9918,
+            "line": 9929,
             "name": "decay_start",
             "type": "TimeDuration"
           },
           {
-            "line": 9917,
+            "line": 9928,
             "name": "duration",
             "type": "TimeDuration"
           }
@@ -5211,22 +5211,22 @@
       {
         "fields": [
           {
-            "line": 10585,
+            "line": 10596,
             "name": "count",
             "type": "integer"
           },
           {
-            "line": 10586,
+            "line": 10597,
             "name": "current_id",
             "type": "string"
           },
           {
-            "line": 10587,
+            "line": 10598,
             "name": "desired_id",
             "type": "string"
           },
           {
-            "line": 10584,
+            "line": 10595,
             "name": "items",
             "type": "table"
           }
@@ -5236,17 +5236,17 @@
       {
         "fields": [
           {
-            "line": 9907,
+            "line": 9918,
             "name": "removed",
             "type": "GameId[]"
           },
           {
-            "line": 9908,
+            "line": 9919,
             "name": "removed_count",
             "type": "integer"
           },
           {
-            "line": 9906,
+            "line": 9917,
             "name": "type",
             "type": "string"
           }
@@ -5264,17 +5264,17 @@
       {
         "fields": [
           {
-            "line": 9419,
+            "line": 9430,
             "name": "completed",
             "type": "boolean"
           },
           {
-            "line": 9418,
+            "line": 9429,
             "name": "started",
             "type": "boolean"
           },
           {
-            "line": 9417,
+            "line": 9428,
             "name": "status",
             "type": "CcbNpcDialogueStatus"
           }
@@ -5292,42 +5292,42 @@
       {
         "fields": [
           {
-            "line": 9308,
+            "line": 9319,
             "name": "action",
             "type": "'assign'|'success'|'failure'|'clear'|'reward'"
           },
           {
-            "line": 9313,
+            "line": 9324,
             "name": "after",
             "type": "CcbNpcMissionsState"
           },
           {
-            "line": 9312,
+            "line": 9323,
             "name": "before",
             "type": "CcbNpcMissionsState"
           },
           {
-            "line": 9310,
+            "line": 9321,
             "name": "forced",
             "type": "boolean"
           },
           {
-            "line": 9311,
+            "line": 9322,
             "name": "owed_delta",
             "type": "integer"
           },
           {
-            "line": 9309,
+            "line": 9320,
             "name": "owner",
             "type": "GameHandle"
           },
           {
-            "line": 9315,
+            "line": 9326,
             "name": "provider_after",
             "type": "CcbNpcProviderState"
           },
           {
-            "line": 9314,
+            "line": 9325,
             "name": "provider_before",
             "type": "CcbNpcProviderState"
           }
@@ -5337,22 +5337,22 @@
       {
         "fields": [
           {
-            "line": 9305,
+            "line": 9316,
             "name": "after",
             "type": "CcbNpcMissionsState"
           },
           {
-            "line": 9304,
+            "line": 9315,
             "name": "before",
             "type": "CcbNpcMissionsState"
           },
           {
-            "line": 9302,
+            "line": 9313,
             "name": "mission",
             "type": "CcbNpcMissionSnapshot"
           },
           {
-            "line": 9303,
+            "line": 9314,
             "name": "owner",
             "type": "GameHandle"
           }
@@ -5362,17 +5362,17 @@
       {
         "fields": [
           {
-            "line": 9299,
+            "line": 9310,
             "name": "after",
             "type": "CcbNpcMissionsState"
           },
           {
-            "line": 9298,
+            "line": 9309,
             "name": "before",
             "type": "CcbNpcMissionsState"
           },
           {
-            "line": 9297,
+            "line": 9308,
             "name": "mission",
             "type": "CcbNpcMissionSnapshot"
           }
@@ -5382,22 +5382,22 @@
       {
         "fields": [
           {
-            "line": 9260,
+            "line": 9271,
             "name": "items",
             "type": "CcbNpcMissionSnapshot[]"
           },
           {
-            "line": 9262,
+            "line": 9273,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 9261,
+            "line": 9272,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 9263,
+            "line": 9274,
             "name": "truncated",
             "type": "boolean"
           }
@@ -5407,57 +5407,57 @@
       {
         "fields": [
           {
-            "line": 9252,
+            "line": 9263,
             "name": "assigned",
             "type": "boolean"
           },
           {
-            "line": 9254,
+            "line": 9265,
             "name": "failed",
             "type": "boolean"
           },
           {
-            "line": 9257,
+            "line": 9268,
             "name": "follow_up",
             "type": "GameId"
           },
           {
-            "line": 9256,
+            "line": 9267,
             "name": "generic_reward_claimed",
             "type": "boolean"
           },
           {
-            "line": 9255,
+            "line": 9266,
             "name": "has_generic_rewards",
             "type": "boolean"
           },
           {
-            "line": 9249,
+            "line": 9260,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 9253,
+            "line": 9264,
             "name": "in_progress",
             "type": "boolean"
           },
           {
-            "line": 9250,
+            "line": 9261,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 9251,
+            "line": 9262,
             "name": "status",
             "type": "CcbNpcMissionStatus"
           },
           {
-            "line": 9247,
+            "line": 9258,
             "name": "token",
             "type": "MissionToken"
           },
           {
-            "line": 9248,
+            "line": 9259,
             "name": "uid",
             "type": "integer"
           }
@@ -5471,32 +5471,32 @@
       {
         "fields": [
           {
-            "line": 9268,
+            "line": 9279,
             "name": "assigned",
             "type": "CcbNpcMissionPage"
           },
           {
-            "line": 9267,
+            "line": 9278,
             "name": "available",
             "type": "CcbNpcMissionPage"
           },
           {
-            "line": 9266,
+            "line": 9277,
             "name": "provider_id",
             "type": "integer"
           },
           {
-            "line": 9269,
+            "line": 9280,
             "name": "selected",
             "type": "CcbNpcMissionSnapshot"
           },
           {
-            "line": 9271,
+            "line": 9282,
             "name": "selected_invalid",
             "type": "boolean"
           },
           {
-            "line": 9270,
+            "line": 9281,
             "name": "selected_stale",
             "type": "boolean"
           }
@@ -5506,12 +5506,12 @@
       {
         "fields": [
           {
-            "line": 9294,
+            "line": 9305,
             "name": "after",
             "type": "CcbNpcMissionsState"
           },
           {
-            "line": 9293,
+            "line": 9304,
             "name": "before",
             "type": "CcbNpcMissionsState"
           }
@@ -5521,32 +5521,32 @@
       {
         "fields": [
           {
-            "line": 9222,
+            "line": 9233,
             "name": "anger",
             "type": "integer"
           },
           {
-            "line": 9220,
+            "line": 9231,
             "name": "fear",
             "type": "integer"
           },
           {
-            "line": 9223,
+            "line": 9234,
             "name": "owed",
             "type": "integer"
           },
           {
-            "line": 9224,
+            "line": 9235,
             "name": "sold",
             "type": "integer"
           },
           {
-            "line": 9219,
+            "line": 9230,
             "name": "trust",
             "type": "integer"
           },
           {
-            "line": 9221,
+            "line": 9232,
             "name": "value",
             "type": "integer"
           }
@@ -5556,87 +5556,87 @@
       {
         "fields": [
           {
-            "line": 9286,
+            "line": 9297,
             "name": "activity",
             "type": "GameId"
           },
           {
-            "line": 9288,
+            "line": 9299,
             "name": "attitude",
             "type": "integer"
           },
           {
-            "line": 9276,
+            "line": 9287,
             "name": "avatar",
             "type": "boolean"
           },
           {
-            "line": 9279,
+            "line": 9290,
             "name": "bionics",
             "type": "integer"
           },
           {
-            "line": 9283,
+            "line": 9294,
             "name": "bitten",
             "type": "boolean"
           },
           {
-            "line": 9282,
+            "line": 9293,
             "name": "bleeding",
             "type": "boolean"
           },
           {
-            "line": 9289,
+            "line": 9300,
             "name": "busy_turns",
             "type": "integer"
           },
           {
-            "line": 9290,
+            "line": 9301,
             "name": "current_activity",
             "type": "string"
           },
           {
-            "line": 9277,
+            "line": 9288,
             "name": "hp",
             "type": "integer"
           },
           {
-            "line": 9274,
+            "line": 9285,
             "name": "id",
             "type": "integer"
           },
           {
-            "line": 9284,
+            "line": 9295,
             "name": "infected",
             "type": "boolean"
           },
           {
-            "line": 9285,
+            "line": 9296,
             "name": "inventory_stacks",
             "type": "integer"
           },
           {
-            "line": 9278,
+            "line": 9289,
             "name": "maximum_hp",
             "type": "integer"
           },
           {
-            "line": 9281,
+            "line": 9292,
             "name": "mounted",
             "type": "boolean"
           },
           {
-            "line": 9280,
+            "line": 9291,
             "name": "mutations",
             "type": "integer"
           },
           {
-            "line": 9275,
+            "line": 9286,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 9287,
+            "line": 9298,
             "name": "owed",
             "type": "integer"
           }
@@ -5666,82 +5666,82 @@
       {
         "fields": [
           {
-            "line": 9242,
+            "line": 9253,
             "name": "ai_rules",
             "type": "table<string,"
           },
           {
-            "line": 9236,
+            "line": 9247,
             "name": "attitude",
             "type": "GameId"
           },
           {
-            "line": 9237,
+            "line": 9248,
             "name": "attitude_name",
             "type": "string"
           },
           {
-            "line": 9233,
+            "line": 9244,
             "name": "class",
             "type": "GameId"
           },
           {
-            "line": 9238,
+            "line": 9249,
             "name": "dead",
             "type": "boolean"
           },
           {
-            "line": 9231,
+            "line": 9242,
             "name": "display_name",
             "type": "string"
           },
           {
-            "line": 9235,
+            "line": 9246,
             "name": "faction",
             "type": "GameId|nil"
           },
           {
-            "line": 9240,
+            "line": 9251,
             "name": "first_topic",
             "type": "string"
           },
           {
-            "line": 9227,
+            "line": 9238,
             "name": "handle",
             "type": "GameHandle"
           },
           {
-            "line": 9228,
+            "line": 9239,
             "name": "id",
             "type": "integer"
           },
           {
-            "line": 9230,
+            "line": 9241,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 9241,
+            "line": 9252,
             "name": "opinion",
             "type": "CcbNpcOpinion"
           },
           {
-            "line": 9239,
+            "line": 9250,
             "name": "player_ally",
             "type": "boolean"
           },
           {
-            "line": 9232,
+            "line": 9243,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 9234,
+            "line": 9245,
             "name": "template",
             "type": "GameId|nil"
           },
           {
-            "line": 9229,
+            "line": 9240,
             "name": "unique_id",
             "type": "string"
           }
@@ -5755,27 +5755,27 @@
       {
         "fields": [
           {
-            "line": 9571,
+            "line": 9582,
             "name": "dialogue",
             "type": "CcbNpcDialogueActionsApi"
           },
           {
-            "line": 9568,
+            "line": 9579,
             "name": "grooming",
             "type": "CcbNpcGroomingApi"
           },
           {
-            "line": 9567,
+            "line": 9578,
             "name": "medical",
             "type": "CcbNpcMedicalApi"
           },
           {
-            "line": 9570,
+            "line": 9581,
             "name": "missions",
             "type": "CcbNpcMissionsApi"
           },
           {
-            "line": 9569,
+            "line": 9580,
             "name": "training",
             "type": "CcbNpcTrainingApi"
           }
@@ -5785,22 +5785,22 @@
       {
         "fields": [
           {
-            "line": 9922,
+            "line": 9933,
             "name": "items",
             "type": "GameId[]"
           },
           {
-            "line": 9924,
+            "line": 9935,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 9923,
+            "line": 9934,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 9925,
+            "line": 9936,
             "name": "truncated",
             "type": "boolean"
           }
@@ -6077,12 +6077,12 @@
       {
         "fields": [
           {
-            "line": 9835,
+            "line": 9846,
             "name": "activity",
             "type": "CcbPlatformActivitySnapshot"
           },
           {
-            "line": 9834,
+            "line": 9845,
             "name": "changed",
             "type": "boolean"
           }
@@ -6092,57 +6092,57 @@
       {
         "fields": [
           {
-            "line": 9821,
+            "line": 9832,
             "name": "active",
             "type": "boolean"
           },
           {
-            "line": 9828,
+            "line": 9839,
             "name": "auto_resume",
             "type": "boolean"
           },
           {
-            "line": 9822,
+            "line": 9833,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 9826,
+            "line": 9837,
             "name": "interruptible",
             "type": "boolean"
           },
           {
-            "line": 9827,
+            "line": 9838,
             "name": "interruptible_with_keyboard",
             "type": "boolean"
           },
           {
-            "line": 9825,
+            "line": 9836,
             "name": "moves_left",
             "type": "integer"
           },
           {
-            "line": 9824,
+            "line": 9835,
             "name": "moves_total",
             "type": "integer"
           },
           {
-            "line": 9831,
+            "line": 9842,
             "name": "progress",
             "type": "number"
           },
           {
-            "line": 9830,
+            "line": 9841,
             "name": "resumable",
             "type": "boolean"
           },
           {
-            "line": 9829,
+            "line": 9840,
             "name": "rooted",
             "type": "boolean"
           },
           {
-            "line": 9823,
+            "line": 9834,
             "name": "verb",
             "type": "string"
           }
@@ -6182,22 +6182,22 @@
       {
         "fields": [
           {
-            "line": 10204,
+            "line": 10215,
             "name": "has_capacity",
             "type": "boolean"
           },
           {
-            "line": 10201,
+            "line": 10212,
             "name": "installed_count",
             "type": "integer"
           },
           {
-            "line": 10203,
+            "line": 10214,
             "name": "maximum_power",
             "type": "UnitValue"
           },
           {
-            "line": 10202,
+            "line": 10213,
             "name": "power",
             "type": "UnitValue"
           }
@@ -6493,27 +6493,27 @@
       {
         "fields": [
           {
-            "line": 10544,
+            "line": 10555,
             "name": "environment",
             "type": "CcbPlatformEnvironmentQueries"
           },
           {
-            "line": 10543,
+            "line": 10554,
             "name": "math",
             "type": "CcbPlatformMathApi"
           },
           {
-            "line": 10542,
+            "line": 10553,
             "name": "mods",
             "type": "CcbPlatformModQueries"
           },
           {
-            "line": 10545,
+            "line": 10556,
             "name": "options",
             "type": "CcbPlatformGameplayOptionsApi"
           },
           {
-            "line": 10541,
+            "line": 10552,
             "name": "strings",
             "type": "CcbPlatformStringPredicates"
           }
@@ -6614,17 +6614,17 @@
       {
         "fields": [
           {
-            "line": 6822,
+            "line": 6833,
             "name": "terrain_ids",
             "type": "string[]"
           },
           {
-            "line": 6824,
+            "line": 6835,
             "name": "z_max",
             "type": "integer"
           },
           {
-            "line": 6823,
+            "line": 6834,
             "name": "z_min",
             "type": "integer"
           }
@@ -6654,17 +6654,17 @@
       {
         "fields": [
           {
-            "line": 10408,
+            "line": 10419,
             "name": "capped",
             "type": "boolean"
           },
           {
-            "line": 10407,
+            "line": 10418,
             "name": "decay_start",
             "type": "TimeDuration"
           },
           {
-            "line": 10406,
+            "line": 10417,
             "name": "duration",
             "type": "TimeDuration"
           }
@@ -6746,32 +6746,32 @@
       {
         "fields": [
           {
-            "line": 10324,
+            "line": 10335,
             "name": "category",
             "type": "GameId"
           },
           {
-            "line": 10320,
+            "line": 10331,
             "name": "changed",
             "type": "boolean"
           },
           {
-            "line": 10321,
+            "line": 10332,
             "name": "forgotten_count",
             "type": "integer"
           },
           {
-            "line": 10323,
+            "line": 10334,
             "name": "known_after",
             "type": "integer"
           },
           {
-            "line": 10322,
+            "line": 10333,
             "name": "known_before",
             "type": "integer"
           },
           {
-            "line": 10325,
+            "line": 10336,
             "name": "subcategory",
             "type": "string"
           }
@@ -6804,307 +6804,307 @@
       {
         "fields": [
           {
-            "line": 8241,
+            "line": 8252,
             "name": "achievements",
             "type": "CcbPlatformAchievementsApi"
           },
           {
-            "line": 8242,
+            "line": 8253,
             "name": "activities",
             "type": "CcbPlatformActivitiesApi"
           },
           {
-            "line": 8243,
+            "line": 8254,
             "name": "addictions",
             "type": "CcbAddictionsApi"
           },
           {
-            "line": 8244,
+            "line": 8255,
             "name": "bionics",
             "type": "CcbPlatformBionicsApi"
           },
           {
-            "line": 8245,
+            "line": 8256,
             "name": "camps",
             "type": "CcbCampsApi"
           },
           {
-            "line": 8246,
+            "line": 8257,
             "name": "characters",
             "type": "CcbCharactersApi"
           },
           {
-            "line": 8247,
+            "line": 8258,
             "name": "constants",
             "type": "CcbConstantsApi"
           },
           {
-            "line": 8248,
+            "line": 8259,
             "name": "coords",
             "type": "CcbCoordsApi"
           },
           {
-            "line": 8249,
+            "line": 8260,
             "name": "crafting",
             "type": "CcbCraftingApi"
           },
           {
-            "line": 8250,
+            "line": 8261,
             "name": "creatures",
             "type": "CcbCreaturesApi"
           },
           {
-            "line": 8251,
+            "line": 8262,
             "name": "effects",
             "type": "CcbEffectsApi"
           },
           {
-            "line": 8252,
+            "line": 8263,
             "name": "enums",
             "type": "CcbEnumsApi"
           },
           {
-            "line": 8296,
+            "line": 8307,
             "name": "equipment",
             "type": "CcbEquipmentApi"
           },
           {
-            "line": 8253,
+            "line": 8264,
             "name": "factions",
             "type": "CcbFactionsApi"
           },
           {
-            "line": 8254,
+            "line": 8265,
             "name": "followers",
             "type": "CcbFollowersApi"
           },
           {
-            "line": 8295,
+            "line": 8306,
             "name": "gameplay",
             "type": "CcbPlatformGameplayApi"
           },
           {
-            "line": 8255,
+            "line": 8266,
             "name": "handles",
             "type": "CcbHandlesApi"
           },
           {
-            "line": 8257,
+            "line": 8268,
             "name": "hordes",
             "type": "CcbHordesApi"
           },
           {
-            "line": 8256,
+            "line": 8267,
             "name": "interaction",
             "type": "CcbPlatformInteractionApi"
           },
           {
-            "line": 8258,
+            "line": 8269,
             "name": "inventory",
             "type": "CcbPlatformInventoryApi"
           },
           {
-            "line": 8260,
+            "line": 8271,
             "name": "item_categories",
             "type": "CcbItemCategoriesApi"
           },
           {
-            "line": 8259,
+            "line": 8270,
             "name": "items",
             "type": "CcbItemsApi"
           },
           {
-            "line": 8236,
+            "line": 8247,
             "name": "lore",
             "type": "CcbPlatformLoreApi"
           },
           {
-            "line": 8266,
+            "line": 8277,
             "name": "map",
             "type": "CcbMapApi"
           },
           {
-            "line": 8265,
+            "line": 8276,
             "name": "mapgen",
             "type": "CcbMapgenApi"
           },
           {
-            "line": 8261,
+            "line": 8272,
             "name": "martial_arts",
             "type": "CcbPlatformMartialArtsApi"
           },
           {
-            "line": 8262,
+            "line": 8273,
             "name": "messages",
             "type": "CcbPlatformMessagesApi"
           },
           {
-            "line": 8263,
+            "line": 8274,
             "name": "missions",
             "type": "CcbMissionsApi"
           },
           {
-            "line": 8264,
+            "line": 8275,
             "name": "morale",
             "type": "CcbPlatformMoraleApi"
           },
           {
-            "line": 8267,
+            "line": 8278,
             "name": "mutations",
             "type": "CcbMutationsApi"
           },
           {
-            "line": 8237,
+            "line": 8248,
             "name": "native_events",
             "type": "CcbPlatformNativeEventsApi"
           },
           {
-            "line": 8268,
+            "line": 8279,
             "name": "needs",
             "type": "CcbNeedsApi"
           },
           {
-            "line": 8269,
+            "line": 8280,
             "name": "npcs",
             "type": "CcbNpcsApi"
           },
           {
-            "line": 8270,
+            "line": 8281,
             "name": "overmap",
             "type": "CcbOvermapApi"
           },
           {
-            "line": 8271,
+            "line": 8282,
             "name": "proficiencies",
             "type": "CcbProficienciesApi"
           },
           {
-            "line": 8272,
+            "line": 8283,
             "name": "random",
             "type": "CcbPlatformRandomApi"
           },
           {
-            "line": 8273,
+            "line": 8284,
             "name": "recipes",
             "type": "CcbPlatformRecipesApi"
           },
           {
-            "line": 8276,
+            "line": 8287,
             "name": "registry",
             "type": "CcbRegistryApi"
           },
           {
-            "line": 8274,
+            "line": 8285,
             "name": "relocation",
             "type": "CcbRelocationApi"
           },
           {
-            "line": 8275,
+            "line": 8286,
             "name": "requirements",
             "type": "CcbRequirementsApi"
           },
           {
-            "line": 8277,
+            "line": 8288,
             "name": "serde",
             "type": "CcbSerdeApi"
           },
           {
-            "line": 8278,
+            "line": 8289,
             "name": "skills",
             "type": "CcbSkillsApi"
           },
           {
-            "line": 8238,
+            "line": 8249,
             "name": "snippets",
             "type": "CcbPlatformSnippetsApi"
           },
           {
-            "line": 8279,
+            "line": 8290,
             "name": "sound",
             "type": "CcbPlatformSoundApi"
           },
           {
-            "line": 8280,
+            "line": 8291,
             "name": "spawns",
             "type": "CcbSpawnsApi"
           },
           {
-            "line": 8281,
+            "line": 8292,
             "name": "spells",
             "type": "CcbSpellsApi"
           },
           {
-            "line": 8282,
+            "line": 8293,
             "name": "statistics",
             "type": "CcbStatisticsApi"
           },
           {
-            "line": 8283,
+            "line": 8294,
             "name": "targeting",
             "type": "CcbTargetingApi"
           },
           {
-            "line": 8239,
+            "line": 8250,
             "name": "text",
             "type": "CcbPlatformTextApi"
           },
           {
-            "line": 8240,
+            "line": 8251,
             "name": "tileset",
             "type": "CcbPlatformTilesetApi"
           },
           {
-            "line": 8284,
+            "line": 8295,
             "name": "time",
             "type": "CcbTimeApi"
           },
           {
-            "line": 8285,
+            "line": 8296,
             "name": "trade",
             "type": "CcbTradeApi"
           },
           {
-            "line": 8286,
+            "line": 8297,
             "name": "types",
             "type": "CcbTypesApi"
           },
           {
-            "line": 8287,
+            "line": 8298,
             "name": "units",
             "type": "CcbUnitsApi"
           },
           {
-            "line": 8288,
+            "line": 8299,
             "name": "variables",
             "type": "CcbVariablesApi"
           },
           {
-            "line": 8289,
+            "line": 8300,
             "name": "vehicles",
             "type": "CcbVehiclesApi"
           },
           {
-            "line": 8290,
+            "line": 8301,
             "name": "vitamins",
             "type": "CcbVitaminsApi"
           },
           {
-            "line": 8291,
+            "line": 8302,
             "name": "weather",
             "type": "CcbWeatherApi"
           },
           {
-            "line": 8293,
+            "line": 8304,
             "name": "world",
             "type": "CcbWorldApi"
           },
           {
-            "line": 8292,
+            "line": 8303,
             "name": "wounds",
             "type": "CcbPlatformWoundsApi"
           },
           {
-            "line": 8294,
+            "line": 8305,
             "name": "zones",
             "type": "CcbZonesApi"
           }
@@ -7377,47 +7377,47 @@
       {
         "fields": [
           {
-            "line": 10734,
+            "line": 10745,
             "name": "ModDefinition",
             "type": "fun(options:"
           },
           {
-            "line": 10735,
+            "line": 10746,
             "name": "content",
             "type": "CcbPlatformContent"
           },
           {
-            "line": 10737,
+            "line": 10748,
             "name": "dialogue",
             "type": "CcbPlatformDialogueApi"
           },
           {
-            "line": 10733,
+            "line": 10744,
             "name": "platform_version",
             "type": "1"
           },
           {
-            "line": 10740,
+            "line": 10751,
             "name": "presentation",
             "type": "CcbPlatformPresentation"
           },
           {
-            "line": 10736,
+            "line": 10747,
             "name": "runtime",
             "type": "CcbPlatformRuntime"
           },
           {
-            "line": 10741,
+            "line": 10752,
             "name": "services",
             "type": "CcbPlatformServices"
           },
           {
-            "line": 10738,
+            "line": 10749,
             "name": "state",
             "type": "CcbPlatformState"
           },
           {
-            "line": 10739,
+            "line": 10750,
             "name": "tasks",
             "type": "CcbPlatformTasks"
           }
@@ -7427,17 +7427,17 @@
       {
         "fields": [
           {
-            "line": 9870,
+            "line": 9881,
             "name": "after",
             "type": "CcbPlatformWoundSnapshot[]"
           },
           {
-            "line": 9869,
+            "line": 9880,
             "name": "before",
             "type": "CcbPlatformWoundSnapshot[]"
           },
           {
-            "line": 9868,
+            "line": 9879,
             "name": "changed",
             "type": "boolean"
           }
@@ -7447,32 +7447,32 @@
       {
         "fields": [
           {
-            "line": 9861,
+            "line": 9872,
             "name": "base_pain",
             "type": "integer"
           },
           {
-            "line": 9862,
+            "line": 9873,
             "name": "current_pain",
             "type": "integer"
           },
           {
-            "line": 9865,
+            "line": 9876,
             "name": "healing_fraction",
             "type": "number"
           },
           {
-            "line": 9864,
+            "line": 9875,
             "name": "healing_progress",
             "type": "TimeDuration"
           },
           {
-            "line": 9863,
+            "line": 9874,
             "name": "healing_time",
             "type": "TimeDuration"
           },
           {
-            "line": 9860,
+            "line": 9871,
             "name": "id",
             "type": "GameId"
           }
@@ -7486,37 +7486,37 @@
       {
         "fields": [
           {
-            "line": 10241,
+            "line": 10252,
             "name": "batch",
             "type": "integer"
           },
           {
-            "line": 10240,
+            "line": 10251,
             "name": "has_more",
             "type": "boolean"
           },
           {
-            "line": 10235,
+            "line": 10246,
             "name": "items",
             "type": "table"
           },
           {
-            "line": 10238,
+            "line": 10249,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 10237,
+            "line": 10248,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 10239,
+            "line": 10250,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 10236,
+            "line": 10247,
             "name": "total",
             "type": "integer"
           }
@@ -7526,47 +7526,47 @@
       {
         "fields": [
           {
-            "line": 10226,
+            "line": 10237,
             "name": "batch",
             "type": "integer"
           },
           {
-            "line": 10229,
+            "line": 10240,
             "name": "craftable",
             "type": "boolean"
           },
           {
-            "line": 10232,
+            "line": 10243,
             "name": "flag",
             "type": "string"
           },
           {
-            "line": 10227,
+            "line": 10238,
             "name": "include_obsolete",
             "type": "boolean"
           },
           {
-            "line": 10228,
+            "line": 10239,
             "name": "known",
             "type": "boolean"
           },
           {
-            "line": 10225,
+            "line": 10236,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 10224,
+            "line": 10235,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 10231,
+            "line": 10242,
             "name": "result",
             "type": "GameId"
           },
           {
-            "line": 10230,
+            "line": 10241,
             "name": "skill",
             "type": "GameId"
           }
@@ -7584,7 +7584,7 @@
       {
         "fields": [
           {
-            "line": 7513,
+            "line": 7524,
             "name": "strict",
             "type": "true"
           }
@@ -7594,12 +7594,12 @@
       {
         "fields": [
           {
-            "line": 7524,
+            "line": 7535,
             "name": "error",
             "type": "CcbPlatformResultError"
           },
           {
-            "line": 7523,
+            "line": 7534,
             "name": "value",
             "type": "CcbRelocationMoveValue"
           }
@@ -7609,27 +7609,27 @@
       {
         "fields": [
           {
-            "line": 7516,
+            "line": 7527,
             "name": "changed",
             "type": "boolean"
           },
           {
-            "line": 7518,
+            "line": 7529,
             "name": "handle",
             "type": "GameHandle"
           },
           {
-            "line": 7520,
+            "line": 7531,
             "name": "overmap_terrain",
             "type": "TripointCoord"
           },
           {
-            "line": 7519,
+            "line": 7530,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 7517,
+            "line": 7528,
             "name": "scope",
             "type": "'monster'|'avatar'|'npc'|'vehicle'"
           }
@@ -7639,17 +7639,17 @@
       {
         "fields": [
           {
-            "line": 10246,
+            "line": 10257,
             "name": "batch",
             "type": "integer"
           },
           {
-            "line": 10245,
+            "line": 10256,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 10244,
+            "line": 10255,
             "name": "offset",
             "type": "integer"
           }
@@ -7687,37 +7687,37 @@
       {
         "fields": [
           {
-            "line": 7419,
+            "line": 7430,
             "name": "accepted",
             "type": "boolean"
           },
           {
-            "line": 7421,
+            "line": 7432,
             "name": "attack_vector",
             "type": "GameId"
           },
           {
-            "line": 7423,
+            "line": 7434,
             "name": "attacker",
             "type": "GameHandle"
           },
           {
-            "line": 7422,
+            "line": 7433,
             "name": "contact_area",
             "type": "GameId"
           },
           {
-            "line": 7418,
+            "line": 7429,
             "name": "found",
             "type": "boolean"
           },
           {
-            "line": 7424,
+            "line": 7435,
             "name": "target",
             "type": "GameHandle"
           },
           {
-            "line": 7420,
+            "line": 7431,
             "name": "technique",
             "type": "GameId"
           }
@@ -7727,22 +7727,22 @@
       {
         "fields": [
           {
-            "line": 7415,
+            "line": 7426,
             "name": "blacklist",
             "type": "(string|GameId)[]"
           },
           {
-            "line": 7414,
+            "line": 7425,
             "name": "block_counter",
             "type": "boolean"
           },
           {
-            "line": 7412,
+            "line": 7423,
             "name": "critical",
             "type": "boolean"
           },
           {
-            "line": 7413,
+            "line": 7424,
             "name": "dodge_counter",
             "type": "boolean"
           }
@@ -7752,7 +7752,7 @@
       {
         "fields": [
           {
-            "line": 7427,
+            "line": 7438,
             "name": "value",
             "type": "CcbTechniqueChoice|nil"
           }
@@ -7762,172 +7762,172 @@
       {
         "fields": [
           {
-            "line": 10379,
+            "line": 10390,
             "name": "area",
             "type": "string"
           },
           {
-            "line": 10381,
+            "line": 10392,
             "name": "attack_vectors",
             "type": "CcbTechniqueIdPage"
           },
           {
-            "line": 10354,
+            "line": 10365,
             "name": "avatar_message",
             "type": "string"
           },
           {
-            "line": 10364,
+            "line": 10375,
             "name": "block_counter",
             "type": "boolean"
           },
           {
-            "line": 10360,
+            "line": 10371,
             "name": "critical_compatible",
             "type": "boolean"
           },
           {
-            "line": 10359,
+            "line": 10370,
             "name": "critical_only",
             "type": "boolean"
           },
           {
-            "line": 10356,
+            "line": 10367,
             "name": "defensive",
             "type": "boolean"
           },
           {
-            "line": 10351,
+            "line": 10362,
             "name": "description",
             "type": "string"
           },
           {
-            "line": 10367,
+            "line": 10378,
             "name": "disarms",
             "type": "boolean"
           },
           {
-            "line": 10363,
+            "line": 10374,
             "name": "dodge_counter",
             "type": "boolean"
           },
           {
-            "line": 10374,
+            "line": 10385,
             "name": "down_duration",
             "type": "integer"
           },
           {
-            "line": 10358,
+            "line": 10369,
             "name": "dummy",
             "type": "boolean"
           },
           {
-            "line": 10382,
+            "line": 10393,
             "name": "eocs",
             "type": "CcbTechniqueIdPage"
           },
           {
-            "line": 10380,
+            "line": 10391,
             "name": "flags",
             "type": "CcbTechniqueFlagPage"
           },
           {
-            "line": 10352,
+            "line": 10363,
             "name": "flavor_description",
             "type": "string"
           },
           {
-            "line": 10353,
+            "line": 10364,
             "name": "goal",
             "type": "string"
           },
           {
-            "line": 10366,
+            "line": 10377,
             "name": "grab_break",
             "type": "boolean"
           },
           {
-            "line": 10349,
+            "line": 10360,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 10376,
+            "line": 10387,
             "name": "knockback_distance",
             "type": "integer"
           },
           {
-            "line": 10378,
+            "line": 10389,
             "name": "knockback_follow",
             "type": "boolean"
           },
           {
-            "line": 10377,
+            "line": 10388,
             "name": "knockback_spread",
             "type": "number"
           },
           {
-            "line": 10365,
+            "line": 10376,
             "name": "miss_recovery",
             "type": "boolean"
           },
           {
-            "line": 10350,
+            "line": 10361,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 10369,
+            "line": 10380,
             "name": "needs_ammo",
             "type": "boolean"
           },
           {
-            "line": 10355,
+            "line": 10366,
             "name": "npc_message",
             "type": "string"
           },
           {
-            "line": 10362,
+            "line": 10373,
             "name": "reach_compatible",
             "type": "boolean"
           },
           {
-            "line": 10361,
+            "line": 10372,
             "name": "reach_only",
             "type": "boolean"
           },
           {
-            "line": 10373,
+            "line": 10384,
             "name": "repeat_max",
             "type": "integer"
           },
           {
-            "line": 10372,
+            "line": 10383,
             "name": "repeat_min",
             "type": "integer"
           },
           {
-            "line": 10357,
+            "line": 10368,
             "name": "side_switch",
             "type": "boolean"
           },
           {
-            "line": 10375,
+            "line": 10386,
             "name": "stun_duration",
             "type": "integer"
           },
           {
-            "line": 10368,
+            "line": 10379,
             "name": "take_weapon",
             "type": "boolean"
           },
           {
-            "line": 10370,
+            "line": 10381,
             "name": "wall_adjacent",
             "type": "boolean"
           },
           {
-            "line": 10371,
+            "line": 10382,
             "name": "weight",
             "type": "integer"
           }
@@ -7937,22 +7937,22 @@
       {
         "fields": [
           {
-            "line": 10343,
+            "line": 10354,
             "name": "items",
             "type": "string[]"
           },
           {
-            "line": 10345,
+            "line": 10356,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 10344,
+            "line": 10355,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 10346,
+            "line": 10357,
             "name": "truncated",
             "type": "boolean"
           }
@@ -7962,22 +7962,22 @@
       {
         "fields": [
           {
-            "line": 10337,
+            "line": 10348,
             "name": "items",
             "type": "GameId[]"
           },
           {
-            "line": 10339,
+            "line": 10350,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 10338,
+            "line": 10349,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 10340,
+            "line": 10351,
             "name": "truncated",
             "type": "boolean"
           }
@@ -7987,22 +7987,22 @@
       {
         "fields": [
           {
-            "line": 10628,
+            "line": 10639,
             "name": "season_id",
             "type": "string"
           },
           {
-            "line": 10629,
+            "line": 10640,
             "name": "season_name",
             "type": "string"
           },
           {
-            "line": 10626,
+            "line": 10637,
             "name": "turn",
             "type": "integer"
           },
           {
-            "line": 10627,
+            "line": 10638,
             "name": "year",
             "type": "integer"
           }
@@ -8016,7 +8016,7 @@
       {
         "fields": [
           {
-            "line": 9720,
+            "line": 9731,
             "name": "code",
             "type": "CcbTradeCommitErrorCode"
           }
@@ -8026,27 +8026,27 @@
       {
         "fields": [
           {
-            "line": 9723,
+            "line": 9734,
             "name": "direction",
             "type": "'seller_to_buyer'|'buyer_to_seller'"
           },
           {
-            "line": 9724,
+            "line": 9735,
             "name": "item_uid",
             "type": "integer"
           },
           {
-            "line": 9726,
+            "line": 9737,
             "name": "quantity",
             "type": "integer"
           },
           {
-            "line": 9727,
+            "line": 9738,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 9725,
+            "line": 9736,
             "name": "transferred_item_uid",
             "type": "integer"
           }
@@ -8056,12 +8056,12 @@
       {
         "fields": [
           {
-            "line": 9749,
+            "line": 9760,
             "name": "error",
             "type": "CcbTradeCommitError"
           },
           {
-            "line": 9748,
+            "line": 9759,
             "name": "value",
             "type": "CcbTradeCommitValue"
           }
@@ -8071,82 +8071,82 @@
       {
         "fields": [
           {
-            "line": 9743,
+            "line": 9754,
             "name": "buyer_cash_after",
             "type": "integer"
           },
           {
-            "line": 9741,
+            "line": 9752,
             "name": "buyer_cash_before",
             "type": "integer"
           },
           {
-            "line": 9733,
+            "line": 9744,
             "name": "commit_generation",
             "type": "integer"
           },
           {
-            "line": 9730,
+            "line": 9741,
             "name": "committed",
             "type": "true"
           },
           {
-            "line": 9731,
+            "line": 9742,
             "name": "consumed",
             "type": "true"
           },
           {
-            "line": 9735,
+            "line": 9746,
             "name": "currency",
             "type": "'cash'"
           },
           {
-            "line": 9738,
+            "line": 9749,
             "name": "debt_after",
             "type": "integer"
           },
           {
-            "line": 9737,
+            "line": 9748,
             "name": "debt_before",
             "type": "integer"
           },
           {
-            "line": 9745,
+            "line": 9756,
             "name": "lines",
             "type": "CcbTradeCommitLineResult[]"
           },
           {
-            "line": 9732,
+            "line": 9743,
             "name": "quote_id",
             "type": "integer"
           },
           {
-            "line": 9744,
+            "line": 9755,
             "name": "seller_cash_after",
             "type": "integer"
           },
           {
-            "line": 9742,
+            "line": 9753,
             "name": "seller_cash_before",
             "type": "integer"
           },
           {
-            "line": 9736,
+            "line": 9747,
             "name": "settlement_amount",
             "type": "integer"
           },
           {
-            "line": 9734,
+            "line": 9745,
             "name": "settlement_strategy",
             "type": "CcbTradeCommitSettlementStrategy"
           },
           {
-            "line": 9740,
+            "line": 9751,
             "name": "sold_after",
             "type": "integer"
           },
           {
-            "line": 9739,
+            "line": 9750,
             "name": "sold_before",
             "type": "integer"
           }
@@ -8156,12 +8156,12 @@
       {
         "fields": [
           {
-            "line": 9601,
+            "line": 9612,
             "name": "currency",
             "type": "'cash'"
           },
           {
-            "line": 9600,
+            "line": 9611,
             "name": "strategy",
             "type": "'npc_debt'"
           }
@@ -8171,17 +8171,17 @@
       {
         "fields": [
           {
-            "line": 9609,
+            "line": 9620,
             "name": "character",
             "type": "GameHandle"
           },
           {
-            "line": 9608,
+            "line": 9619,
             "name": "kind",
             "type": "'character'"
           },
           {
-            "line": 9610,
+            "line": 9621,
             "name": "slot",
             "type": "'inventory'|'worn'|'wielded'"
           }
@@ -8191,12 +8191,12 @@
       {
         "fields": [
           {
-            "line": 9613,
+            "line": 9624,
             "name": "locator",
             "type": "table<string,"
           },
           {
-            "line": 9614,
+            "line": 9625,
             "name": "mutation_generation",
             "type": "integer"
           }
@@ -8206,54 +8206,9 @@
       {
         "fields": [
           {
-            "line": 9621,
+            "line": 9632,
             "name": "destination_holder",
             "type": "CcbTradeQuoteHolder"
-          },
-          {
-            "line": 9617,
-            "name": "direction",
-            "type": "'seller_to_buyer'|'buyer_to_seller'"
-          },
-          {
-            "line": 9618,
-            "name": "item",
-            "type": "GameHandle"
-          },
-          {
-            "line": 9619,
-            "name": "quantity",
-            "type": "integer"
-          },
-          {
-            "line": 9620,
-            "name": "source_holder",
-            "type": "CcbTradeQuoteHolder"
-          }
-        ],
-        "name": "CcbTradeQuoteLineInput"
-      },
-      {
-        "fields": [
-          {
-            "line": 9641,
-            "name": "accepted",
-            "type": "boolean"
-          },
-          {
-            "line": 9633,
-            "name": "charges_at_quote",
-            "type": "integer"
-          },
-          {
-            "line": 9635,
-            "name": "destination_holder",
-            "type": "CcbTradeQuoteHolderSnapshot"
-          },
-          {
-            "line": 9637,
-            "name": "destination_holder_mutation_generation",
-            "type": "integer"
           },
           {
             "line": 9628,
@@ -8266,47 +8221,92 @@
             "type": "GameHandle"
           },
           {
-            "line": 9631,
-            "name": "item_identity_generation",
-            "type": "integer"
-          },
-          {
             "line": 9630,
-            "name": "item_uid",
-            "type": "integer"
-          },
-          {
-            "line": 9632,
             "name": "quantity",
             "type": "integer"
           },
           {
-            "line": 9642,
-            "name": "rejection_reason",
-            "type": "string"
-          },
-          {
-            "line": 9634,
+            "line": 9631,
             "name": "source_holder",
-            "type": "CcbTradeQuoteHolderSnapshot"
+            "type": "CcbTradeQuoteHolder"
+          }
+        ],
+        "name": "CcbTradeQuoteLineInput"
+      },
+      {
+        "fields": [
+          {
+            "line": 9652,
+            "name": "accepted",
+            "type": "boolean"
           },
           {
-            "line": 9636,
-            "name": "source_holder_mutation_generation",
+            "line": 9644,
+            "name": "charges_at_quote",
             "type": "integer"
           },
           {
-            "line": 9640,
-            "name": "tax",
+            "line": 9646,
+            "name": "destination_holder",
+            "type": "CcbTradeQuoteHolderSnapshot"
+          },
+          {
+            "line": 9648,
+            "name": "destination_holder_mutation_generation",
             "type": "integer"
           },
           {
             "line": 9639,
+            "name": "direction",
+            "type": "'seller_to_buyer'|'buyer_to_seller'"
+          },
+          {
+            "line": 9640,
+            "name": "item",
+            "type": "GameHandle"
+          },
+          {
+            "line": 9642,
+            "name": "item_identity_generation",
+            "type": "integer"
+          },
+          {
+            "line": 9641,
+            "name": "item_uid",
+            "type": "integer"
+          },
+          {
+            "line": 9643,
+            "name": "quantity",
+            "type": "integer"
+          },
+          {
+            "line": 9653,
+            "name": "rejection_reason",
+            "type": "string"
+          },
+          {
+            "line": 9645,
+            "name": "source_holder",
+            "type": "CcbTradeQuoteHolderSnapshot"
+          },
+          {
+            "line": 9647,
+            "name": "source_holder_mutation_generation",
+            "type": "integer"
+          },
+          {
+            "line": 9651,
+            "name": "tax",
+            "type": "integer"
+          },
+          {
+            "line": 9650,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 9638,
+            "line": 9649,
             "name": "unit_price",
             "type": "integer"
           }
@@ -8316,12 +8316,12 @@
       {
         "fields": [
           {
-            "line": 9625,
+            "line": 9636,
             "name": "expiry_turns",
             "type": "integer"
           },
           {
-            "line": 9624,
+            "line": 9635,
             "name": "settlement",
             "type": "CcbTradeQuoteSettlement"
           }
@@ -8331,12 +8331,12 @@
       {
         "fields": [
           {
-            "line": 9595,
+            "line": 9606,
             "name": "currency",
             "type": "'cash'"
           },
           {
-            "line": 9594,
+            "line": 9605,
             "name": "strategy",
             "type": "CcbTradeQuoteSettlementStrategy"
           }
@@ -8346,157 +8346,157 @@
       {
         "fields": [
           {
-            "line": 9673,
+            "line": 9684,
             "name": "available_settlement_modes",
             "type": "string[]"
           },
           {
-            "line": 9647,
+            "line": 9658,
             "name": "buyer",
             "type": "GameHandle"
           },
           {
-            "line": 9668,
+            "line": 9679,
             "name": "buyer_cash_before",
             "type": "integer"
           },
           {
-            "line": 9651,
+            "line": 9662,
             "name": "buyer_identity_generation",
             "type": "integer"
           },
           {
-            "line": 9649,
+            "line": 9660,
             "name": "buyer_stable_id",
             "type": "integer"
           },
           {
-            "line": 9660,
+            "line": 9671,
             "name": "buyer_to_seller_total",
             "type": "integer"
           },
           {
-            "line": 9658,
+            "line": 9669,
             "name": "currency",
             "type": "'cash'"
           },
           {
-            "line": 9665,
+            "line": 9676,
             "name": "debt_after",
             "type": "integer|nil"
           },
           {
-            "line": 9664,
+            "line": 9675,
             "name": "debt_before",
             "type": "integer|nil"
           },
           {
-            "line": 9655,
+            "line": 9666,
             "name": "debt_generation",
             "type": "integer"
           },
           {
-            "line": 9672,
+            "line": 9683,
             "name": "expires_turn",
             "type": "integer"
           },
           {
-            "line": 9654,
+            "line": 9665,
             "name": "faction_generation",
             "type": "integer"
           },
           {
-            "line": 9670,
+            "line": 9681,
             "name": "free_exchange",
             "type": "boolean"
           },
           {
-            "line": 9652,
+            "line": 9663,
             "name": "holder_mutation_generation",
             "type": "integer"
           },
           {
-            "line": 9671,
+            "line": 9682,
             "name": "issued_turn",
             "type": "integer"
           },
           {
-            "line": 9674,
+            "line": 9685,
             "name": "lines",
             "type": "CcbTradeQuoteLineSnapshot[]"
           },
           {
-            "line": 9661,
+            "line": 9672,
             "name": "net",
             "type": "integer"
           },
           {
-            "line": 9656,
+            "line": 9667,
             "name": "opinion_generation",
             "type": "integer"
           },
           {
-            "line": 9653,
+            "line": 9664,
             "name": "pricing_generation",
             "type": "integer"
           },
           {
-            "line": 9675,
+            "line": 9686,
             "name": "rejection_reasons",
             "type": "string[]"
           },
           {
-            "line": 9646,
+            "line": 9657,
             "name": "seller",
             "type": "GameHandle"
           },
           {
-            "line": 9669,
+            "line": 9680,
             "name": "seller_cash_before",
             "type": "integer"
           },
           {
-            "line": 9650,
+            "line": 9661,
             "name": "seller_identity_generation",
             "type": "integer"
           },
           {
-            "line": 9648,
+            "line": 9659,
             "name": "seller_stable_id",
             "type": "integer"
           },
           {
-            "line": 9659,
+            "line": 9670,
             "name": "seller_to_buyer_total",
             "type": "integer"
           },
           {
-            "line": 9663,
+            "line": 9674,
             "name": "settlement_amount",
             "type": "integer"
           },
           {
-            "line": 9657,
+            "line": 9668,
             "name": "settlement_strategy",
             "type": "CcbTradeQuoteSettlementStrategy"
           },
           {
-            "line": 9667,
+            "line": 9678,
             "name": "sold_after",
             "type": "integer|nil"
           },
           {
-            "line": 9666,
+            "line": 9677,
             "name": "sold_before",
             "type": "integer|nil"
           },
           {
-            "line": 9662,
+            "line": 9673,
             "name": "tax",
             "type": "integer"
           },
           {
-            "line": 9645,
+            "line": 9656,
             "name": "token",
             "type": "TradeQuoteToken"
           }
@@ -8510,7 +8510,7 @@
       {
         "fields": [
           {
-            "line": 9997,
+            "line": 10008,
             "name": "value",
             "type": "CcbVariableReadValue"
           }
@@ -8520,12 +8520,12 @@
       {
         "fields": [
           {
-            "line": 9993,
+            "line": 10004,
             "name": "exists",
             "type": "boolean"
           },
           {
-            "line": 9994,
+            "line": 10005,
             "name": "value",
             "type": "any"
           }
@@ -8559,37 +8559,37 @@
       {
         "fields": [
           {
-            "line": 8465,
+            "line": 8476,
             "name": "after",
             "type": "CcbVehiclePartSnapshot"
           },
           {
-            "line": 8464,
+            "line": 8475,
             "name": "before",
             "type": "CcbVehiclePartSnapshot"
           },
           {
-            "line": 8463,
+            "line": 8474,
             "name": "changed",
             "type": "boolean"
           },
           {
-            "line": 8467,
+            "line": 8478,
             "name": "part",
             "type": "GameHandle"
           },
           {
-            "line": 8469,
+            "line": 8480,
             "name": "part_error",
             "type": "string"
           },
           {
-            "line": 8468,
+            "line": 8479,
             "name": "part_stale",
             "type": "boolean"
           },
           {
-            "line": 8466,
+            "line": 8477,
             "name": "vehicle",
             "type": "GameHandle"
           }
@@ -8614,7 +8614,7 @@
       {
         "fields": [
           {
-            "line": 8472,
+            "line": 8483,
             "name": "status",
             "type": "\"cancelled\"|\"no_vehicle\"|\"no_value\"|\"no_output\"|\"payment_cancelled\"|\"invalidated\"|\"repairing\"|\"removing\"|\"installing\""
           }
@@ -8624,102 +8624,102 @@
       {
         "fields": [
           {
-            "line": 8428,
+            "line": 8439,
             "name": "ammo",
             "type": "table<string,"
           },
           {
-            "line": 8423,
+            "line": 8434,
             "name": "available",
             "type": "boolean"
           },
           {
-            "line": 8422,
+            "line": 8433,
             "name": "broken",
             "type": "boolean"
           },
           {
-            "line": 8421,
+            "line": 8432,
             "name": "damage_percent",
             "type": "number"
           },
           {
-            "line": 8420,
+            "line": 8431,
             "name": "durability",
             "type": "integer"
           },
           {
-            "line": 8424,
+            "line": 8435,
             "name": "enabled",
             "type": "boolean"
           },
           {
-            "line": 8426,
+            "line": 8437,
             "name": "fake",
             "type": "boolean"
           },
           {
-            "line": 8427,
+            "line": 8438,
             "name": "features",
             "type": "table<string,"
           },
           {
-            "line": 8409,
+            "line": 8420,
             "name": "handle",
             "type": "GameHandle"
           },
           {
-            "line": 8419,
+            "line": 8430,
             "name": "hp",
             "type": "integer"
           },
           {
-            "line": 8413,
+            "line": 8424,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 8412,
+            "line": 8423,
             "name": "index",
             "type": "integer"
           },
           {
-            "line": 8414,
+            "line": 8425,
             "name": "location",
             "type": "GameId"
           },
           {
-            "line": 8416,
+            "line": 8427,
             "name": "mount",
             "type": "table<string,"
           },
           {
-            "line": 8415,
+            "line": 8426,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 8411,
+            "line": 8422,
             "name": "part_uid",
             "type": "integer"
           },
           {
-            "line": 8417,
+            "line": 8428,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 8425,
+            "line": 8436,
             "name": "removed",
             "type": "boolean"
           },
           {
-            "line": 8418,
+            "line": 8429,
             "name": "variant",
             "type": "string"
           },
           {
-            "line": 8410,
+            "line": 8421,
             "name": "vehicle",
             "type": "GameHandle"
           }
@@ -8729,42 +8729,42 @@
       {
         "fields": [
           {
-            "line": 8436,
+            "line": 8447,
             "name": "has_more",
             "type": "boolean"
           },
           {
-            "line": 8437,
+            "line": 8448,
             "name": "include_fake",
             "type": "boolean"
           },
           {
-            "line": 8438,
+            "line": 8449,
             "name": "include_removed",
             "type": "boolean"
           },
           {
-            "line": 8431,
+            "line": 8442,
             "name": "items",
             "type": "CcbVehiclePartSnapshot[]"
           },
           {
-            "line": 8433,
+            "line": 8444,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 8432,
+            "line": 8443,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 8435,
+            "line": 8446,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 8434,
+            "line": 8445,
             "name": "total",
             "type": "integer"
           }
@@ -8774,47 +8774,47 @@
       {
         "fields": [
           {
-            "line": 8442,
+            "line": 8453,
             "name": "display_name",
             "type": "string"
           },
           {
-            "line": 8449,
+            "line": 8460,
             "name": "lift",
             "type": "table<string,"
           },
           {
-            "line": 8448,
+            "line": 8459,
             "name": "motion",
             "type": "table<string,"
           },
           {
-            "line": 8441,
+            "line": 8452,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 8445,
+            "line": 8456,
             "name": "parts",
             "type": "integer"
           },
           {
-            "line": 8444,
+            "line": 8455,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 8443,
+            "line": 8454,
             "name": "prototype",
             "type": "GameId"
           },
           {
-            "line": 8446,
+            "line": 8457,
             "name": "real_parts",
             "type": "integer"
           },
           {
-            "line": 8447,
+            "line": 8458,
             "name": "state",
             "type": "table<string,"
           }
@@ -8824,27 +8824,27 @@
       {
         "fields": [
           {
-            "line": 8453,
+            "line": 8464,
             "name": "fuel_percent",
             "type": "integer"
           },
           {
-            "line": 8455,
+            "line": 8466,
             "name": "merge_wrecks",
             "type": "boolean"
           },
           {
-            "line": 8456,
+            "line": 8467,
             "name": "owner",
             "type": "GameId"
           },
           {
-            "line": 8452,
+            "line": 8463,
             "name": "rotation_degrees",
             "type": "integer"
           },
           {
-            "line": 8454,
+            "line": 8465,
             "name": "status",
             "type": "integer"
           }
@@ -8854,12 +8854,12 @@
       {
         "fields": [
           {
-            "line": 8459,
+            "line": 8470,
             "name": "handle",
             "type": "GameHandle"
           },
           {
-            "line": 8460,
+            "line": 8471,
             "name": "vehicle",
             "type": "CcbVehicleSnapshot"
           }
@@ -8897,72 +8897,72 @@
       {
         "fields": [
           {
-            "line": 7623,
+            "line": 7634,
             "name": "changed",
             "type": "boolean"
           },
           {
-            "line": 7624,
+            "line": 7635,
             "name": "lightning_active",
             "type": "boolean"
           },
           {
-            "line": 7622,
+            "line": 7633,
             "name": "next_update",
             "type": "TimePoint"
           },
           {
-            "line": 7629,
+            "line": 7640,
             "name": "precise",
             "type": "CcbWeatherPointSnapshot"
           },
           {
-            "line": 7618,
+            "line": 7629,
             "name": "temperature",
             "type": "UnitValue"
           },
           {
-            "line": 7619,
+            "line": 7630,
             "name": "temperature_c",
             "type": "number"
           },
           {
-            "line": 7626,
+            "line": 7637,
             "name": "temperature_override",
             "type": "UnitValue"
           },
           {
-            "line": 7617,
+            "line": 7628,
             "name": "type",
             "type": "CcbWeatherTypeSnapshot"
           },
           {
-            "line": 7616,
+            "line": 7627,
             "name": "weather",
             "type": "GameId"
           },
           {
-            "line": 7625,
+            "line": 7636,
             "name": "weather_override",
             "type": "GameId"
           },
           {
-            "line": 7621,
+            "line": 7632,
             "name": "wind_direction_degrees",
             "type": "integer"
           },
           {
-            "line": 7628,
+            "line": 7639,
             "name": "wind_direction_override_degrees",
             "type": "integer"
           },
           {
-            "line": 7620,
+            "line": 7631,
             "name": "wind_speed_mph",
             "type": "integer"
           },
           {
-            "line": 7627,
+            "line": 7638,
             "name": "wind_speed_override_mph",
             "type": "integer"
           }
@@ -8972,42 +8972,7 @@
       {
         "fields": [
           {
-            "line": 7665,
-            "name": "limit",
-            "type": "integer"
-          },
-          {
-            "line": 7663,
-            "name": "position",
-            "type": "TripointCoord"
-          },
-          {
-            "line": 7666,
-            "name": "respect_override",
-            "type": "boolean"
-          },
-          {
-            "line": 7662,
-            "name": "start",
-            "type": "TimePoint"
-          },
-          {
-            "line": 7664,
-            "name": "step",
-            "type": "TimeDuration"
-          }
-        ],
-        "name": "CcbWeatherForecastOptions"
-      },
-      {
-        "fields": [
-          {
-            "line": 7669,
-            "name": "items",
-            "type": "CcbWeatherPointSnapshot[]"
-          },
-          {
-            "line": 7671,
+            "line": 7676,
             "name": "limit",
             "type": "integer"
           },
@@ -9017,22 +8982,57 @@
             "type": "TripointCoord"
           },
           {
-            "line": 7675,
-            "name": "respected_override",
+            "line": 7677,
+            "name": "respect_override",
             "type": "boolean"
           },
           {
-            "line": 7670,
-            "name": "returned",
-            "type": "integer"
-          },
-          {
-            "line": 7672,
+            "line": 7673,
             "name": "start",
             "type": "TimePoint"
           },
           {
-            "line": 7673,
+            "line": 7675,
+            "name": "step",
+            "type": "TimeDuration"
+          }
+        ],
+        "name": "CcbWeatherForecastOptions"
+      },
+      {
+        "fields": [
+          {
+            "line": 7680,
+            "name": "items",
+            "type": "CcbWeatherPointSnapshot[]"
+          },
+          {
+            "line": 7682,
+            "name": "limit",
+            "type": "integer"
+          },
+          {
+            "line": 7685,
+            "name": "position",
+            "type": "TripointCoord"
+          },
+          {
+            "line": 7686,
+            "name": "respected_override",
+            "type": "boolean"
+          },
+          {
+            "line": 7681,
+            "name": "returned",
+            "type": "integer"
+          },
+          {
+            "line": 7683,
+            "name": "start",
+            "type": "TimePoint"
+          },
+          {
+            "line": 7684,
             "name": "step",
             "type": "TimeDuration"
           }
@@ -9042,62 +9042,62 @@
       {
         "fields": [
           {
-            "line": 7651,
+            "line": 7662,
             "name": "base_humidity",
             "type": "number"
           },
           {
-            "line": 7652,
+            "line": 7663,
             "name": "base_pressure",
             "type": "number"
           },
           {
-            "line": 7650,
+            "line": 7661,
             "name": "base_temperature_c",
             "type": "number"
           },
           {
-            "line": 7653,
+            "line": 7664,
             "name": "base_wind_mph",
             "type": "number"
           },
           {
-            "line": 7657,
+            "line": 7668,
             "name": "blacklist",
             "type": "CcbWeatherStringPage"
           },
           {
-            "line": 7648,
+            "line": 7659,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 7649,
+            "line": 7660,
             "name": "loaded",
             "type": "boolean"
           },
           {
-            "line": 7656,
+            "line": 7667,
             "name": "seasonal",
             "type": "CcbWeatherSeasonalSnapshot"
           },
           {
-            "line": 7659,
+            "line": 7670,
             "name": "sorted_weather",
             "type": "CcbWeatherTypeIdPage"
           },
           {
-            "line": 7658,
+            "line": 7669,
             "name": "whitelist",
             "type": "CcbWeatherStringPage"
           },
           {
-            "line": 7654,
+            "line": 7665,
             "name": "wind_distribution_peaks",
             "type": "integer"
           },
           {
-            "line": 7655,
+            "line": 7666,
             "name": "wind_season_variation",
             "type": "integer"
           }
@@ -9107,32 +9107,32 @@
       {
         "fields": [
           {
-            "line": 7728,
+            "line": 7739,
             "name": "accepted",
             "type": "boolean"
           },
           {
-            "line": 7725,
+            "line": 7736,
             "name": "duration",
             "type": "TimeDuration"
           },
           {
-            "line": 7726,
+            "line": 7737,
             "name": "expires_at",
             "type": "TimePoint"
           },
           {
-            "line": 7727,
+            "line": 7738,
             "name": "key",
             "type": "string"
           },
           {
-            "line": 7724,
+            "line": 7735,
             "name": "level",
             "type": "integer"
           },
           {
-            "line": 7729,
+            "line": 7740,
             "name": "replaced",
             "type": "boolean"
           }
@@ -9142,72 +9142,72 @@
       {
         "fields": [
           {
-            "line": 7678,
+            "line": 7689,
             "name": "catalog_limit",
             "type": "integer"
           },
           {
-            "line": 7681,
+            "line": 7692,
             "name": "forecast_limit",
             "type": "integer"
           },
           {
-            "line": 7684,
+            "line": 7695,
             "name": "forecast_maximum_horizon",
             "type": "TimeDuration"
           },
           {
-            "line": 7683,
+            "line": 7694,
             "name": "forecast_maximum_step",
             "type": "TimeDuration"
           },
           {
-            "line": 7682,
+            "line": 7693,
             "name": "forecast_minimum_step",
             "type": "TimeDuration"
           },
           {
-            "line": 7679,
+            "line": 7690,
             "name": "maximum_catalog_offset",
             "type": "integer"
           },
           {
-            "line": 7689,
+            "line": 7700,
             "name": "maximum_custom_light_duration",
             "type": "TimeDuration"
           },
           {
-            "line": 7690,
+            "line": 7701,
             "name": "maximum_custom_light_key_bytes",
             "type": "integer"
           },
           {
-            "line": 7688,
+            "line": 7699,
             "name": "maximum_custom_light_level",
             "type": "integer"
           },
           {
-            "line": 7680,
+            "line": 7691,
             "name": "maximum_nested_values",
             "type": "integer"
           },
           {
-            "line": 7691,
+            "line": 7702,
             "name": "maximum_pending_custom_light_events",
             "type": "integer"
           },
           {
-            "line": 7687,
+            "line": 7698,
             "name": "maximum_temperature_kelvin",
             "type": "number"
           },
           {
-            "line": 7686,
+            "line": 7697,
             "name": "maximum_wind_direction_degrees",
             "type": "integer"
           },
           {
-            "line": 7685,
+            "line": 7696,
             "name": "maximum_wind_speed_mph",
             "type": "integer"
           }
@@ -9217,27 +9217,27 @@
       {
         "fields": [
           {
-            "line": 7586,
+            "line": 7597,
             "name": "dangerous",
             "type": "boolean"
           },
           {
-            "line": 7584,
+            "line": 7595,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7583,
+            "line": 7594,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 7585,
+            "line": 7596,
             "name": "query",
             "type": "string"
           },
           {
-            "line": 7587,
+            "line": 7598,
             "name": "rains",
             "type": "boolean"
           }
@@ -9247,32 +9247,32 @@
       {
         "fields": [
           {
-            "line": 7590,
+            "line": 7601,
             "name": "items",
             "type": "CcbWeatherTypeSnapshot[]"
           },
           {
-            "line": 7594,
+            "line": 7605,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7593,
+            "line": 7604,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 7592,
+            "line": 7603,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 7591,
+            "line": 7602,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 7595,
+            "line": 7606,
             "name": "truncated",
             "type": "boolean"
           }
@@ -9282,82 +9282,82 @@
       {
         "fields": [
           {
-            "line": 7598,
+            "line": 7609,
             "name": "at",
             "type": "TimePoint"
           },
           {
-            "line": 7602,
+            "line": 7613,
             "name": "humidity",
             "type": "number"
           },
           {
-            "line": 7612,
+            "line": 7623,
             "name": "is_day",
             "type": "boolean"
           },
           {
-            "line": 7613,
+            "line": 7624,
             "name": "is_night",
             "type": "boolean"
           },
           {
-            "line": 7611,
+            "line": 7622,
             "name": "moonlight",
             "type": "number"
           },
           {
-            "line": 7607,
+            "line": 7618,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 7608,
+            "line": 7619,
             "name": "precipitation_mm_per_hour",
             "type": "number"
           },
           {
-            "line": 7603,
+            "line": 7614,
             "name": "pressure",
             "type": "number"
           },
           {
-            "line": 7610,
+            "line": 7621,
             "name": "sun_irradiance",
             "type": "number"
           },
           {
-            "line": 7609,
+            "line": 7620,
             "name": "sunlight",
             "type": "number"
           },
           {
-            "line": 7600,
+            "line": 7611,
             "name": "temperature",
             "type": "UnitValue"
           },
           {
-            "line": 7601,
+            "line": 7612,
             "name": "temperature_c",
             "type": "number"
           },
           {
-            "line": 7599,
+            "line": 7610,
             "name": "weather",
             "type": "GameId"
           },
           {
-            "line": 7606,
+            "line": 7617,
             "name": "wind_description",
             "type": "string"
           },
           {
-            "line": 7605,
+            "line": 7616,
             "name": "wind_direction_degrees",
             "type": "integer"
           },
           {
-            "line": 7604,
+            "line": 7615,
             "name": "wind_speed_mph",
             "type": "number"
           }
@@ -9367,12 +9367,12 @@
       {
         "fields": [
           {
-            "line": 7639,
+            "line": 7650,
             "name": "humidity_modifier",
             "type": "integer"
           },
           {
-            "line": 7638,
+            "line": 7649,
             "name": "temperature_modifier",
             "type": "integer"
           }
@@ -9382,22 +9382,22 @@
       {
         "fields": [
           {
-            "line": 7644,
+            "line": 7655,
             "name": "autumn",
             "type": "CcbWeatherSeasonModifiers"
           },
           {
-            "line": 7642,
+            "line": 7653,
             "name": "spring",
             "type": "CcbWeatherSeasonModifiers"
           },
           {
-            "line": 7643,
+            "line": 7654,
             "name": "summer",
             "type": "CcbWeatherSeasonModifiers"
           },
           {
-            "line": 7645,
+            "line": 7656,
             "name": "winter",
             "type": "CcbWeatherSeasonModifiers"
           }
@@ -9407,22 +9407,22 @@
       {
         "fields": [
           {
-            "line": 10632,
+            "line": 10643,
             "name": "id",
             "type": "string"
           },
           {
-            "line": 10633,
+            "line": 10644,
             "name": "temperature_c",
             "type": "number"
           },
           {
-            "line": 10635,
+            "line": 10646,
             "name": "wind_direction",
             "type": "number"
           },
           {
-            "line": 10634,
+            "line": 10645,
             "name": "wind_speed",
             "type": "number"
           }
@@ -9432,22 +9432,22 @@
       {
         "fields": [
           {
-            "line": 7552,
+            "line": 7563,
             "name": "items",
             "type": "CcbWeatherSourceSnapshot[]"
           },
           {
-            "line": 7554,
+            "line": 7565,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 7553,
+            "line": 7564,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 7555,
+            "line": 7566,
             "name": "truncated",
             "type": "boolean"
           }
@@ -9457,12 +9457,12 @@
       {
         "fields": [
           {
-            "line": 7549,
+            "line": 7560,
             "name": "mod",
             "type": "string"
           },
           {
-            "line": 7548,
+            "line": 7559,
             "name": "weather",
             "type": "GameId"
           }
@@ -9472,22 +9472,22 @@
       {
         "fields": [
           {
-            "line": 7632,
+            "line": 7643,
             "name": "items",
             "type": "string[]"
           },
           {
-            "line": 7634,
+            "line": 7645,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 7633,
+            "line": 7644,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 7635,
+            "line": 7646,
             "name": "truncated",
             "type": "boolean"
           }
@@ -9497,22 +9497,22 @@
       {
         "fields": [
           {
-            "line": 7542,
+            "line": 7553,
             "name": "items",
             "type": "GameId[]"
           },
           {
-            "line": 7544,
+            "line": 7555,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 7543,
+            "line": 7554,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 7545,
+            "line": 7556,
             "name": "truncated",
             "type": "boolean"
           }
@@ -9522,117 +9522,117 @@
       {
         "fields": [
           {
-            "line": 7569,
+            "line": 7580,
             "name": "dangerous",
             "type": "boolean"
           },
           {
-            "line": 7578,
+            "line": 7589,
             "name": "duration_max",
             "type": "TimeDuration"
           },
           {
-            "line": 7577,
+            "line": 7588,
             "name": "duration_min",
             "type": "TimeDuration"
           },
           {
-            "line": 7558,
+            "line": 7569,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 7565,
+            "line": 7576,
             "name": "light_modifier",
             "type": "integer"
           },
           {
-            "line": 7566,
+            "line": 7577,
             "name": "light_multiplier",
             "type": "number"
           },
           {
-            "line": 7560,
+            "line": 7571,
             "name": "loaded",
             "type": "boolean"
           },
           {
-            "line": 7559,
+            "line": 7570,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 7570,
+            "line": 7581,
             "name": "precipitation",
             "type": "'none'|'very_light'|'light'|'heavy'"
           },
           {
-            "line": 7571,
+            "line": 7582,
             "name": "precipitation_mm_per_hour",
             "type": "number"
           },
           {
-            "line": 7574,
+            "line": 7585,
             "name": "priority",
             "type": "integer"
           },
           {
-            "line": 7572,
+            "line": 7583,
             "name": "rains",
             "type": "boolean"
           },
           {
-            "line": 7563,
+            "line": 7574,
             "name": "ranged_penalty",
             "type": "integer"
           },
           {
-            "line": 7579,
+            "line": 7590,
             "name": "required_weathers",
             "type": "CcbWeatherTypeIdPage"
           },
           {
-            "line": 7564,
+            "line": 7575,
             "name": "sight_penalty",
             "type": "number"
           },
           {
-            "line": 7568,
+            "line": 7579,
             "name": "sound_attenuation",
             "type": "integer"
           },
           {
-            "line": 7576,
+            "line": 7587,
             "name": "sound_category",
             "type": "'silent'|'drizzle'|'rainy'|'rainstorm'|'thunder'|'flurries'|'snowstorm'|'snow'|'portal_storm'|'clear'|'sunny'|'cloudy'"
           },
           {
-            "line": 7580,
+            "line": 7591,
             "name": "sources",
             "type": "CcbWeatherSourcePage"
           },
           {
-            "line": 7567,
+            "line": 7578,
             "name": "sun_multiplier",
             "type": "number"
           },
           {
-            "line": 7562,
+            "line": 7573,
             "name": "sun_symbol",
             "type": "string"
           },
           {
-            "line": 7561,
+            "line": 7572,
             "name": "symbol",
             "type": "string"
           },
           {
-            "line": 7573,
+            "line": 7584,
             "name": "temperature_modifier_c",
             "type": "number"
           },
           {
-            "line": 7575,
+            "line": 7586,
             "name": "tiles_animation",
             "type": "string"
           }
@@ -9642,22 +9642,22 @@
       {
         "fields": [
           {
-            "line": 7721,
+            "line": 7732,
             "name": "clear_direction",
             "type": "boolean"
           },
           {
-            "line": 7720,
+            "line": 7731,
             "name": "clear_speed",
             "type": "boolean"
           },
           {
-            "line": 7719,
+            "line": 7730,
             "name": "direction_degrees",
             "type": "integer"
           },
           {
-            "line": 7718,
+            "line": 7729,
             "name": "speed_mph",
             "type": "integer"
           }
@@ -9667,42 +9667,42 @@
       {
         "fields": [
           {
-            "line": 7852,
+            "line": 7863,
             "name": "enabled",
             "type": "boolean"
           },
           {
-            "line": 7850,
+            "line": 7861,
             "name": "end",
             "type": "TripointCoord"
           },
           {
-            "line": 7848,
+            "line": 7859,
             "name": "faction",
             "type": "GameId"
           },
           {
-            "line": 7851,
+            "line": 7862,
             "name": "invert",
             "type": "boolean"
           },
           {
-            "line": 7853,
+            "line": 7864,
             "name": "kind",
             "type": "'global'|'personal'"
           },
           {
-            "line": 7846,
+            "line": 7857,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 7849,
+            "line": 7860,
             "name": "start",
             "type": "TripointCoord"
           },
           {
-            "line": 7847,
+            "line": 7858,
             "name": "type",
             "type": "GameId"
           }
@@ -9712,32 +9712,32 @@
       {
         "fields": [
           {
-            "line": 7798,
+            "line": 7809,
             "name": "faction",
             "type": "GameId"
           },
           {
-            "line": 7800,
+            "line": 7811,
             "name": "kind",
             "type": "'global'|'personal'|'vehicle'"
           },
           {
-            "line": 7796,
+            "line": 7807,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7795,
+            "line": 7806,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 7797,
+            "line": 7808,
             "name": "query",
             "type": "string"
           },
           {
-            "line": 7799,
+            "line": 7810,
             "name": "type",
             "type": "GameId"
           }
@@ -9747,42 +9747,42 @@
       {
         "fields": [
           {
-            "line": 7837,
+            "line": 7848,
             "name": "faction",
             "type": "GameId"
           },
           {
-            "line": 7843,
+            "line": 7854,
             "name": "has_more",
             "type": "boolean"
           },
           {
-            "line": 7836,
+            "line": 7847,
             "name": "items",
             "type": "CcbZoneSnapshot[]"
           },
           {
-            "line": 7840,
+            "line": 7851,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7839,
+            "line": 7850,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 7838,
+            "line": 7849,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 7842,
+            "line": 7853,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 7841,
+            "line": 7852,
             "name": "total",
             "type": "integer"
           }
@@ -9792,12 +9792,12 @@
       {
         "fields": [
           {
-            "line": 7856,
+            "line": 7867,
             "name": "changed",
             "type": "boolean"
           },
           {
-            "line": 7857,
+            "line": 7868,
             "name": "zone",
             "type": "CcbZoneSnapshot"
           }
@@ -9807,12 +9807,12 @@
       {
         "fields": [
           {
-            "line": 7803,
+            "line": 7814,
             "name": "label",
             "type": "string"
           },
           {
-            "line": 7804,
+            "line": 7815,
             "name": "value",
             "type": "string"
           }
@@ -9822,22 +9822,22 @@
       {
         "fields": [
           {
-            "line": 7807,
+            "line": 7818,
             "name": "items",
             "type": "CcbZoneOptionDescription[]"
           },
           {
-            "line": 7809,
+            "line": 7820,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 7808,
+            "line": 7819,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 7810,
+            "line": 7821,
             "name": "truncated",
             "type": "boolean"
           }
@@ -9847,12 +9847,12 @@
       {
         "fields": [
           {
-            "line": 7860,
+            "line": 7871,
             "name": "removed",
             "type": "boolean"
           },
           {
-            "line": 7861,
+            "line": 7872,
             "name": "zone",
             "type": "CcbZoneSnapshot"
           }
@@ -9862,92 +9862,92 @@
       {
         "fields": [
           {
-            "line": 7825,
+            "line": 7836,
             "name": "center",
             "type": "TripointCoord"
           },
           {
-            "line": 7828,
+            "line": 7839,
             "name": "displayed",
             "type": "boolean"
           },
           {
-            "line": 7831,
+            "line": 7842,
             "name": "enabled",
             "type": "boolean"
           },
           {
-            "line": 7822,
+            "line": 7833,
             "name": "end",
             "type": "TripointCoord"
           },
           {
-            "line": 7820,
+            "line": 7831,
             "name": "faction",
             "type": "GameId"
           },
           {
-            "line": 7832,
+            "line": 7843,
             "name": "has_options",
             "type": "boolean"
           },
           {
-            "line": 7826,
+            "line": 7837,
             "name": "invert",
             "type": "boolean"
           },
           {
-            "line": 7830,
+            "line": 7841,
             "name": "kind",
             "type": "'global'|'personal'|'vehicle'"
           },
           {
-            "line": 7817,
+            "line": 7828,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 7833,
+            "line": 7844,
             "name": "options",
             "type": "CcbZoneOptionPage"
           },
           {
-            "line": 7824,
+            "line": 7835,
             "name": "relative_end",
             "type": "TripointCoord"
           },
           {
-            "line": 7823,
+            "line": 7834,
             "name": "relative_start",
             "type": "TripointCoord"
           },
           {
-            "line": 7821,
+            "line": 7832,
             "name": "start",
             "type": "TripointCoord"
           },
           {
-            "line": 7827,
+            "line": 7838,
             "name": "temporarily_disabled",
             "type": "boolean"
           },
           {
-            "line": 7816,
+            "line": 7827,
             "name": "token",
             "type": "ZoneToken"
           },
           {
-            "line": 7818,
+            "line": 7829,
             "name": "type",
             "type": "GameId"
           },
           {
-            "line": 7819,
+            "line": 7830,
             "name": "type_name",
             "type": "string"
           },
           {
-            "line": 7829,
+            "line": 7840,
             "name": "vehicle",
             "type": "boolean"
           }
@@ -9957,17 +9957,17 @@
       {
         "fields": [
           {
-            "line": 7783,
+            "line": 7794,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7782,
+            "line": 7793,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 7784,
+            "line": 7795,
             "name": "query",
             "type": "string"
           }
@@ -9977,32 +9977,32 @@
       {
         "fields": [
           {
-            "line": 7792,
+            "line": 7803,
             "name": "has_more",
             "type": "boolean"
           },
           {
-            "line": 7787,
+            "line": 7798,
             "name": "items",
             "type": "CcbZoneTypeSnapshot[]"
           },
           {
-            "line": 7789,
+            "line": 7800,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7788,
+            "line": 7799,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 7791,
+            "line": 7802,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 7790,
+            "line": 7801,
             "name": "total",
             "type": "integer"
           }
@@ -10012,12 +10012,12 @@
       {
         "fields": [
           {
-            "line": 7778,
+            "line": 7789,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 7779,
+            "line": 7790,
             "name": "name",
             "type": "string"
           }
@@ -12475,42 +12475,42 @@
       {
         "fields": [
           {
-            "line": 7941,
+            "line": 7952,
             "name": "__tostring",
             "type": "fun(self:"
           },
           {
-            "line": 7939,
+            "line": 7950,
             "name": "identity_generation",
             "type": "integer"
           },
           {
-            "line": 7940,
+            "line": 7951,
             "name": "is_valid",
             "type": "fun(self:"
           },
           {
-            "line": 7935,
+            "line": 7946,
             "name": "monster",
             "type": "GameId"
           },
           {
-            "line": 7938,
+            "line": 7949,
             "name": "owner_generation",
             "type": "integer"
           },
           {
-            "line": 7934,
+            "line": 7945,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 7936,
+            "line": 7947,
             "name": "runtime_generation",
             "type": "integer"
           },
           {
-            "line": 7937,
+            "line": 7948,
             "name": "world_generation",
             "type": "integer"
           }
@@ -12840,42 +12840,42 @@
       {
         "fields": [
           {
-            "line": 7952,
+            "line": 7963,
             "name": "__tostring",
             "type": "fun(self:"
           },
           {
-            "line": 7946,
+            "line": 7957,
             "name": "group",
             "type": "GameId"
           },
           {
-            "line": 7950,
+            "line": 7961,
             "name": "identity_generation",
             "type": "integer"
           },
           {
-            "line": 7951,
+            "line": 7962,
             "name": "is_valid",
             "type": "fun(self:"
           },
           {
-            "line": 7949,
+            "line": 7960,
             "name": "owner_generation",
             "type": "integer"
           },
           {
-            "line": 7945,
+            "line": 7956,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 7947,
+            "line": 7958,
             "name": "runtime_generation",
             "type": "integer"
           },
           {
-            "line": 7948,
+            "line": 7959,
             "name": "world_generation",
             "type": "integer"
           }
@@ -13079,37 +13079,37 @@
       {
         "fields": [
           {
-            "line": 6840,
+            "line": 6851,
             "name": "complete_omt_z_stack",
             "type": "boolean"
           },
           {
-            "line": 6835,
+            "line": 6846,
             "name": "max_submap_x",
             "type": "integer"
           },
           {
-            "line": 6837,
+            "line": 6848,
             "name": "max_submap_y",
             "type": "integer"
           },
           {
-            "line": 6839,
+            "line": 6850,
             "name": "max_z",
             "type": "integer"
           },
           {
-            "line": 6834,
+            "line": 6845,
             "name": "min_submap_x",
             "type": "integer"
           },
           {
-            "line": 6836,
+            "line": 6847,
             "name": "min_submap_y",
             "type": "integer"
           },
           {
-            "line": 6838,
+            "line": 6849,
             "name": "min_z",
             "type": "integer"
           }
@@ -13119,32 +13119,32 @@
       {
         "fields": [
           {
-            "line": 6844,
+            "line": 6855,
             "name": "code",
             "type": "'committed'"
           },
           {
-            "line": 6846,
+            "line": 6857,
             "name": "footprint",
             "type": "MapgenTransactionFootprint"
           },
           {
-            "line": 6845,
+            "line": 6856,
             "name": "message",
             "type": "''"
           },
           {
-            "line": 6843,
+            "line": 6854,
             "name": "state",
             "type": "'committed'"
           },
           {
-            "line": 6847,
+            "line": 6858,
             "name": "target",
             "type": "OvermapTileToken"
           },
           {
-            "line": 6848,
+            "line": 6859,
             "name": "update",
             "type": "MapgenUpdateToken"
           }
@@ -13154,27 +13154,27 @@
       {
         "fields": [
           {
-            "line": 6827,
+            "line": 6838,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 6831,
+            "line": 6842,
             "name": "is_valid",
             "type": "fun(self:"
           },
           {
-            "line": 6830,
+            "line": 6841,
             "name": "owner_is_current",
             "type": "fun(self:"
           },
           {
-            "line": 6828,
+            "line": 6839,
             "name": "runtime_generation",
             "type": "integer"
           },
           {
-            "line": 6829,
+            "line": 6840,
             "name": "world_generation",
             "type": "integer"
           }
@@ -13508,27 +13508,27 @@
       {
         "fields": [
           {
-            "line": 8572,
+            "line": 8583,
             "name": "identity_generation",
             "type": "integer"
           },
           {
-            "line": 8575,
+            "line": 8586,
             "name": "is_valid",
             "type": "fun(self:"
           },
           {
-            "line": 8573,
+            "line": 8584,
             "name": "runtime_generation",
             "type": "integer"
           },
           {
-            "line": 8571,
+            "line": 8582,
             "name": "uid",
             "type": "integer"
           },
           {
-            "line": 8574,
+            "line": 8585,
             "name": "world_generation",
             "type": "integer"
           }
@@ -15352,6 +15352,51 @@
       {
         "fields": [],
         "name": "PlatformDialogueContext"
+      },
+      {
+        "fields": [
+          {
+            "line": 6475,
+            "name": "default",
+            "type": "string"
+          },
+          {
+            "line": 6476,
+            "name": "description",
+            "type": "string"
+          },
+          {
+            "line": 6477,
+            "name": "identifier",
+            "type": "string"
+          },
+          {
+            "line": 6478,
+            "name": "width",
+            "type": "integer"
+          }
+        ],
+        "name": "PlatformInteractionTextInputOptions"
+      },
+      {
+        "fields": [
+          {
+            "line": 6481,
+            "name": "accepted",
+            "type": "boolean"
+          },
+          {
+            "line": 6482,
+            "name": "cancelled",
+            "type": "boolean"
+          },
+          {
+            "line": 6483,
+            "name": "value",
+            "type": "string"
+          }
+        ],
+        "name": "PlatformInteractionTextInputResult"
       },
       {
         "fields": [
@@ -18245,82 +18290,82 @@
       {
         "fields": [
           {
-            "line": 9580,
+            "line": 9591,
             "name": "buyer_identity_generation",
             "type": "integer"
           },
           {
-            "line": 9578,
+            "line": 9589,
             "name": "buyer_stable_id",
             "type": "integer"
           },
           {
-            "line": 9584,
+            "line": 9595,
             "name": "debt_generation",
             "type": "integer"
           },
           {
-            "line": 9587,
+            "line": 9598,
             "name": "expires_turn",
             "type": "integer"
           },
           {
-            "line": 9583,
+            "line": 9594,
             "name": "faction_generation",
             "type": "integer"
           },
           {
-            "line": 9581,
+            "line": 9592,
             "name": "holder_mutation_generation",
             "type": "integer"
           },
           {
-            "line": 9589,
+            "line": 9600,
             "name": "is_valid",
             "type": "fun(self:"
           },
           {
-            "line": 9586,
+            "line": 9597,
             "name": "issued_turn",
             "type": "integer"
           },
           {
-            "line": 9585,
+            "line": 9596,
             "name": "opinion_generation",
             "type": "integer"
           },
           {
-            "line": 9582,
+            "line": 9593,
             "name": "pricing_generation",
             "type": "integer"
           },
           {
-            "line": 9574,
+            "line": 9585,
             "name": "quote_id",
             "type": "integer"
           },
           {
-            "line": 9588,
+            "line": 9599,
             "name": "registered",
             "type": "boolean"
           },
           {
-            "line": 9575,
+            "line": 9586,
             "name": "runtime_generation",
             "type": "integer"
           },
           {
-            "line": 9579,
+            "line": 9590,
             "name": "seller_identity_generation",
             "type": "integer"
           },
           {
-            "line": 9577,
+            "line": 9588,
             "name": "seller_stable_id",
             "type": "integer"
           },
           {
-            "line": 9576,
+            "line": 9587,
             "name": "world_generation",
             "type": "integer"
           }
@@ -19930,57 +19975,57 @@
       {
         "fields": [
           {
-            "line": 7769,
+            "line": 7780,
             "name": "end",
             "type": "TripointCoord"
           },
           {
-            "line": 7765,
+            "line": 7776,
             "name": "faction",
             "type": "GameId"
           },
           {
-            "line": 7774,
+            "line": 7785,
             "name": "is_valid",
             "type": "fun(self:"
           },
           {
-            "line": 7773,
+            "line": 7784,
             "name": "kind",
             "type": "'global'|'personal'|'vehicle'"
           },
           {
-            "line": 7767,
+            "line": 7778,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 7771,
+            "line": 7782,
             "name": "relative_end",
             "type": "TripointCoord"
           },
           {
-            "line": 7770,
+            "line": 7781,
             "name": "relative_start",
             "type": "TripointCoord"
           },
           {
-            "line": 7768,
+            "line": 7779,
             "name": "start",
             "type": "TripointCoord"
           },
           {
-            "line": 7775,
+            "line": 7786,
             "name": "status",
             "type": "fun(self:"
           },
           {
-            "line": 7766,
+            "line": 7777,
             "name": "type",
             "type": "GameId"
           },
           {
-            "line": 7772,
+            "line": 7783,
             "name": "vehicle",
             "type": "boolean"
           }
@@ -20282,439 +20327,439 @@
         "parameters": "speed, size, butcher, requirement_id"
       },
       {
-        "line": "9972",
+        "line": "9983",
         "name": "grant",
         "owner": "CcbBionicsApi",
         "parameters": "character, bionic"
       },
       {
-        "line": "9966",
+        "line": "9977",
         "name": "has",
         "owner": "CcbBionicsApi",
         "parameters": "character, bionic"
       },
       {
-        "line": "9978",
+        "line": "9989",
         "name": "remove_type",
         "owner": "CcbBionicsApi",
         "parameters": "character, bionic"
       },
       {
-        "line": "9960",
+        "line": "9971",
         "name": "summary",
         "owner": "CcbBionicsApi",
         "parameters": "character"
       },
       {
-        "line": "7272",
+        "line": "7283",
         "name": "create",
         "owner": "CcbCampExpansionsApi",
         "parameters": "camp, manager, position, type, name"
       },
       {
-        "line": "7284",
+        "line": "7295",
         "name": "get",
         "owner": "CcbCampExpansionsApi",
         "parameters": "camp, manager, token"
       },
       {
-        "line": "7278",
+        "line": "7289",
         "name": "list",
         "owner": "CcbCampExpansionsApi",
         "parameters": "camp, manager, options"
       },
       {
-        "line": "7290",
+        "line": "7301",
         "name": "remove",
         "owner": "CcbCampExpansionsApi",
         "parameters": "camp, manager, token"
       },
       {
-        "line": "6960",
+        "line": "6971",
         "name": "add",
         "owner": "CcbCampFoodApi",
         "parameters": "camp, manager, kcal"
       },
       {
-        "line": "6966",
+        "line": "6977",
         "name": "consume",
         "owner": "CcbCampFoodApi",
         "parameters": "camp, manager, kcal"
       },
       {
-        "line": "7313",
+        "line": "7324",
         "name": "storage_tiles",
         "owner": "CcbCampInventoryApi",
         "parameters": "camp, manager, options"
       },
       {
-        "line": "6935",
+        "line": "6946",
         "name": "add",
         "owner": "CcbCampResourcesApi",
         "parameters": "camp, manager, resource_id, amount"
       },
       {
-        "line": "6928",
+        "line": "6939",
         "name": "adjust",
         "owner": "CcbCampResourcesApi",
         "parameters": "camp, manager, changes"
       },
       {
-        "line": "6942",
+        "line": "6953",
         "name": "consume",
         "owner": "CcbCampResourcesApi",
         "parameters": "camp, manager, resource_id, amount"
       },
       {
-        "line": "6922",
+        "line": "6933",
         "name": "snapshot",
         "owner": "CcbCampResourcesApi",
         "parameters": "camp, manager, options"
       },
       {
-        "line": "7216",
+        "line": "7227",
         "name": "cancel",
         "owner": "CcbCampTasksApi",
         "parameters": "camp, manager, worker, token"
       },
       {
-        "line": "7192",
+        "line": "7203",
         "name": "claim",
         "owner": "CcbCampTasksApi",
         "parameters": "camp, manager, worker, token, destination_holder"
       },
       {
-        "line": "7230",
+        "line": "7241",
         "name": "complete",
         "owner": "CcbCampTasksApi",
         "parameters": "camp, manager, worker, token"
       },
       {
-        "line": "7162",
+        "line": "7173",
         "name": "create",
         "owner": "CcbCampTasksApi",
         "parameters": "camp, manager, worker, kind, descriptor"
       },
       {
-        "line": "7176",
+        "line": "7187",
         "name": "get",
         "owner": "CcbCampTasksApi",
         "parameters": "camp, manager, worker, token"
       },
       {
-        "line": "7169",
+        "line": "7180",
         "name": "page",
         "owner": "CcbCampTasksApi",
         "parameters": "camp, manager, worker, options"
       },
       {
-        "line": "7223",
+        "line": "7234",
         "name": "recall",
         "owner": "CcbCampTasksApi",
         "parameters": "camp, manager, worker, token"
       },
       {
-        "line": "7184",
+        "line": "7195",
         "name": "resolve",
         "owner": "CcbCampTasksApi",
         "parameters": "camp, manager, worker, token, destination_holder"
       },
       {
-        "line": "7200",
+        "line": "7211",
         "name": "retry",
         "owner": "CcbCampTasksApi",
         "parameters": "camp, manager, worker, token, destination_holder"
       },
       {
-        "line": "7209",
+        "line": "7220",
         "name": "start",
         "owner": "CcbCampTasksApi",
         "parameters": "camp, manager, worker, token, requests_or_duration, duration_turns"
       },
       {
-        "line": "7395",
+        "line": "7406",
         "name": "assign_worker",
         "owner": "CcbCampsApi",
         "parameters": "camp, manager, worker"
       },
       {
-        "line": "7356",
+        "line": "7367",
         "name": "create",
         "owner": "CcbCampsApi",
         "parameters": "owner_faction, manager, omt_position, name, options"
       },
       {
-        "line": "7371",
+        "line": "7382",
         "name": "get",
-        "owner": "CcbCampsApi",
-        "parameters": "camp, manager"
-      },
-      {
-        "line": "7366",
-        "name": "list",
-        "owner": "CcbCampsApi",
-        "parameters": "center, options"
-      },
-      {
-        "line": "7401",
-        "name": "recall_worker",
-        "owner": "CcbCampsApi",
-        "parameters": "camp, manager, worker"
-      },
-      {
-        "line": "7361",
-        "name": "remove",
         "owner": "CcbCampsApi",
         "parameters": "camp, manager"
       },
       {
         "line": "7377",
+        "name": "list",
+        "owner": "CcbCampsApi",
+        "parameters": "center, options"
+      },
+      {
+        "line": "7412",
+        "name": "recall_worker",
+        "owner": "CcbCampsApi",
+        "parameters": "camp, manager, worker"
+      },
+      {
+        "line": "7372",
+        "name": "remove",
+        "owner": "CcbCampsApi",
+        "parameters": "camp, manager"
+      },
+      {
+        "line": "7388",
         "name": "rename",
         "owner": "CcbCampsApi",
         "parameters": "camp, manager, name"
       },
       {
-        "line": "7389",
+        "line": "7400",
         "name": "set_board_position",
         "owner": "CcbCampsApi",
         "parameters": "camp, manager, position"
       },
       {
-        "line": "7383",
+        "line": "7394",
         "name": "set_owner",
         "owner": "CcbCampsApi",
         "parameters": "camp, manager, owner"
       },
       {
-        "line": "7470",
+        "line": "7481",
         "name": "attack",
         "owner": "CcbCharactersApi",
         "parameters": "attacker, target, technique, options"
       },
       {
-        "line": "7442",
+        "line": "7453",
         "name": "avatar",
         "owner": "CcbCharactersApi",
         "parameters": ""
       },
       {
-        "line": "7447",
+        "line": "7458",
         "name": "body_parts",
         "owner": "CcbCharactersApi",
         "parameters": "character"
       },
       {
-        "line": "7497",
+        "line": "7508",
         "name": "cast_spell",
         "owner": "CcbCharactersApi",
         "parameters": "character, spell, options"
       },
       {
-        "line": "7437",
+        "line": "7448",
         "name": "choose_technique",
         "owner": "CcbCharactersApi",
         "parameters": "attacker, target, options"
       },
       {
-        "line": "7502",
+        "line": "7513",
         "name": "die",
         "owner": "CcbCharactersApi",
         "parameters": "character, options"
       },
       {
-        "line": "7491",
+        "line": "7502",
         "name": "emit",
         "owner": "CcbCharactersApi",
         "parameters": "character, emission, chance"
       },
       {
-        "line": "7485",
+        "line": "7496",
         "name": "explosion",
         "owner": "CcbCharactersApi",
         "parameters": "character, options"
       },
       {
-        "line": "7480",
+        "line": "7491",
         "name": "knockback",
         "owner": "CcbCharactersApi",
         "parameters": "character, options"
       },
       {
-        "line": "7463",
+        "line": "7474",
         "name": "nearby",
         "owner": "CcbCharactersApi",
         "parameters": "observer, options"
       },
       {
-        "line": "7506",
+        "line": "7517",
         "name": "prevent_death",
         "owner": "CcbCharactersApi",
         "parameters": "character"
       },
       {
-        "line": "7453",
+        "line": "7464",
         "name": "random_body_part",
         "owner": "CcbCharactersApi",
         "parameters": "character, main_parts_only"
       },
       {
-        "line": "7475",
+        "line": "7486",
         "name": "ranged_attack",
         "owner": "CcbCharactersApi",
         "parameters": "attacker, target"
       },
       {
-        "line": "7510",
+        "line": "7521",
         "name": "recalculate_enchantments",
         "owner": "CcbCharactersApi",
         "parameters": "character"
       },
       {
-        "line": "7458",
+        "line": "7469",
         "name": "snapshot",
         "owner": "CcbCharactersApi",
         "parameters": "character, body_part_limit"
       },
       {
-        "line": "10618",
+        "line": "10629",
         "name": "nearby",
         "owner": "CcbCreaturesApi",
         "parameters": "observer, options"
       },
       {
-        "line": "10613",
+        "line": "10624",
         "name": "snapshot",
         "owner": "CcbCreaturesApi",
         "parameters": "handle"
       },
       {
-        "line": "10623",
+        "line": "10634",
         "name": "visible_monsters",
         "owner": "CcbCreaturesApi",
         "parameters": "observer, direction"
       },
       {
-        "line": "10096",
+        "line": "10107",
         "name": "add",
         "owner": "CcbEffectsApi",
         "parameters": "character, effect, duration, options"
       },
       {
-        "line": "10111",
+        "line": "10122",
         "name": "get",
         "owner": "CcbEffectsApi",
         "parameters": "character, effect, body_part"
       },
       {
-        "line": "10104",
+        "line": "10115",
         "name": "has",
         "owner": "CcbEffectsApi",
         "parameters": "character, effect, body_part, intensity"
       },
       {
-        "line": "10118",
+        "line": "10129",
         "name": "remove",
         "owner": "CcbEffectsApi",
         "parameters": "character, effect, body_part"
       },
       {
-        "line": "9216",
+        "line": "9227",
         "name": "unequip",
         "owner": "CcbEquipmentApi",
         "parameters": "actor, item, destination_holder"
       },
       {
-        "line": "9210",
+        "line": "9221",
         "name": "wear",
         "owner": "CcbEquipmentApi",
         "parameters": "actor, item, source_holder, displaced_destination"
       },
       {
-        "line": "9203",
+        "line": "9214",
         "name": "wield",
         "owner": "CcbEquipmentApi",
         "parameters": "actor, item, source_holder, displaced_destination"
       },
       {
-        "line": "8766",
+        "line": "8777",
         "name": "food",
         "owner": "CcbFactionsApi",
         "parameters": "id, options"
       },
       {
-        "line": "8750",
+        "line": "8761",
         "name": "for_character",
         "owner": "CcbFactionsApi",
         "parameters": "character"
       },
       {
-        "line": "8747",
+        "line": "8758",
         "name": "get",
         "owner": "CcbFactionsApi",
         "parameters": "id"
       },
       {
-        "line": "8744",
+        "line": "8755",
         "name": "list",
         "owner": "CcbFactionsApi",
         "parameters": "options"
       },
       {
-        "line": "8754",
+        "line": "8765",
         "name": "members",
         "owner": "CcbFactionsApi",
         "parameters": "id, options"
       },
       {
-        "line": "8786",
+        "line": "8797",
         "name": "modify_food",
         "owner": "CcbFactionsApi",
         "parameters": "id, kcal"
       },
       {
-        "line": "8778",
+        "line": "8789",
         "name": "modify_reputation",
         "owner": "CcbFactionsApi",
         "parameters": "id, deltas"
       },
       {
-        "line": "8782",
+        "line": "8793",
         "name": "modify_resources",
         "owner": "CcbFactionsApi",
         "parameters": "id, deltas"
       },
       {
-        "line": "8762",
+        "line": "8773",
         "name": "relationship",
         "owner": "CcbFactionsApi",
         "parameters": "id, target"
       },
       {
-        "line": "8758",
+        "line": "8769",
         "name": "relationships",
         "owner": "CcbFactionsApi",
         "parameters": "id, options"
       },
       {
-        "line": "8770",
+        "line": "8781",
         "name": "rename",
         "owner": "CcbFactionsApi",
         "parameters": "id, name"
       },
       {
-        "line": "8774",
+        "line": "8785",
         "name": "set_known",
         "owner": "CcbFactionsApi",
         "parameters": "id, known"
       },
       {
-        "line": "8790",
+        "line": "8801",
         "name": "set_policy",
         "owner": "CcbFactionsApi",
         "parameters": "id, options"
       },
       {
-        "line": "8795",
+        "line": "8806",
         "name": "set_relationship",
         "owner": "CcbFactionsApi",
         "parameters": "id, target, options"
@@ -20726,379 +20771,379 @@
         "parameters": ""
       },
       {
-        "line": "8216",
+        "line": "8227",
         "name": "alert_entity",
         "owner": "CcbHordesApi",
         "parameters": "token, destination, intensity"
       },
       {
-        "line": "8183",
+        "line": "8194",
         "name": "contains",
         "owner": "CcbHordesApi",
         "parameters": "group, monster"
       },
       {
-        "line": "8172",
+        "line": "8183",
         "name": "definition",
         "owner": "CcbHordesApi",
         "parameters": "id, options"
       },
       {
-        "line": "8167",
+        "line": "8178",
         "name": "definitions",
         "owner": "CcbHordesApi",
         "parameters": "options"
       },
       {
-        "line": "8188",
+        "line": "8199",
         "name": "entities",
         "owner": "CcbHordesApi",
         "parameters": "center, options"
       },
       {
-        "line": "8192",
+        "line": "8203",
         "name": "entity",
         "owner": "CcbHordesApi",
         "parameters": "token"
       },
       {
-        "line": "8201",
+        "line": "8212",
         "name": "legacy_group",
         "owner": "CcbHordesApi",
         "parameters": "token"
       },
       {
-        "line": "8197",
+        "line": "8208",
         "name": "legacy_groups",
         "owner": "CcbHordesApi",
         "parameters": "center, options"
       },
       {
-        "line": "8163",
+        "line": "8174",
         "name": "limits",
         "owner": "CcbHordesApi",
         "parameters": ""
       },
       {
-        "line": "8178",
+        "line": "8189",
         "name": "monsters",
         "owner": "CcbHordesApi",
         "parameters": "id, recursive, options"
       },
       {
-        "line": "8220",
+        "line": "8231",
         "name": "remove_entity",
         "owner": "CcbHordesApi",
         "parameters": "token"
       },
       {
-        "line": "8233",
+        "line": "8244",
         "name": "remove_legacy_group",
         "owner": "CcbHordesApi",
         "parameters": "token"
       },
       {
-        "line": "8210",
+        "line": "8221",
         "name": "spawn_entity",
         "owner": "CcbHordesApi",
         "parameters": "position, monster"
       },
       {
-        "line": "8224",
+        "line": "8235",
         "name": "spawn_legacy_group",
         "owner": "CcbHordesApi",
         "parameters": "options"
       },
       {
-        "line": "8205",
+        "line": "8216",
         "name": "summary",
         "owner": "CcbHordesApi",
         "parameters": "position"
       },
       {
-        "line": "8229",
+        "line": "8240",
         "name": "update_legacy_group",
         "owner": "CcbHordesApi",
         "parameters": "token, options"
       },
       {
-        "line": "9092",
+        "line": "9103",
         "name": "category_count",
         "owner": "CcbInventoryApi",
         "parameters": "character, category"
       },
       {
-        "line": "9045",
+        "line": "9056",
         "name": "choose",
         "owner": "CcbInventoryApi",
         "parameters": "character, candidates, title"
       },
       {
-        "line": "9050",
+        "line": "9061",
         "name": "choose_many",
         "owner": "CcbInventoryApi",
         "parameters": "character, candidates, title"
       },
       {
-        "line": "9060",
+        "line": "9071",
         "name": "choose_many_map",
         "owner": "CcbInventoryApi",
         "parameters": "character, candidates, options"
       },
       {
-        "line": "9055",
+        "line": "9066",
         "name": "choose_map",
         "owner": "CcbInventoryApi",
         "parameters": "character, candidates, options"
       },
       {
-        "line": "9125",
+        "line": "9136",
         "name": "consume",
         "owner": "CcbInventoryApi",
         "parameters": "character, item_type, count, charges"
       },
       {
-        "line": "9136",
+        "line": "9147",
         "name": "consume_sum",
         "owner": "CcbInventoryApi",
         "parameters": "character, entries"
       },
       {
-        "line": "9114",
+        "line": "9125",
         "name": "give",
         "owner": "CcbInventoryApi",
         "parameters": "character, item_type, quantity, options"
       },
       {
-        "line": "9119",
+        "line": "9130",
         "name": "give_group",
         "owner": "CcbInventoryApi",
         "parameters": "character, group, options"
       },
       {
-        "line": "9132",
+        "line": "9143",
         "name": "hand_in",
         "owner": "CcbInventoryApi",
         "parameters": "character, recipient, item_type, count, charges"
       },
       {
-        "line": "9088",
+        "line": "9099",
         "name": "has_item_flag",
         "owner": "CcbInventoryApi",
         "parameters": "character, flag"
       },
       {
-        "line": "9069",
+        "line": "9080",
         "name": "has_items_sum",
         "owner": "CcbInventoryApi",
         "parameters": "character, entries"
       },
       {
-        "line": "9075",
+        "line": "9086",
         "name": "has_software",
         "owner": "CcbInventoryApi",
         "parameters": "character, software, minimum_charges, device"
       },
       {
-        "line": "9105",
+        "line": "9116",
         "name": "has_stolen_from",
         "owner": "CcbInventoryApi",
         "parameters": "holder, owner"
       },
       {
-        "line": "9080",
+        "line": "9091",
         "name": "has_worn_flag",
         "owner": "CcbInventoryApi",
         "parameters": "character, flag, body_part"
       },
       {
-        "line": "9084",
+        "line": "9095",
         "name": "is_wearing",
         "owner": "CcbInventoryApi",
         "parameters": "character, item_type"
       },
       {
-        "line": "9097",
+        "line": "9108",
         "name": "item_radiation",
         "owner": "CcbInventoryApi",
         "parameters": "character, flag, aggregate"
       },
       {
-        "line": "9065",
+        "line": "9076",
         "name": "resources",
         "owner": "CcbInventoryApi",
         "parameters": "character, item_type, quantity"
       },
       {
-        "line": "9108",
+        "line": "9119",
         "name": "weapon_state",
         "owner": "CcbInventoryApi",
         "parameters": "character"
       },
       {
-        "line": "9101",
+        "line": "9112",
         "name": "wielded_matches",
         "owner": "CcbInventoryApi",
         "parameters": "character, criterion"
       },
       {
-        "line": "8919",
+        "line": "8930",
         "name": "set_spawn_rate",
         "owner": "CcbItemCategoriesApi",
         "parameters": "id, rate"
       },
       {
-        "line": "8923",
+        "line": "8934",
         "name": "set_spawn_rates",
         "owner": "CcbItemCategoriesApi",
         "parameters": "updates"
       },
       {
-        "line": "8914",
+        "line": "8925",
         "name": "spawn_rate",
         "owner": "CcbItemCategoriesApi",
         "parameters": "id"
       },
       {
-        "line": "9005",
+        "line": "9016",
         "name": "activate",
         "owner": "CcbItemsApi",
         "parameters": "item_handle, character_handle, method, options"
       },
       {
-        "line": "8994",
+        "line": "9005",
         "name": "ammo_sufficient",
         "owner": "CcbItemsApi",
         "parameters": "item_handle, character, method, quantity"
       },
       {
-        "line": "9036",
+        "line": "9047",
         "name": "clear_old_owner",
         "owner": "CcbItemsApi",
         "parameters": "item_handle"
       },
       {
-        "line": "9033",
+        "line": "9044",
         "name": "clear_owner",
         "owner": "CcbItemsApi",
         "parameters": "item_handle, remember_previous"
       },
       {
-        "line": "8984",
+        "line": "8995",
         "name": "erase_var",
         "owner": "CcbItemsApi",
         "parameters": "handle, key"
       },
       {
-        "line": "8945",
+        "line": "8956",
         "name": "food_fun",
         "owner": "CcbItemsApi",
         "parameters": "id"
       },
       {
-        "line": "8975",
+        "line": "8986",
         "name": "get_var",
         "owner": "CcbItemsApi",
         "parameters": "handle, key"
       },
       {
-        "line": "8961",
+        "line": "8972",
         "name": "gun_damage",
         "owner": "CcbItemsApi",
         "parameters": "handle, damage_type, with_ammo"
       },
       {
-        "line": "8988",
+        "line": "8999",
         "name": "has_flag",
         "owner": "CcbItemsApi",
         "parameters": "handle, flag"
       },
       {
-        "line": "9019",
+        "line": "9030",
         "name": "has_technique",
         "owner": "CcbItemsApi",
         "parameters": "handle, technique"
       },
       {
-        "line": "8956",
+        "line": "8967",
         "name": "melee_damage",
         "owner": "CcbItemsApi",
         "parameters": "handle, damage_type"
       },
       {
-        "line": "8938",
+        "line": "8949",
         "name": "page",
         "owner": "CcbItemsApi",
         "parameters": "holder, options, continuation"
       },
       {
-        "line": "8948",
+        "line": "8959",
         "name": "possible_from_group",
         "owner": "CcbItemsApi",
         "parameters": "group"
       },
       {
-        "line": "8966",
+        "line": "8977",
         "name": "quality",
         "owner": "CcbItemsApi",
         "parameters": "handle, quality, strict"
       },
       {
-        "line": "9010",
+        "line": "9021",
         "name": "set_fault",
         "owner": "CcbItemsApi",
         "parameters": "handle, fault, options"
       },
       {
-        "line": "8999",
+        "line": "9010",
         "name": "set_flag",
         "owner": "CcbItemsApi",
         "parameters": "handle, flag, enabled"
       },
       {
-        "line": "9029",
+        "line": "9040",
         "name": "set_owner",
         "owner": "CcbItemsApi",
         "parameters": "item_handle, owner, remember_previous"
       },
       {
-        "line": "9015",
+        "line": "9026",
         "name": "set_random_fault",
         "owner": "CcbItemsApi",
         "parameters": "handle, fault_type, options"
       },
       {
-        "line": "9024",
+        "line": "9035",
         "name": "set_technique",
         "owner": "CcbItemsApi",
         "parameters": "handle, technique, enabled"
       },
       {
-        "line": "8980",
+        "line": "8991",
         "name": "set_var",
         "owner": "CcbItemsApi",
         "parameters": "handle, key, value"
       },
       {
-        "line": "8942",
+        "line": "8953",
         "name": "snapshot",
         "owner": "CcbItemsApi",
         "parameters": "handle, relation_limit"
       },
       {
-        "line": "8933",
+        "line": "8944",
         "name": "transfer",
         "owner": "CcbItemsApi",
         "parameters": "item_handle, source_holder, destination_holder, quantity"
       },
       {
-        "line": "8971",
+        "line": "8982",
         "name": "transform",
         "owner": "CcbItemsApi",
         "parameters": "handle, target, options"
       },
       {
-        "line": "8952",
+        "line": "8963",
         "name": "update",
         "owner": "CcbItemsApi",
         "parameters": "handle, updates"
@@ -21122,631 +21167,631 @@
         "parameters": "position"
       },
       {
-        "line": "6878",
+        "line": "6889",
         "name": "apply",
         "owner": "CcbMapgenApi",
         "parameters": "target, update, options"
       },
       {
-        "line": "8368",
+        "line": "8379",
         "name": "define",
         "owner": "CcbMapgenApi",
         "parameters": "descriptor"
       },
       {
-        "line": "8370",
+        "line": "8381",
         "name": "limits",
         "owner": "CcbMapgenApi",
         "parameters": ""
       },
       {
-        "line": "6883",
+        "line": "6894",
         "name": "on_generate",
         "owner": "CcbMapgenApi",
         "parameters": "handler_id, options"
       },
       {
-        "line": "6888",
+        "line": "6899",
         "name": "on_postprocess",
         "owner": "CcbMapgenApi",
         "parameters": "handler_id, options"
       },
       {
-        "line": "8373",
+        "line": "8384",
         "name": "register_palette",
         "owner": "CcbMapgenApi",
         "parameters": "descriptor"
       },
       {
-        "line": "6872",
+        "line": "6883",
         "name": "update_token",
         "owner": "CcbMapgenApi",
         "parameters": "id"
       },
       {
-        "line": "8694",
+        "line": "8705",
         "name": "abandon",
         "owner": "CcbMissionsApi",
         "parameters": "owner, token"
       },
       {
-        "line": "8660",
+        "line": "8671",
         "name": "assign",
         "owner": "CcbMissionsApi",
         "parameters": "owner, token"
       },
       {
-        "line": "8690",
+        "line": "8701",
         "name": "cancel",
         "owner": "CcbMissionsApi",
         "parameters": "token"
       },
       {
-        "line": "8687",
+        "line": "8698",
         "name": "complete",
         "owner": "CcbMissionsApi",
         "parameters": "owner, token, force"
       },
       {
-        "line": "8629",
+        "line": "8640",
         "name": "definition",
         "owner": "CcbMissionsApi",
         "parameters": "id"
       },
       {
-        "line": "8626",
+        "line": "8637",
         "name": "definitions",
         "owner": "CcbMissionsApi",
         "parameters": "options"
       },
       {
-        "line": "8682",
+        "line": "8693",
         "name": "fail",
         "owner": "CcbMissionsApi",
         "parameters": "owner, token"
       },
       {
-        "line": "8636",
+        "line": "8647",
         "name": "get",
         "owner": "CcbMissionsApi",
         "parameters": "token"
       },
       {
-        "line": "8643",
+        "line": "8654",
         "name": "has_active",
         "owner": "CcbMissionsApi",
         "parameters": "owner, id"
       },
       {
-        "line": "8673",
+        "line": "8684",
         "name": "is_complete",
         "owner": "CcbMissionsApi",
         "parameters": "owner, token, npc_id"
       },
       {
-        "line": "8633",
+        "line": "8644",
         "name": "list",
         "owner": "CcbMissionsApi",
         "parameters": "owner, options"
       },
       {
-        "line": "8647",
+        "line": "8658",
         "name": "random_definition",
         "owner": "CcbMissionsApi",
         "parameters": "origin, position"
       },
       {
-        "line": "8651",
+        "line": "8662",
         "name": "reserve",
         "owner": "CcbMissionsApi",
         "parameters": "id, npc_id"
       },
       {
-        "line": "8656",
+        "line": "8667",
         "name": "reserve_random",
         "owner": "CcbMissionsApi",
         "parameters": "origin, position, npc_id"
       },
       {
-        "line": "8668",
+        "line": "8679",
         "name": "select",
         "owner": "CcbMissionsApi",
         "parameters": "owner, token"
       },
       {
-        "line": "8639",
+        "line": "8650",
         "name": "selected",
         "owner": "CcbMissionsApi",
         "parameters": "owner"
       },
       {
-        "line": "8664",
+        "line": "8675",
         "name": "set_deadline",
         "owner": "CcbMissionsApi",
         "parameters": "token, deadline"
       },
       {
-        "line": "8678",
+        "line": "8689",
         "name": "step_complete",
         "owner": "CcbMissionsApi",
         "parameters": "owner, token, step"
       },
       {
-        "line": "9946",
+        "line": "9957",
         "name": "add",
         "owner": "CcbMoraleApi",
         "parameters": "character, morale, bonus, max_bonus, options"
       },
       {
-        "line": "9952",
+        "line": "9963",
         "name": "remove",
         "owner": "CcbMoraleApi",
         "parameters": "character, morale"
       },
       {
-        "line": "10157",
+        "line": "10168",
         "name": "grant",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation, variant"
       },
       {
-        "line": "10127",
+        "line": "10138",
         "name": "has",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation"
       },
       {
-        "line": "10141",
+        "line": "10152",
         "name": "is_purifiable",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation"
       },
       {
-        "line": "10134",
+        "line": "10145",
         "name": "is_visible_to",
         "owner": "CcbMutationsApi",
         "parameters": "observed, observer, mutation"
       },
       {
-        "line": "10186",
+        "line": "10197",
         "name": "mutate_category",
         "owner": "CcbMutationsApi",
         "parameters": "character, category, use_vitamins, true_random"
       },
       {
-        "line": "10164",
+        "line": "10175",
         "name": "remove",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation"
       },
       {
-        "line": "10178",
+        "line": "10189",
         "name": "remove_category",
         "owner": "CcbMutationsApi",
         "parameters": "character, category"
       },
       {
-        "line": "10195",
+        "line": "10206",
         "name": "remove_type",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation_type"
       },
       {
-        "line": "10172",
+        "line": "10183",
         "name": "set_active",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation, active"
       },
       {
-        "line": "10149",
+        "line": "10160",
         "name": "set_purifiable",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation, purifiable"
       },
       {
-        "line": "9409",
+        "line": "9420",
         "name": "finish",
         "owner": "CcbNpcDialogueActionsApi",
         "parameters": "handle"
       },
       {
-        "line": "9412",
+        "line": "9423",
         "name": "provoke_combat",
         "owner": "CcbNpcDialogueActionsApi",
         "parameters": "handle"
       },
       {
-        "line": "9381",
+        "line": "9392",
         "name": "open_style",
         "owner": "CcbNpcGroomingApi",
         "parameters": "provider, client, area"
       },
       {
-        "line": "9386",
+        "line": "9397",
         "name": "provide",
         "owner": "CcbNpcGroomingApi",
         "parameters": "provider, client, service"
       },
       {
-        "line": "9369",
+        "line": "9380",
         "name": "open_bionic_service",
         "owner": "CcbNpcMedicalApi",
         "parameters": "provider, operation, patient"
       },
       {
-        "line": "9364",
+        "line": "9375",
         "name": "provide_aid",
         "owner": "CcbNpcMedicalApi",
         "parameters": "provider, patient, level, include_allies"
       },
       {
-        "line": "9373",
+        "line": "9384",
         "name": "repair_bionic_limbs",
         "owner": "CcbNpcMedicalApi",
         "parameters": "provider, patient"
       },
       {
-        "line": "9334",
+        "line": "9345",
         "name": "add_assigned",
         "owner": "CcbNpcMissionsApi",
         "parameters": "provider, owner, mission"
       },
       {
-        "line": "9338",
+        "line": "9349",
         "name": "assign_selected",
         "owner": "CcbNpcMissionsApi",
         "parameters": "provider, owner"
       },
       {
-        "line": "9355",
+        "line": "9366",
         "name": "claim_selected_reward",
         "owner": "CcbNpcMissionsApi",
         "parameters": "provider, owner"
       },
       {
-        "line": "9351",
+        "line": "9362",
         "name": "clear_selected",
         "owner": "CcbNpcMissionsApi",
         "parameters": "provider, owner"
       },
       {
-        "line": "9347",
+        "line": "9358",
         "name": "fail_selected",
         "owner": "CcbNpcMissionsApi",
         "parameters": "provider, owner"
       },
       {
-        "line": "9329",
+        "line": "9340",
         "name": "offer",
         "owner": "CcbNpcMissionsApi",
         "parameters": "provider, mission"
       },
       {
-        "line": "9325",
+        "line": "9336",
         "name": "select",
         "owner": "CcbNpcMissionsApi",
         "parameters": "provider, token"
       },
       {
-        "line": "9321",
+        "line": "9332",
         "name": "state",
         "owner": "CcbNpcMissionsApi",
         "parameters": "provider"
       },
       {
-        "line": "9343",
+        "line": "9354",
         "name": "succeed_selected",
         "owner": "CcbNpcMissionsApi",
         "parameters": "provider, owner, force"
       },
       {
-        "line": "9393",
+        "line": "9404",
         "name": "offerings",
         "owner": "CcbNpcTrainingApi",
         "parameters": "teacher, student"
       },
       {
-        "line": "9398",
+        "line": "9409",
         "name": "start",
         "owner": "CcbNpcTrainingApi",
         "parameters": "teacher, students, subject"
       },
       {
-        "line": "9403",
+        "line": "9414",
         "name": "start_selected",
         "owner": "CcbNpcTrainingApi",
         "parameters": "provider, student, mode"
       },
       {
-        "line": "9466",
+        "line": "9477",
         "name": "add_debt",
         "owner": "CcbNpcsApi",
         "parameters": "handle, amount"
       },
       {
-        "line": "9470",
+        "line": "9481",
         "name": "add_faction_rep",
         "owner": "CcbNpcsApi",
         "parameters": "handle, amount"
       },
       {
-        "line": "9489",
+        "line": "9500",
         "name": "ai_rule_catalog",
         "owner": "CcbNpcsApi",
         "parameters": ""
       },
       {
-        "line": "9566",
+        "line": "9577",
         "name": "ai_rules",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9534",
+        "line": "9545",
         "name": "become_hostile",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9428",
+        "line": "9439",
         "name": "class",
         "owner": "CcbNpcsApi",
         "parameters": "id"
       },
       {
-        "line": "9425",
+        "line": "9436",
         "name": "classes",
         "owner": "CcbNpcsApi",
         "parameters": "options"
       },
       {
-        "line": "9536",
+        "line": "9547",
         "name": "clear_stolen_item_claim",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9545",
+        "line": "9556",
         "name": "companion_state",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9508",
+        "line": "9519",
         "name": "copy_ai_rules",
         "owner": "CcbNpcsApi",
         "parameters": "target, source"
       },
       {
-        "line": "9440",
+        "line": "9451",
         "name": "count_allies",
         "owner": "CcbNpcsApi",
         "parameters": "global"
       },
       {
-        "line": "9538",
+        "line": "9549",
         "name": "destinations",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9437",
+        "line": "9448",
         "name": "find_unique",
         "owner": "CcbNpcsApi",
         "parameters": "unique_id"
       },
       {
-        "line": "9519",
+        "line": "9530",
         "name": "follow_temporarily",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9434",
+        "line": "9445",
         "name": "get",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9450",
+        "line": "9461",
         "name": "has_follower_nearby",
         "owner": "CcbNpcsApi",
         "parameters": "origin, class, radius"
       },
       {
-        "line": "9445",
+        "line": "9456",
         "name": "has_role_nearby",
         "owner": "CcbNpcsApi",
         "parameters": "origin, role, radius"
       },
       {
-        "line": "9527",
+        "line": "9538",
         "name": "join_player",
         "owner": "CcbNpcsApi",
         "parameters": "handle, avatar"
       },
       {
-        "line": "9543",
+        "line": "9554",
         "name": "lead_to",
         "owner": "CcbNpcsApi",
         "parameters": "handle, goal"
       },
       {
-        "line": "9530",
+        "line": "9541",
         "name": "leave_player",
         "owner": "CcbNpcsApi",
         "parameters": "handle, avatar"
       },
       {
-        "line": "9431",
+        "line": "9442",
         "name": "list",
         "owner": "CcbNpcsApi",
         "parameters": "options"
       },
       {
-        "line": "9521",
+        "line": "9532",
         "name": "make_neutral",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9511",
+        "line": "9522",
         "name": "make_thankful",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9462",
+        "line": "9473",
         "name": "modify_opinion",
         "owner": "CcbNpcsApi",
         "parameters": "handle, deltas"
       },
       {
-        "line": "9552",
+        "line": "9563",
         "name": "offer_item",
         "owner": "CcbNpcsApi",
         "parameters": "recipient, giver, item, use_item"
       },
       {
-        "line": "9547",
+        "line": "9558",
         "name": "open_companion_missions",
         "owner": "CcbNpcsApi",
         "parameters": "handle, role"
       },
       {
-        "line": "9560",
+        "line": "9571",
         "name": "open_control_menu",
         "owner": "CcbNpcsApi",
         "parameters": "avatar"
       },
       {
-        "line": "9557",
+        "line": "9568",
         "name": "open_dialogue",
         "owner": "CcbNpcsApi",
         "parameters": "npc, speaker, topic"
       },
       {
-        "line": "9558",
+        "line": "9569",
         "name": "open_rules",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9541",
+        "line": "9552",
         "name": "plan_travel",
         "owner": "CcbNpcsApi",
         "parameters": "handle, goal"
       },
       {
-        "line": "9515",
+        "line": "9526",
         "name": "record_refusal",
         "owner": "CcbNpcsApi",
         "parameters": "handle, request"
       },
       {
-        "line": "9454",
+        "line": "9465",
         "name": "rename",
         "owner": "CcbNpcsApi",
         "parameters": "handle, name"
       },
       {
-        "line": "9494",
+        "line": "9505",
         "name": "set_ai_policy",
         "owner": "CcbNpcsApi",
         "parameters": "handle, family, rule"
       },
       {
-        "line": "9504",
+        "line": "9515",
         "name": "set_ally_override",
         "owner": "CcbNpcsApi",
         "parameters": "handle, rule, state"
       },
       {
-        "line": "9499",
+        "line": "9510",
         "name": "set_ally_rule",
         "owner": "CcbNpcsApi",
         "parameters": "handle, rule, enabled"
       },
       {
-        "line": "9458",
+        "line": "9469",
         "name": "set_attitude",
         "owner": "CcbNpcsApi",
         "parameters": "handle, attitude"
       },
       {
-        "line": "9474",
+        "line": "9485",
         "name": "set_class",
         "owner": "CcbNpcsApi",
         "parameters": "handle, class"
       },
       {
-        "line": "9546",
+        "line": "9557",
         "name": "set_companion_role",
         "owner": "CcbNpcsApi",
         "parameters": "handle, role"
       },
       {
-        "line": "9478",
+        "line": "9489",
         "name": "set_faction",
         "owner": "CcbNpcsApi",
         "parameters": "handle, faction"
       },
       {
-        "line": "9482",
+        "line": "9493",
         "name": "set_first_topic",
         "owner": "CcbNpcsApi",
         "parameters": "handle, topic"
       },
       {
-        "line": "9542",
+        "line": "9553",
         "name": "set_goal",
         "owner": "CcbNpcsApi",
         "parameters": "handle, goal"
       },
       {
-        "line": "9544",
+        "line": "9555",
         "name": "set_guard_position",
         "owner": "CcbNpcsApi",
         "parameters": "handle, position"
       },
       {
-        "line": "9533",
+        "line": "9544",
         "name": "set_guarding",
         "owner": "CcbNpcsApi",
         "parameters": "handle, enabled"
       },
       {
-        "line": "9487",
+        "line": "9498",
         "name": "set_radio_representative",
         "owner": "CcbNpcsApi",
         "parameters": "handle, avatar, enabled"
       },
       {
-        "line": "9522",
+        "line": "9533",
         "name": "start_fleeing",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9523",
+        "line": "9534",
         "name": "start_mugging",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9520",
+        "line": "9531",
         "name": "stop_temporary_following",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9563",
+        "line": "9574",
         "name": "take_control",
         "owner": "CcbNpcsApi",
         "parameters": "handle, avatar"
       },
       {
-        "line": "9535",
+        "line": "9546",
         "name": "warn_player_departure",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
@@ -21770,139 +21815,139 @@
         "parameters": "position"
       },
       {
-        "line": "9818",
+        "line": "9829",
         "name": "complete",
         "owner": "CcbPlatformAchievementsApi",
         "parameters": "id"
       },
       {
-        "line": "8301",
+        "line": "8312",
         "name": "assign_npc_job",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "handle, job"
       },
       {
-        "line": "9852",
+        "line": "9863",
         "name": "assign_timed",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "character, id, duration"
       },
       {
-        "line": "9857",
+        "line": "9868",
         "name": "cancel",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "character"
       },
       {
-        "line": "8304",
+        "line": "8315",
         "name": "clear_backlog",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "character_handle"
       },
       {
-        "line": "8307",
+        "line": "8318",
         "name": "dismount",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "npc_handle"
       },
       {
-        "line": "8314",
+        "line": "8325",
         "name": "drop_item",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "character_handle, item_handle, quantity, placement, force_ground"
       },
       {
-        "line": "8317",
+        "line": "8328",
         "name": "drop_nonfavorite_items",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "npc_handle"
       },
       {
-        "line": "8320",
+        "line": "8331",
         "name": "offer_interruption",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "reason"
       },
       {
-        "line": "8323",
+        "line": "8334",
         "name": "offer_portal_storm_interruption",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "message"
       },
       {
-        "line": "8329",
+        "line": "8340",
         "name": "pickup_item",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "character_handle, item_handle, quantity, autopickup"
       },
       {
-        "line": "8337",
+        "line": "8348",
         "name": "read",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "character_handle, book_handle, duration, ereader_handle, continuous, learner_handle"
       },
       {
-        "line": "8340",
+        "line": "8351",
         "name": "resume",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "character_handle"
       },
       {
-        "line": "8343",
+        "line": "8354",
         "name": "revert_npc_job",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "handle"
       },
       {
-        "line": "9843",
+        "line": "9854",
         "name": "snapshot",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "character"
       },
       {
-        "line": "8348",
+        "line": "8359",
         "name": "socialize",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "character_handle, partner_handle, duration"
       },
       {
-        "line": "8354",
+        "line": "8365",
         "name": "start_training",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "teacher_handle, trainee_handles, subject_id, duration"
       },
       {
-        "line": "8357",
+        "line": "8368",
         "name": "suspend",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "character_handle"
       },
       {
-        "line": "8360",
+        "line": "8371",
         "name": "target_practice",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "character_handle"
       },
       {
-        "line": "8365",
+        "line": "8376",
         "name": "wait_for_npc",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "character_handle, npc_handle, duration"
       },
       {
-        "line": "10215",
+        "line": "10226",
         "name": "grant",
         "owner": "CcbPlatformBionicsApi",
         "parameters": "character, id"
       },
       {
-        "line": "10221",
+        "line": "10232",
         "name": "remove_type",
         "owner": "CcbPlatformBionicsApi",
         "parameters": "character, id"
       },
       {
-        "line": "10209",
+        "line": "10220",
         "name": "summary",
         "owner": "CcbPlatformBionicsApi",
         "parameters": "character"
@@ -23642,67 +23687,67 @@
         "parameters": "dimension"
       },
       {
-        "line": "10485",
+        "line": "10496",
         "name": "dimension",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": ""
       },
       {
-        "line": "10523",
+        "line": "10534",
         "name": "field_exists",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position, field_id"
       },
       {
-        "line": "10506",
+        "line": "10517",
         "name": "furniture_has_flag",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position, flag"
       },
       {
-        "line": "10518",
+        "line": "10529",
         "name": "furniture_id",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position"
       },
       {
-        "line": "10533",
+        "line": "10544",
         "name": "is_indoor_tile",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position"
       },
       {
-        "line": "10489",
+        "line": "10500",
         "name": "is_night",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": ""
       },
       {
-        "line": "10493",
+        "line": "10504",
         "name": "is_outside",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position"
       },
       {
-        "line": "10500",
+        "line": "10511",
         "name": "line_of_sight",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "from, to, range, with_fields"
       },
       {
-        "line": "10538",
+        "line": "10549",
         "name": "safe_mode_dangerous",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "direction"
       },
       {
-        "line": "10528",
+        "line": "10539",
         "name": "terrain_has_flag",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position, flag"
       },
       {
-        "line": "10512",
+        "line": "10523",
         "name": "terrain_id",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position"
@@ -23726,7 +23771,7 @@
         "parameters": "id"
       },
       {
-        "line": "6487",
+        "line": "6498",
         "name": "choose",
         "owner": "CcbPlatformInteractionApi",
         "parameters": "entries, options"
@@ -23738,25 +23783,25 @@
         "parameters": "message"
       },
       {
-        "line": "6482",
+        "line": "6493",
         "name": "input_number",
         "owner": "CcbPlatformInteractionApi",
         "parameters": "description, default_value"
       },
       {
-        "line": "6477",
+        "line": "6488",
         "name": "input_text",
         "owner": "CcbPlatformInteractionApi",
         "parameters": "title, options"
       },
       {
-        "line": "9810",
+        "line": "9821",
         "name": "is_wearing",
         "owner": "CcbPlatformInventoryApi",
         "parameters": "character, item"
       },
       {
-        "line": "9801",
+        "line": "9812",
         "name": "wielded",
         "owner": "CcbPlatformInventoryApi",
         "parameters": "character"
@@ -23780,31 +23825,31 @@
         "parameters": "id"
       },
       {
-        "line": "10403",
+        "line": "10414",
         "name": "forget",
         "owner": "CcbPlatformMartialArtsApi",
         "parameters": "character, id"
       },
       {
-        "line": "10397",
+        "line": "10408",
         "name": "learn",
         "owner": "CcbPlatformMartialArtsApi",
         "parameters": "character, id"
       },
       {
-        "line": "10390",
+        "line": "10401",
         "name": "technique_definition",
         "owner": "CcbPlatformMartialArtsApi",
         "parameters": "id"
       },
       {
-        "line": "10565",
+        "line": "10576",
         "name": "apply",
         "owner": "CcbPlatformMathApi",
         "parameters": "expression, actor, context"
       },
       {
-        "line": "10558",
+        "line": "10569",
         "name": "evaluate",
         "owner": "CcbPlatformMathApi",
         "parameters": "expression, actor, context"
@@ -23828,25 +23873,25 @@
         "parameters": "message, type"
       },
       {
-        "line": "10479",
+        "line": "10490",
         "name": "is_loaded",
         "owner": "CcbPlatformModQueries",
         "parameters": "mod_id"
       },
       {
-        "line": "8376",
+        "line": "8387",
         "name": "load_order",
         "owner": "CcbPlatformModQueries",
         "parameters": "id"
       },
       {
-        "line": "10420",
+        "line": "10431",
         "name": "add",
         "owner": "CcbPlatformMoraleApi",
         "parameters": "character, id, bonus, max_bonus, options"
       },
       {
-        "line": "10426",
+        "line": "10437",
         "name": "remove",
         "owner": "CcbPlatformMoraleApi",
         "parameters": "character, id"
@@ -23888,19 +23933,19 @@
         "parameters": "message"
       },
       {
-        "line": "8400",
+        "line": "8411",
         "name": "notice_any_key",
         "owner": "CcbPlatformPresentation",
         "parameters": "message"
       },
       {
-        "line": "8403",
+        "line": "8414",
         "name": "notice_large",
         "owner": "CcbPlatformPresentation",
         "parameters": "message"
       },
       {
-        "line": "8406",
+        "line": "8417",
         "name": "notice_top",
         "owner": "CcbPlatformPresentation",
         "parameters": "message"
@@ -23912,97 +23957,97 @@
         "parameters": "file, volume"
       },
       {
-        "line": "10439",
+        "line": "10450",
         "name": "chance",
         "owner": "CcbPlatformRandomApi",
         "parameters": "numerator, denominator"
       },
       {
-        "line": "10461",
+        "line": "10472",
         "name": "contested",
         "owner": "CcbPlatformRandomApi",
         "parameters": "check, difficulty, die_size"
       },
       {
-        "line": "10434",
+        "line": "10445",
         "name": "int",
         "owner": "CcbPlatformRandomApi",
         "parameters": "minimum, maximum"
       },
       {
-        "line": "10443",
+        "line": "10454",
         "name": "one_in",
         "owner": "CcbPlatformRandomApi",
         "parameters": "denominator"
       },
       {
-        "line": "10448",
+        "line": "10459",
         "name": "probability",
         "owner": "CcbPlatformRandomApi",
         "parameters": "numerator, denominator"
       },
       {
-        "line": "10455",
+        "line": "10466",
         "name": "sample_integers",
         "owner": "CcbPlatformRandomApi",
         "parameters": "minimum, maximum, count, with_replacement"
       },
       {
-        "line": "10265",
+        "line": "10276",
         "name": "all",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, options"
       },
       {
-        "line": "10275",
+        "line": "10286",
         "name": "by_flag",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "flag, character, options"
       },
       {
-        "line": "10270",
+        "line": "10281",
         "name": "by_skill",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "skill, character, options"
       },
       {
-        "line": "10317",
+        "line": "10328",
         "name": "forget",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, id"
       },
       {
-        "line": "10334",
+        "line": "10345",
         "name": "forget_category",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, category, subcategory"
       },
       {
-        "line": "10280",
+        "line": "10291",
         "name": "get",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, id, batch"
       },
       {
-        "line": "10284",
+        "line": "10295",
         "name": "has_flag",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "id, flag"
       },
       {
-        "line": "10305",
+        "line": "10316",
         "name": "knows",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, id"
       },
       {
-        "line": "10311",
+        "line": "10322",
         "name": "learn",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, id"
       },
       {
-        "line": "10261",
+        "line": "10272",
         "name": "list",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, options"
@@ -24044,115 +24089,115 @@
         "parameters": "event_name, handler_id"
       },
       {
-        "line": "10724",
+        "line": "10735",
         "name": "activity_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10714",
+        "line": "10725",
         "name": "bionics_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10661",
+        "line": "10672",
         "name": "character_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character"
       },
       {
-        "line": "10704",
+        "line": "10715",
         "name": "current_tile_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, field_limit"
       },
       {
-        "line": "10682",
+        "line": "10693",
         "name": "effects_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10692",
+        "line": "10703",
         "name": "equipment_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10677",
+        "line": "10688",
         "name": "inventory_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10699",
+        "line": "10710",
         "name": "item_contents_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, item_handle, offset, limit"
       },
       {
-        "line": "10637",
+        "line": "10648",
         "name": "message",
         "owner": "CcbPlatformServices",
         "parameters": "text"
       },
       {
-        "line": "10719",
+        "line": "10730",
         "name": "missions_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10665",
+        "line": "10676",
         "name": "movement_modes_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character"
       },
       {
-        "line": "10709",
+        "line": "10720",
         "name": "mutations_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10730",
+        "line": "10741",
         "name": "nearby_creatures_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, radius, limit"
       },
       {
-        "line": "10687",
+        "line": "10698",
         "name": "skills_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10668",
+        "line": "10679",
         "name": "time_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": ""
       },
       {
-        "line": "10644",
+        "line": "10655",
         "name": "translate",
         "owner": "CcbPlatformServices",
         "parameters": "text, context"
       },
       {
-        "line": "10654",
+        "line": "10665",
         "name": "translate_plural",
         "owner": "CcbPlatformServices",
         "parameters": "singular, plural, count, context"
       },
       {
-        "line": "10657",
+        "line": "10668",
         "name": "turn",
         "owner": "CcbPlatformServices",
         "parameters": ""
       },
       {
-        "line": "10671",
+        "line": "10682",
         "name": "weather_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": ""
@@ -24224,13 +24269,13 @@
         "parameters": "key, value"
       },
       {
-        "line": "10472",
+        "line": "10483",
         "name": "all_equal",
         "owner": "CcbPlatformStringPredicates",
         "parameters": "values"
       },
       {
-        "line": "10468",
+        "line": "10479",
         "name": "any_equal",
         "owner": "CcbPlatformStringPredicates",
         "parameters": "values"
@@ -24248,25 +24293,25 @@
         "parameters": "task_id"
       },
       {
-        "line": "8385",
+        "line": "8396",
         "name": "every",
         "owner": "CcbPlatformTasks",
         "parameters": "interval_turns, handler_id, payload, payload_version, scope, actor, participants"
       },
       {
-        "line": "8388",
+        "line": "8399",
         "name": "get",
         "owner": "CcbPlatformTasks",
         "parameters": "id"
       },
       {
-        "line": "8393",
+        "line": "8404",
         "name": "list",
         "owner": "CcbPlatformTasks",
         "parameters": "handler_id, scope, requested_limit"
       },
       {
-        "line": "8397",
+        "line": "8408",
         "name": "next",
         "owner": "CcbPlatformTasks",
         "parameters": "handler_id, scope"
@@ -24290,433 +24335,433 @@
         "parameters": "descriptor"
       },
       {
-        "line": "9894",
+        "line": "9905",
         "name": "add",
         "owner": "CcbPlatformWoundsApi",
         "parameters": "character, body_part, wound"
       },
       {
-        "line": "9903",
+        "line": "9914",
         "name": "remove",
         "owner": "CcbPlatformWoundsApi",
         "parameters": "character, body_part, wound"
       },
       {
-        "line": "9882",
+        "line": "9893",
         "name": "snapshot",
         "owner": "CcbPlatformWoundsApi",
         "parameters": "character, body_part"
       },
       {
-        "line": "7533",
+        "line": "7544",
         "name": "move",
         "owner": "CcbRelocationApi",
         "parameters": "entity, target, options"
       },
       {
-        "line": "7539",
+        "line": "7550",
         "name": "travel_to_omt",
         "owner": "CcbRelocationApi",
         "parameters": "avatar, target, options"
       },
       {
-        "line": "10299",
+        "line": "10310",
         "name": "for_recipe",
         "owner": "CcbRequirementsApi",
         "parameters": "character, id, batch"
       },
       {
-        "line": "10294",
+        "line": "10305",
         "name": "get",
         "owner": "CcbRequirementsApi",
         "parameters": "character, id, batch"
       },
       {
-        "line": "10289",
+        "line": "10300",
         "name": "list",
         "owner": "CcbRequirementsApi",
         "parameters": "character, options"
       },
       {
-        "line": "9934",
+        "line": "9945",
         "name": "offered",
         "owner": "CcbSkillsApi",
         "parameters": "teacher, student"
       },
       {
-        "line": "9791",
+        "line": "9802",
         "name": "commit",
         "owner": "CcbTradeApi",
         "parameters": "token, settlement"
       },
       {
-        "line": "9786",
+        "line": "9797",
         "name": "get",
         "owner": "CcbTradeApi",
         "parameters": "token"
       },
       {
-        "line": "9760",
+        "line": "9771",
         "name": "open",
         "owner": "CcbTradeApi",
         "parameters": "seller, buyer, cost, title"
       },
       {
-        "line": "9775",
+        "line": "9786",
         "name": "order_price",
         "owner": "CcbTradeApi",
         "parameters": "seller, buyer, item_type, count"
       },
       {
-        "line": "9767",
+        "line": "9778",
         "name": "pay",
         "owner": "CcbTradeApi",
         "parameters": "seller, buyer, cost"
       },
       {
-        "line": "9782",
+        "line": "9793",
         "name": "quote",
         "owner": "CcbTradeApi",
         "parameters": "seller, buyer, lines, options"
       },
       {
-        "line": "9987",
+        "line": "9998",
         "name": "id",
         "owner": "CcbTypesApi",
         "parameters": "kind, value"
       },
       {
-        "line": "9990",
+        "line": "10001",
         "name": "id_kinds",
         "owner": "CcbTypesApi",
         "parameters": ""
       },
       {
-        "line": "10005",
+        "line": "10016",
         "name": "get",
         "owner": "CcbVariablesApi",
         "parameters": "character, key"
       },
       {
-        "line": "10021",
+        "line": "10032",
         "name": "get_global",
         "owner": "CcbVariablesApi",
         "parameters": "key"
       },
       {
-        "line": "10017",
+        "line": "10028",
         "name": "remove",
         "owner": "CcbVariablesApi",
         "parameters": "character, key"
       },
       {
-        "line": "10030",
+        "line": "10041",
         "name": "remove_global",
         "owner": "CcbVariablesApi",
         "parameters": "key"
       },
       {
-        "line": "10039",
+        "line": "10050",
         "name": "resolve",
         "owner": "CcbVariablesApi",
         "parameters": "context, actor, scope, key"
       },
       {
-        "line": "10012",
+        "line": "10023",
         "name": "set",
         "owner": "CcbVariablesApi",
         "parameters": "character, key, value"
       },
       {
-        "line": "10026",
+        "line": "10037",
         "name": "set_global",
         "owner": "CcbVariablesApi",
         "parameters": "key, value"
       },
       {
-        "line": "10047",
+        "line": "10058",
         "name": "set_resolved",
         "owner": "CcbVariablesApi",
         "parameters": "context, actor, scope, key, value"
       },
       {
-        "line": "8482",
+        "line": "8493",
         "name": "definition",
         "owner": "CcbVehiclesApi",
         "parameters": "id"
       },
       {
-        "line": "8479",
+        "line": "8490",
         "name": "definitions",
         "owner": "CcbVehiclesApi",
         "parameters": "options"
       },
       {
-        "line": "8537",
+        "line": "8548",
         "name": "destroy",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle"
       },
       {
-        "line": "8492",
+        "line": "8503",
         "name": "fuels",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle"
       },
       {
-        "line": "8485",
+        "line": "8496",
         "name": "get",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle"
       },
       {
-        "line": "8529",
+        "line": "8540",
         "name": "has_part_flag",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle, flag, enabled"
       },
       {
-        "line": "8524",
+        "line": "8535",
         "name": "is_player_controlling",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle"
       },
       {
-        "line": "8568",
+        "line": "8579",
         "name": "open_part_service",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle, mechanic, repair_multiplier, install_multiplier"
       },
       {
-        "line": "8489",
+        "line": "8500",
         "name": "parts",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle, options"
       },
       {
-        "line": "8517",
+        "line": "8528",
         "name": "prototype_value",
         "owner": "CcbVehiclesApi",
         "parameters": "id, post_cataclysm"
       },
       {
-        "line": "8546",
+        "line": "8557",
         "name": "quote_full_repair",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle, mechanic, repair_multiplier"
       },
       {
-        "line": "8496",
+        "line": "8507",
         "name": "rename",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle, name"
       },
       {
-        "line": "8500",
+        "line": "8511",
         "name": "set_cruise_velocity",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle, velocity"
       },
       {
-        "line": "8541",
+        "line": "8552",
         "name": "set_owner",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle, owner"
       },
       {
-        "line": "8513",
+        "line": "8524",
         "name": "set_part_enabled",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle, part, enabled"
       },
       {
-        "line": "8508",
+        "line": "8519",
         "name": "set_tracking",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle, enabled"
       },
       {
-        "line": "8534",
+        "line": "8545",
         "name": "spawn",
         "owner": "CcbVehiclesApi",
         "parameters": "prototype, position, options"
       },
       {
-        "line": "8551",
+        "line": "8562",
         "name": "start_full_repair",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle, mechanic, repair_multiplier"
       },
       {
-        "line": "8504",
+        "line": "8515",
         "name": "stop",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle, options"
       },
       {
-        "line": "8521",
+        "line": "8532",
         "name": "value",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle, options"
       },
       {
-        "line": "7756",
+        "line": "7767",
         "name": "activate_lightning",
         "owner": "CcbWeatherApi",
         "parameters": ""
       },
       {
-        "line": "7736",
+        "line": "7747",
         "name": "clear_override",
         "owner": "CcbWeatherApi",
         "parameters": ""
       },
       {
-        "line": "7750",
+        "line": "7761",
         "name": "clear_overrides",
         "owner": "CcbWeatherApi",
         "parameters": ""
       },
       {
-        "line": "7743",
+        "line": "7754",
         "name": "clear_temperature_override",
         "owner": "CcbWeatherApi",
         "parameters": ""
       },
       {
-        "line": "7705",
+        "line": "7716",
         "name": "current",
         "owner": "CcbWeatherApi",
         "parameters": ""
       },
       {
-        "line": "7712",
+        "line": "7723",
         "name": "forecast",
         "owner": "CcbWeatherApi",
         "parameters": "options"
       },
       {
-        "line": "7708",
+        "line": "7719",
         "name": "generator",
         "owner": "CcbWeatherApi",
         "parameters": ""
       },
       {
-        "line": "7715",
+        "line": "7726",
         "name": "limits",
         "owner": "CcbWeatherApi",
         "parameters": ""
       },
       {
-        "line": "7762",
+        "line": "7773",
         "name": "override_light",
         "owner": "CcbWeatherApi",
         "parameters": "level, duration, key"
       },
       {
-        "line": "7753",
+        "line": "7764",
         "name": "refresh",
         "owner": "CcbWeatherApi",
         "parameters": ""
       },
       {
-        "line": "7733",
+        "line": "7744",
         "name": "set_override",
         "owner": "CcbWeatherApi",
         "parameters": "id"
       },
       {
-        "line": "7740",
+        "line": "7751",
         "name": "set_temperature_override",
         "owner": "CcbWeatherApi",
         "parameters": "temperature"
       },
       {
-        "line": "7747",
+        "line": "7758",
         "name": "set_wind",
         "owner": "CcbWeatherApi",
         "parameters": "options"
       },
       {
-        "line": "7702",
+        "line": "7713",
         "name": "type",
         "owner": "CcbWeatherApi",
         "parameters": "id"
       },
       {
-        "line": "7698",
+        "line": "7709",
         "name": "types",
         "owner": "CcbWeatherApi",
         "parameters": "options"
       },
       {
-        "line": "7881",
+        "line": "7892",
         "name": "at",
         "owner": "CcbZonesApi",
         "parameters": "position, options"
       },
       {
-        "line": "7890",
+        "line": "7901",
         "name": "contains",
         "owner": "CcbZonesApi",
         "parameters": "token, position"
       },
       {
-        "line": "7895",
+        "line": "7906",
         "name": "create",
         "owner": "CcbZonesApi",
         "parameters": "options"
       },
       {
-        "line": "7885",
+        "line": "7896",
         "name": "get",
         "owner": "CcbZonesApi",
         "parameters": "token"
       },
       {
-        "line": "7876",
+        "line": "7887",
         "name": "list",
         "owner": "CcbZonesApi",
         "parameters": "options"
       },
       {
-        "line": "7921",
+        "line": "7932",
         "name": "remove",
         "owner": "CcbZonesApi",
         "parameters": "token"
       },
       {
-        "line": "7900",
+        "line": "7911",
         "name": "rename",
         "owner": "CcbZonesApi",
         "parameters": "token, name"
       },
       {
-        "line": "7905",
+        "line": "7916",
         "name": "set_enabled",
         "owner": "CcbZonesApi",
         "parameters": "token, enabled"
       },
       {
-        "line": "7917",
+        "line": "7928",
         "name": "set_position",
         "owner": "CcbZonesApi",
         "parameters": "token, start, finish"
       },
       {
-        "line": "7910",
+        "line": "7921",
         "name": "set_temporary_disabled",
         "owner": "CcbZonesApi",
         "parameters": "token, disabled"
       },
       {
-        "line": "7872",
+        "line": "7883",
         "name": "type",
         "owner": "CcbZonesApi",
         "parameters": "id"
       },
       {
-        "line": "7868",
+        "line": "7879",
         "name": "types",
         "owner": "CcbZonesApi",
         "parameters": "options"
@@ -26942,355 +26987,355 @@
         "parameters": "species_id"
       },
       {
-        "line": "6533",
+        "line": "6544",
         "name": "above",
         "owner": "ScriptMapgenContext",
         "parameters": ""
       },
       {
-        "line": "6767",
+        "line": "6778",
         "name": "add_computer_chat_topic",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, topic_id"
       },
       {
-        "line": "6757",
+        "line": "6768",
         "name": "add_computer_eoc",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, eoc_id"
       },
       {
-        "line": "6752",
+        "line": "6763",
         "name": "add_computer_failure",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, failure"
       },
       {
-        "line": "6747",
+        "line": "6758",
         "name": "add_computer_option",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, name, action, security"
       },
       {
-        "line": "6668",
+        "line": "6679",
         "name": "add_field",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, field_id, intensity, age_turns"
       },
       {
-        "line": "6536",
+        "line": "6547",
         "name": "below",
         "owner": "ScriptMapgenContext",
         "parameters": ""
       },
       {
-        "line": "6512",
+        "line": "6523",
         "name": "east",
         "owner": "ScriptMapgenContext",
         "parameters": ""
       },
       {
-        "line": "6819",
+        "line": "6830",
         "name": "fill_groundcover",
         "owner": "ScriptMapgenContext",
         "parameters": ""
       },
       {
-        "line": "6577",
+        "line": "6588",
         "name": "furniture_at",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y"
       },
       {
-        "line": "6547",
+        "line": "6558",
         "name": "get_direction",
         "owner": "ScriptMapgenContext",
         "parameters": "index"
       },
       {
-        "line": "6540",
+        "line": "6551",
         "name": "get_nesw",
         "owner": "ScriptMapgenContext",
         "parameters": "index"
       },
       {
-        "line": "6557",
+        "line": "6568",
         "name": "get_rot_suffix",
         "owner": "ScriptMapgenContext",
         "parameters": ""
       },
       {
-        "line": "6554",
+        "line": "6565",
         "name": "get_rotation",
         "owner": "ScriptMapgenContext",
         "parameters": ""
       },
       {
-        "line": "6506",
+        "line": "6517",
         "name": "id",
         "owner": "ScriptMapgenContext",
         "parameters": ""
       },
       {
-        "line": "6731",
+        "line": "6742",
         "name": "make_rubble",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, furniture_id, items, floor_terrain_id, overwrite"
       },
       {
-        "line": "6521",
+        "line": "6532",
         "name": "neast",
         "owner": "ScriptMapgenContext",
         "parameters": ""
       },
       {
-        "line": "6509",
+        "line": "6520",
         "name": "north",
         "owner": "ScriptMapgenContext",
         "parameters": ""
       },
       {
-        "line": "6530",
+        "line": "6541",
         "name": "nwest",
         "owner": "ScriptMapgenContext",
         "parameters": ""
       },
       {
-        "line": "6503",
+        "line": "6514",
         "name": "operations_remaining",
         "owner": "ScriptMapgenContext",
         "parameters": ""
       },
       {
-        "line": "6500",
+        "line": "6511",
         "name": "operations_used",
         "owner": "ScriptMapgenContext",
         "parameters": ""
       },
       {
-        "line": "6740",
+        "line": "6751",
         "name": "place_computer",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, name, security, access_denied, mission_target"
       },
       {
-        "line": "6717",
+        "line": "6728",
         "name": "place_corpse",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, monster_id, age_days"
       },
       {
-        "line": "6723",
+        "line": "6734",
         "name": "place_corpse_from_group",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, group_id, age_days"
       },
       {
-        "line": "6689",
+        "line": "6700",
         "name": "place_gas_pump",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, charges, fuel_id"
       },
       {
-        "line": "6640",
+        "line": "6651",
         "name": "place_item",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, item_id, quantity, charges, faction_id"
       },
       {
-        "line": "6649",
+        "line": "6660",
         "name": "place_item_group",
         "owner": "ScriptMapgenContext",
         "parameters": "x1, y1, x2, y2, group_id, chance, faction_id"
       },
       {
-        "line": "6655",
+        "line": "6666",
         "name": "place_liquid",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, item_id, charges"
       },
       {
-        "line": "6711",
+        "line": "6722",
         "name": "place_monster",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, monster_id, count, friendly, name, mission_target"
       },
       {
-        "line": "6702",
+        "line": "6713",
         "name": "place_monster_group",
         "owner": "ScriptMapgenContext",
         "parameters": "x1, y1, x2, y2, group_id, chance, density, individual, friendly, name, mission_target"
       },
       {
-        "line": "6778",
+        "line": "6789",
         "name": "place_sealed_item",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, furniture_id, item_id, quantity, charges, item_group_name, item_group_chance, faction_id"
       },
       {
-        "line": "6784",
+        "line": "6795",
         "name": "place_sign",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, text, furniture_id"
       },
       {
-        "line": "6660",
+        "line": "6671",
         "name": "place_toilet",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, charges"
       },
       {
-        "line": "6683",
+        "line": "6694",
         "name": "place_vending_machine",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, item_group_id, reinforced, lootable, powered, networked"
       },
       {
-        "line": "6804",
+        "line": "6815",
         "name": "queue_npc",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, template_id, unique_id"
       },
       {
-        "line": "6794",
+        "line": "6805",
         "name": "queue_point",
         "owner": "ScriptMapgenContext",
         "parameters": "name, x, y"
       },
       {
-        "line": "6817",
+        "line": "6828",
         "name": "queue_zone",
         "owner": "ScriptMapgenContext",
         "parameters": "x1, y1, x2, y2, zone_type, faction, name, filter"
       },
       {
-        "line": "6567",
+        "line": "6578",
         "name": "random_chance",
         "owner": "ScriptMapgenContext",
         "parameters": "numerator, denominator"
       },
       {
-        "line": "6562",
+        "line": "6573",
         "name": "random_int",
         "owner": "ScriptMapgenContext",
         "parameters": "minimum, maximum"
       },
       {
-        "line": "6674",
+        "line": "6685",
         "name": "remove_field",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, field_id"
       },
       {
-        "line": "6621",
+        "line": "6632",
         "name": "reset",
         "owner": "ScriptMapgenContext",
         "parameters": "terrain_id"
       },
       {
-        "line": "6524",
+        "line": "6535",
         "name": "seast",
         "owner": "ScriptMapgenContext",
         "parameters": ""
       },
       {
-        "line": "6762",
+        "line": "6773",
         "name": "set_computer_access_handler",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, handler_id"
       },
       {
-        "line": "6551",
+        "line": "6562",
         "name": "set_dir",
         "owner": "ScriptMapgenContext",
         "parameters": "index, value"
       },
       {
-        "line": "6594",
+        "line": "6605",
         "name": "set_furniture",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, id"
       },
       {
-        "line": "6612",
+        "line": "6623",
         "name": "set_furniture_id",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, id"
       },
       {
-        "line": "6789",
+        "line": "6800",
         "name": "set_graffiti",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, text"
       },
       {
-        "line": "6632",
+        "line": "6643",
         "name": "set_item_faction",
         "owner": "ScriptMapgenContext",
         "parameters": "x1, y1, x2, y2, faction"
       },
       {
-        "line": "6588",
+        "line": "6599",
         "name": "set_terrain",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, id"
       },
       {
-        "line": "6606",
+        "line": "6617",
         "name": "set_terrain_id",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, id"
       },
       {
-        "line": "6600",
+        "line": "6611",
         "name": "set_trap",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, id"
       },
       {
-        "line": "6618",
+        "line": "6629",
         "name": "set_trap_id",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, id"
       },
       {
-        "line": "6515",
+        "line": "6526",
         "name": "south",
         "owner": "ScriptMapgenContext",
         "parameters": ""
       },
       {
-        "line": "6527",
+        "line": "6538",
         "name": "swest",
         "owner": "ScriptMapgenContext",
         "parameters": ""
       },
       {
-        "line": "6572",
+        "line": "6583",
         "name": "terrain_at",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y"
       },
       {
-        "line": "6582",
+        "line": "6593",
         "name": "trap_at",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y"
       },
       {
-        "line": "6497",
+        "line": "6508",
         "name": "valid",
         "owner": "ScriptMapgenContext",
         "parameters": ""
       },
       {
-        "line": "6518",
+        "line": "6529",
         "name": "west",
         "owner": "ScriptMapgenContext",
         "parameters": ""
       },
       {
-        "line": "6543",
+        "line": "6554",
         "name": "zlevel",
         "owner": "ScriptMapgenContext",
         "parameters": ""
@@ -30340,47 +30385,47 @@
   "public_root": {
     "fields": [
       {
-        "line": 10734,
+        "line": 10745,
         "name": "ModDefinition",
         "type": "fun(options:"
       },
       {
-        "line": 10735,
+        "line": 10746,
         "name": "content",
         "type": "CcbPlatformContent"
       },
       {
-        "line": 10737,
+        "line": 10748,
         "name": "dialogue",
         "type": "CcbPlatformDialogueApi"
       },
       {
-        "line": 10733,
+        "line": 10744,
         "name": "platform_version",
         "type": "1"
       },
       {
-        "line": 10740,
+        "line": 10751,
         "name": "presentation",
         "type": "CcbPlatformPresentation"
       },
       {
-        "line": 10736,
+        "line": 10747,
         "name": "runtime",
         "type": "CcbPlatformRuntime"
       },
       {
-        "line": 10741,
+        "line": 10752,
         "name": "services",
         "type": "CcbPlatformServices"
       },
       {
-        "line": 10738,
+        "line": 10749,
         "name": "state",
         "type": "CcbPlatformState"
       },
       {
-        "line": 10739,
+        "line": 10750,
         "name": "tasks",
         "type": "CcbPlatformTasks"
       }

--- a/data/lua/reference/ccb_platform_api_v1.json
+++ b/data/lua/reference/ccb_platform_api_v1.json
@@ -7,7 +7,7 @@
     "root_class": "CcbPlatformV1"
   },
   "lua_luals": {
-    "class_count": 695,
+    "class_count": 698,
     "classes": [
       {
         "fields": [
@@ -1230,27 +1230,27 @@
       {
         "fields": [
           {
-            "line": 10564,
+            "line": 10590,
             "name": "items",
             "type": "table"
           },
           {
-            "line": 10567,
+            "line": 10593,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 10566,
+            "line": 10592,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 10565,
+            "line": 10591,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 10568,
+            "line": 10594,
             "name": "truncated",
             "type": "boolean"
           }
@@ -2450,67 +2450,67 @@
       {
         "fields": [
           {
-            "line": 10551,
+            "line": 10577,
             "name": "focus",
             "type": "integer"
           },
           {
-            "line": 10553,
+            "line": 10579,
             "name": "hunger",
             "type": "integer"
           },
           {
-            "line": 10547,
+            "line": 10573,
             "name": "moves",
             "type": "integer"
           },
           {
-            "line": 10543,
+            "line": 10569,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 10550,
+            "line": 10576,
             "name": "pain",
             "type": "integer"
           },
           {
-            "line": 10555,
+            "line": 10581,
             "name": "sleepiness",
             "type": "integer"
           },
           {
-            "line": 10552,
+            "line": 10578,
             "name": "speed",
             "type": "integer"
           },
           {
-            "line": 10548,
+            "line": 10574,
             "name": "stamina",
             "type": "integer"
           },
           {
-            "line": 10549,
+            "line": 10575,
             "name": "stamina_max",
             "type": "integer"
           },
           {
-            "line": 10554,
+            "line": 10580,
             "name": "thirst",
             "type": "integer"
           },
           {
-            "line": 10544,
+            "line": 10570,
             "name": "x",
             "type": "integer"
           },
           {
-            "line": 10545,
+            "line": 10571,
             "name": "y",
             "type": "integer"
           },
           {
-            "line": 10546,
+            "line": 10572,
             "name": "z",
             "type": "integer"
           }
@@ -2544,52 +2544,52 @@
       {
         "fields": [
           {
-            "line": 10577,
+            "line": 10603,
             "name": "attitude",
             "type": "string"
           },
           {
-            "line": 10578,
+            "line": 10604,
             "name": "dead",
             "type": "boolean"
           },
           {
-            "line": 10573,
+            "line": 10599,
             "name": "display_name",
             "type": "string"
           },
           {
-            "line": 10576,
+            "line": 10602,
             "name": "distance",
             "type": "integer"
           },
           {
-            "line": 10579,
+            "line": 10605,
             "name": "hp",
             "type": "integer"
           },
           {
-            "line": 10580,
+            "line": 10606,
             "name": "hp_max",
             "type": "integer"
           },
           {
-            "line": 10571,
+            "line": 10597,
             "name": "kind",
             "type": "'avatar'|'npc'|'monster'|'creature'"
           },
           {
-            "line": 10572,
+            "line": 10598,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 10574,
+            "line": 10600,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 10575,
+            "line": 10601,
             "name": "visible",
             "type": "boolean"
           }
@@ -2623,22 +2623,22 @@
       {
         "fields": [
           {
-            "line": 9885,
+            "line": 9911,
             "name": "body_part",
             "type": "GameId"
           },
           {
-            "line": 9888,
+            "line": 9914,
             "name": "force",
             "type": "boolean"
           },
           {
-            "line": 9887,
+            "line": 9913,
             "name": "intensity",
             "type": "integer"
           },
           {
-            "line": 9886,
+            "line": 9912,
             "name": "permanent",
             "type": "boolean"
           }
@@ -2648,22 +2648,22 @@
       {
         "fields": [
           {
-            "line": 10024,
+            "line": 10050,
             "name": "items",
             "type": "GameId[]"
           },
           {
-            "line": 10026,
+            "line": 10052,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 10025,
+            "line": 10051,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 10027,
+            "line": 10053,
             "name": "truncated",
             "type": "boolean"
           }
@@ -2673,12 +2673,12 @@
       {
         "fields": [
           {
-            "line": 10031,
+            "line": 10057,
             "name": "effects",
             "type": "CcbEffectRelatedIdPage"
           },
           {
-            "line": 10030,
+            "line": 10056,
             "name": "mutations",
             "type": "CcbEffectRelatedIdPage"
           }
@@ -2688,112 +2688,112 @@
       {
         "fields": [
           {
-            "line": 10055,
+            "line": 10081,
             "name": "blocks_effects",
             "type": "CcbEffectRelatedIdPage"
           },
           {
-            "line": 10053,
+            "line": 10079,
             "name": "body_part",
             "type": "GameId"
           },
           {
-            "line": 10036,
+            "line": 10062,
             "name": "description",
             "type": "string"
           },
           {
-            "line": 10040,
+            "line": 10066,
             "name": "duration",
             "type": "TimeDuration"
           },
           {
-            "line": 10050,
+            "line": 10076,
             "name": "duration_add_percent",
             "type": "integer"
           },
           {
-            "line": 10046,
+            "line": 10072,
             "name": "effective_intensity",
             "type": "integer"
           },
           {
-            "line": 10049,
+            "line": 10075,
             "name": "harmful_cough",
             "type": "boolean"
           },
           {
-            "line": 10034,
+            "line": 10060,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 10048,
+            "line": 10074,
             "name": "impairs_movement",
             "type": "boolean"
           },
           {
-            "line": 10043,
+            "line": 10069,
             "name": "intensity",
             "type": "integer"
           },
           {
-            "line": 10051,
+            "line": 10077,
             "name": "intensity_add",
             "type": "integer"
           },
           {
-            "line": 10052,
+            "line": 10078,
             "name": "intensity_duration",
             "type": "TimeDuration"
           },
           {
-            "line": 10041,
+            "line": 10067,
             "name": "maximum_duration",
             "type": "TimeDuration"
           },
           {
-            "line": 10045,
+            "line": 10071,
             "name": "maximum_effective_intensity",
             "type": "integer"
           },
           {
-            "line": 10044,
+            "line": 10070,
             "name": "maximum_intensity",
             "type": "integer"
           },
           {
-            "line": 10038,
+            "line": 10064,
             "name": "mod_source",
             "type": "string"
           },
           {
-            "line": 10035,
+            "line": 10061,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 10047,
+            "line": 10073,
             "name": "permanent",
             "type": "boolean"
           },
           {
-            "line": 10054,
+            "line": 10080,
             "name": "resisted_by",
             "type": "CcbEffectResistanceIds"
           },
           {
-            "line": 10037,
+            "line": 10063,
             "name": "short_description",
             "type": "string"
           },
           {
-            "line": 10042,
+            "line": 10068,
             "name": "start_time",
             "type": "TimePoint"
           },
           {
-            "line": 10039,
+            "line": 10065,
             "name": "uses_body_part_description",
             "type": "boolean"
           }
@@ -2803,7 +2803,7 @@
       {
         "fields": [
           {
-            "line": 10058,
+            "line": 10084,
             "name": "value",
             "type": "CcbEffectSnapshot"
           }
@@ -2821,22 +2821,22 @@
       {
         "fields": [
           {
-            "line": 9148,
+            "line": 9174,
             "name": "handle",
             "type": "GameHandle"
           },
           {
-            "line": 9149,
+            "line": 9175,
             "name": "item",
             "type": "table<string,"
           },
           {
-            "line": 9147,
+            "line": 9173,
             "name": "source_handle_stale",
             "type": "boolean"
           },
           {
-            "line": 9146,
+            "line": 9172,
             "name": "source_uid",
             "type": "integer"
           }
@@ -2846,7 +2846,7 @@
       {
         "fields": [
           {
-            "line": 9143,
+            "line": 9169,
             "name": "code",
             "type": "CcbEquipmentErrorCode"
           }
@@ -2856,12 +2856,12 @@
       {
         "fields": [
           {
-            "line": 9167,
+            "line": 9193,
             "name": "error",
             "type": "CcbEquipmentError"
           },
           {
-            "line": 9166,
+            "line": 9192,
             "name": "value",
             "type": "CcbEquipmentValue"
           }
@@ -2871,62 +2871,62 @@
       {
         "fields": [
           {
-            "line": 9152,
+            "line": 9178,
             "name": "accepted",
             "type": "true"
           },
           {
-            "line": 9153,
+            "line": 9179,
             "name": "changed",
             "type": "boolean"
           },
           {
-            "line": 9159,
+            "line": 9185,
             "name": "destination_holder",
             "type": "CcbItemHolder"
           },
           {
-            "line": 9162,
+            "line": 9188,
             "name": "displaced",
             "type": "CcbEquipmentDisplacedItem[]"
           },
           {
-            "line": 9163,
+            "line": 9189,
             "name": "displaced_count",
             "type": "integer"
           },
           {
-            "line": 9160,
+            "line": 9186,
             "name": "handle",
             "type": "GameHandle"
           },
           {
-            "line": 9161,
+            "line": 9187,
             "name": "item",
             "type": "table<string,"
           },
           {
-            "line": 9157,
+            "line": 9183,
             "name": "old_handle_stale",
             "type": "boolean"
           },
           {
-            "line": 9154,
+            "line": 9180,
             "name": "operation",
             "type": "CcbEquipmentOperation"
           },
           {
-            "line": 9156,
+            "line": 9182,
             "name": "source_handle_stale",
             "type": "boolean"
           },
           {
-            "line": 9158,
+            "line": 9184,
             "name": "source_holder",
             "type": "CcbItemHolder"
           },
           {
-            "line": 9155,
+            "line": 9181,
             "name": "source_uid",
             "type": "integer"
           }
@@ -2936,32 +2936,32 @@
       {
         "fields": [
           {
-            "line": 8711,
+            "line": 8737,
             "name": "has_more",
             "type": "boolean"
           },
           {
-            "line": 8706,
+            "line": 8732,
             "name": "items",
             "type": "CcbFactionSnapshot[]"
           },
           {
-            "line": 8708,
+            "line": 8734,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 8707,
+            "line": 8733,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 8710,
+            "line": 8736,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 8709,
+            "line": 8735,
             "name": "total",
             "type": "integer"
           }
@@ -2971,22 +2971,22 @@
       {
         "fields": [
           {
-            "line": 8686,
+            "line": 8712,
             "name": "consumes_food",
             "type": "boolean"
           },
           {
-            "line": 8688,
+            "line": 8714,
             "name": "limited_area_claim",
             "type": "boolean"
           },
           {
-            "line": 8687,
+            "line": 8713,
             "name": "lone_wolf",
             "type": "boolean"
           },
           {
-            "line": 8689,
+            "line": 8715,
             "name": "stealing",
             "type": "'ask'|'always'|'never'"
           }
@@ -3061,27 +3061,27 @@
       {
         "fields": [
           {
-            "line": 8671,
+            "line": 8697,
             "name": "likes",
             "type": "integer"
           },
           {
-            "line": 8674,
+            "line": 8700,
             "name": "ranking",
             "type": "string"
           },
           {
-            "line": 8675,
+            "line": 8701,
             "name": "respect",
             "type": "string"
           },
           {
-            "line": 8672,
+            "line": 8698,
             "name": "respects",
             "type": "integer"
           },
           {
-            "line": 8673,
+            "line": 8699,
             "name": "trusts",
             "type": "integer"
           }
@@ -3091,32 +3091,32 @@
       {
         "fields": [
           {
-            "line": 8683,
+            "line": 8709,
             "name": "combat_ability",
             "type": "string"
           },
           {
-            "line": 8681,
+            "line": 8707,
             "name": "food_kcal",
             "type": "integer"
           },
           {
-            "line": 8679,
+            "line": 8705,
             "name": "power",
             "type": "integer"
           },
           {
-            "line": 8678,
+            "line": 8704,
             "name": "size",
             "type": "integer"
           },
           {
-            "line": 8680,
+            "line": 8706,
             "name": "wealth",
             "type": "integer"
           },
           {
-            "line": 8682,
+            "line": 8708,
             "name": "wealth_description",
             "type": "string"
           }
@@ -3126,62 +3126,62 @@
       {
         "fields": [
           {
-            "line": 8700,
+            "line": 8726,
             "name": "currency",
             "type": "GameId"
           },
           {
-            "line": 8694,
+            "line": 8720,
             "name": "description",
             "type": "string"
           },
           {
-            "line": 8692,
+            "line": 8718,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 8696,
+            "line": 8722,
             "name": "known_by_player",
             "type": "boolean"
           },
           {
-            "line": 8702,
+            "line": 8728,
             "name": "members",
             "type": "integer"
           },
           {
-            "line": 8701,
+            "line": 8727,
             "name": "monster_faction",
             "type": "GameId"
           },
           {
-            "line": 8693,
+            "line": 8719,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 8699,
+            "line": 8725,
             "name": "policy",
             "type": "CcbFactionPolicy"
           },
           {
-            "line": 8703,
+            "line": 8729,
             "name": "relationship_targets",
             "type": "integer"
           },
           {
-            "line": 8697,
+            "line": 8723,
             "name": "reputation",
             "type": "CcbFactionReputation"
           },
           {
-            "line": 8698,
+            "line": 8724,
             "name": "resources",
             "type": "CcbFactionResources"
           },
           {
-            "line": 8695,
+            "line": 8721,
             "name": "summary",
             "type": "string"
           }
@@ -3254,17 +3254,17 @@
       {
         "fields": [
           {
-            "line": 8050,
+            "line": 8076,
             "name": "after",
             "type": "CcbHordeEntitySnapshot"
           },
           {
-            "line": 8049,
+            "line": 8075,
             "name": "before",
             "type": "CcbHordeEntitySnapshot"
           },
           {
-            "line": 8048,
+            "line": 8074,
             "name": "status",
             "type": "\"committed\""
           }
@@ -3274,47 +3274,47 @@
       {
         "fields": [
           {
-            "line": 8116,
+            "line": 8142,
             "name": "default_monster",
             "type": "GameId|nil"
           },
           {
-            "line": 8123,
+            "line": 8149,
             "name": "entries",
             "type": "CcbHordeDefinitionEntryPage"
           },
           {
-            "line": 8122,
+            "line": 8148,
             "name": "frequency_total",
             "type": "integer"
           },
           {
-            "line": 8115,
+            "line": 8141,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 8117,
+            "line": 8143,
             "name": "is_animal",
             "type": "boolean"
           },
           {
-            "line": 8119,
+            "line": 8145,
             "name": "new_monster_group",
             "type": "GameId|nil"
           },
           {
-            "line": 8118,
+            "line": 8144,
             "name": "replace_monster_group",
             "type": "boolean"
           },
           {
-            "line": 8120,
+            "line": 8146,
             "name": "replacement_time",
             "type": "TimeDuration"
           },
           {
-            "line": 8121,
+            "line": 8147,
             "name": "safe",
             "type": "boolean"
           }
@@ -3324,57 +3324,57 @@
       {
         "fields": [
           {
-            "line": 8096,
+            "line": 8122,
             "name": "conditions",
             "type": "CcbHordeStringPage"
           },
           {
-            "line": 8089,
+            "line": 8115,
             "name": "cost_multiplier",
             "type": "number"
           },
           {
-            "line": 8093,
+            "line": 8119,
             "name": "ends",
             "type": "TimeDuration"
           },
           {
-            "line": 8095,
+            "line": 8121,
             "name": "event",
             "type": "string"
           },
           {
-            "line": 8088,
+            "line": 8114,
             "name": "frequency",
             "type": "integer"
           },
           {
-            "line": 8087,
+            "line": 8113,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 8086,
+            "line": 8112,
             "name": "kind",
             "type": "\"group\"|\"monster\""
           },
           {
-            "line": 8094,
+            "line": 8120,
             "name": "lasts_forever",
             "type": "boolean"
           },
           {
-            "line": 8091,
+            "line": 8117,
             "name": "pack_maximum",
             "type": "integer"
           },
           {
-            "line": 8090,
+            "line": 8116,
             "name": "pack_minimum",
             "type": "integer"
           },
           {
-            "line": 8092,
+            "line": 8118,
             "name": "starts",
             "type": "TimeDuration"
           }
@@ -3384,32 +3384,32 @@
       {
         "fields": [
           {
-            "line": 8104,
+            "line": 8130,
             "name": "has_more",
             "type": "boolean"
           },
           {
-            "line": 8099,
+            "line": 8125,
             "name": "items",
             "type": "CcbHordeDefinitionEntry[]"
           },
           {
-            "line": 8102,
+            "line": 8128,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 8101,
+            "line": 8127,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 8103,
+            "line": 8129,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 8100,
+            "line": 8126,
             "name": "total",
             "type": "integer"
           }
@@ -3419,32 +3419,32 @@
       {
         "fields": [
           {
-            "line": 8112,
+            "line": 8138,
             "name": "has_more",
             "type": "boolean"
           },
           {
-            "line": 8107,
+            "line": 8133,
             "name": "items",
             "type": "CcbHordeDefinitionSummary[]"
           },
           {
-            "line": 8109,
+            "line": 8135,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 8108,
+            "line": 8134,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 8111,
+            "line": 8137,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 8110,
+            "line": 8136,
             "name": "total",
             "type": "integer"
           }
@@ -3454,27 +3454,27 @@
       {
         "fields": [
           {
-            "line": 8073,
+            "line": 8099,
             "name": "default_monster",
             "type": "GameId|nil"
           },
           {
-            "line": 8074,
+            "line": 8100,
             "name": "entries",
             "type": "integer"
           },
           {
-            "line": 8072,
+            "line": 8098,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 8075,
+            "line": 8101,
             "name": "is_animal",
             "type": "boolean"
           },
           {
-            "line": 8076,
+            "line": 8102,
             "name": "safe",
             "type": "boolean"
           }
@@ -3484,7 +3484,7 @@
       {
         "fields": [
           {
-            "line": 8053,
+            "line": 8079,
             "name": "status",
             "type": "\"committed\""
           }
@@ -3494,57 +3494,57 @@
       {
         "fields": [
           {
-            "line": 7988,
+            "line": 8014,
             "name": "existing_only",
             "type": "boolean"
           },
           {
-            "line": 7987,
+            "line": 8013,
             "name": "existing_overmaps",
             "type": "integer"
           },
           {
-            "line": 7989,
+            "line": 8015,
             "name": "flavors",
             "type": "integer"
           },
           {
-            "line": 7984,
+            "line": 8010,
             "name": "has_more",
             "type": "boolean"
           },
           {
-            "line": 7979,
+            "line": 8005,
             "name": "items",
             "type": "CcbHordeEntitySnapshot[]"
           },
           {
-            "line": 7982,
+            "line": 8008,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7981,
+            "line": 8007,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 7985,
+            "line": 8011,
             "name": "radius",
             "type": "integer"
           },
           {
-            "line": 7986,
+            "line": 8012,
             "name": "radius_z",
             "type": "integer"
           },
           {
-            "line": 7983,
+            "line": 8009,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 7980,
+            "line": 8006,
             "name": "total",
             "type": "integer"
           }
@@ -3554,22 +3554,22 @@
       {
         "fields": [
           {
-            "line": 7936,
+            "line": 7962,
             "name": "flavors",
             "type": "string[]"
           },
           {
-            "line": 7937,
+            "line": 7963,
             "name": "monster",
             "type": "GameId"
           },
           {
-            "line": 7934,
+            "line": 7960,
             "name": "radius",
             "type": "integer"
           },
           {
-            "line": 7935,
+            "line": 7961,
             "name": "radius_z",
             "type": "integer"
           }
@@ -3579,12 +3579,12 @@
       {
         "fields": [
           {
-            "line": 8065,
+            "line": 8091,
             "name": "removed",
             "type": "boolean"
           },
           {
-            "line": 8064,
+            "line": 8090,
             "name": "status",
             "type": "\"committed\""
           }
@@ -3594,62 +3594,62 @@
       {
         "fields": [
           {
-            "line": 7971,
+            "line": 7997,
             "name": "active",
             "type": "boolean"
           },
           {
-            "line": 7973,
+            "line": 7999,
             "name": "destination",
             "type": "TripointCoord"
           },
           {
-            "line": 7970,
+            "line": 7996,
             "name": "flavor",
             "type": "\"active\"|\"idle\"|\"dormant\"|\"immobile\""
           },
           {
-            "line": 7972,
+            "line": 7998,
             "name": "heavy",
             "type": "boolean"
           },
           {
-            "line": 7976,
+            "line": 8002,
             "name": "last_processed",
             "type": "TimePoint"
           },
           {
-            "line": 7968,
+            "line": 7994,
             "name": "monster",
             "type": "GameId"
           },
           {
-            "line": 7975,
+            "line": 8001,
             "name": "moves",
             "type": "integer"
           },
           {
-            "line": 7969,
+            "line": 7995,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 7967,
+            "line": 7993,
             "name": "overmap_position",
             "type": "TripointCoord"
           },
           {
-            "line": 7966,
+            "line": 7992,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 7965,
+            "line": 7991,
             "name": "token",
             "type": "HordeEntityToken"
           },
           {
-            "line": 7974,
+            "line": 8000,
             "name": "tracking_intensity",
             "type": "integer"
           }
@@ -3659,7 +3659,7 @@
       {
         "fields": [
           {
-            "line": 8061,
+            "line": 8087,
             "name": "status",
             "type": "\"committed\""
           }
@@ -3669,47 +3669,47 @@
       {
         "fields": [
           {
-            "line": 7951,
+            "line": 7977,
             "name": "behavior",
             "type": "\"none\"|\"city\"|\"roam\"|\"nemesis\""
           },
           {
-            "line": 7949,
+            "line": 7975,
             "name": "dying",
             "type": "boolean"
           },
           {
-            "line": 7945,
+            "line": 7971,
             "name": "group",
             "type": "GameId"
           },
           {
-            "line": 7950,
+            "line": 7976,
             "name": "horde",
             "type": "boolean"
           },
           {
-            "line": 7948,
+            "line": 7974,
             "name": "interest",
             "type": "integer"
           },
           {
-            "line": 7953,
+            "line": 7979,
             "name": "nemesis_target",
             "type": "TripointCoord"
           },
           {
-            "line": 7947,
+            "line": 7973,
             "name": "population",
             "type": "integer"
           },
           {
-            "line": 7946,
+            "line": 7972,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 7952,
+            "line": 7978,
             "name": "target",
             "type": "TripointCoord"
           }
@@ -3719,57 +3719,57 @@
       {
         "fields": [
           {
-            "line": 8032,
+            "line": 8058,
             "name": "existing_only",
             "type": "boolean"
           },
           {
-            "line": 8031,
+            "line": 8057,
             "name": "existing_overmaps",
             "type": "integer"
           },
           {
-            "line": 8027,
+            "line": 8053,
             "name": "has_more",
             "type": "boolean"
           },
           {
-            "line": 8030,
+            "line": 8056,
             "name": "horde_only",
             "type": "boolean"
           },
           {
-            "line": 8022,
+            "line": 8048,
             "name": "items",
             "type": "CcbHordeLegacyGroupSnapshot[]"
           },
           {
-            "line": 8024,
+            "line": 8050,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 8023,
+            "line": 8049,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 8028,
+            "line": 8054,
             "name": "radius",
             "type": "integer"
           },
           {
-            "line": 8029,
+            "line": 8055,
             "name": "radius_z",
             "type": "integer"
           },
           {
-            "line": 8026,
+            "line": 8052,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 8025,
+            "line": 8051,
             "name": "total",
             "type": "integer"
           }
@@ -3779,12 +3779,12 @@
       {
         "fields": [
           {
-            "line": 8069,
+            "line": 8095,
             "name": "removed",
             "type": "boolean"
           },
           {
-            "line": 8068,
+            "line": 8094,
             "name": "status",
             "type": "\"committed\""
           }
@@ -3794,82 +3794,82 @@
       {
         "fields": [
           {
-            "line": 8018,
+            "line": 8044,
             "name": "average_speed",
             "type": "number"
           },
           {
-            "line": 8015,
+            "line": 8041,
             "name": "behavior",
             "type": "\"none\"|\"city\"|\"roam\"|\"nemesis\""
           },
           {
-            "line": 8013,
+            "line": 8039,
             "name": "dying",
             "type": "boolean"
           },
           {
-            "line": 8016,
+            "line": 8042,
             "name": "empty",
             "type": "boolean"
           },
           {
-            "line": 8005,
+            "line": 8031,
             "name": "group",
             "type": "GameId"
           },
           {
-            "line": 8014,
+            "line": 8040,
             "name": "horde",
             "type": "boolean"
           },
           {
-            "line": 8012,
+            "line": 8038,
             "name": "interest",
             "type": "integer"
           },
           {
-            "line": 8019,
+            "line": 8045,
             "name": "monsters",
             "type": "CcbHordeLegacyMonsterPage"
           },
           {
-            "line": 8009,
+            "line": 8035,
             "name": "nemesis_target",
             "type": "TripointCoord"
           },
           {
-            "line": 8007,
+            "line": 8033,
             "name": "overmap_position",
             "type": "TripointCoord"
           },
           {
-            "line": 8010,
+            "line": 8036,
             "name": "population",
             "type": "integer"
           },
           {
-            "line": 8006,
+            "line": 8032,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 8017,
+            "line": 8043,
             "name": "safe",
             "type": "boolean"
           },
           {
-            "line": 8008,
+            "line": 8034,
             "name": "target",
             "type": "TripointCoord"
           },
           {
-            "line": 8004,
+            "line": 8030,
             "name": "token",
             "type": "LegacyHordeToken"
           },
           {
-            "line": 8011,
+            "line": 8037,
             "name": "tracked_monsters",
             "type": "integer"
           }
@@ -3879,37 +3879,37 @@
       {
         "fields": [
           {
-            "line": 7960,
+            "line": 7986,
             "name": "behavior",
             "type": "\"none\"|\"city\"|\"roam\"|\"nemesis\""
           },
           {
-            "line": 7958,
+            "line": 7984,
             "name": "dying",
             "type": "boolean"
           },
           {
-            "line": 7959,
+            "line": 7985,
             "name": "horde",
             "type": "boolean"
           },
           {
-            "line": 7957,
+            "line": 7983,
             "name": "interest",
             "type": "integer"
           },
           {
-            "line": 7962,
+            "line": 7988,
             "name": "nemesis_target",
             "type": "TripointCoord"
           },
           {
-            "line": 7956,
+            "line": 7982,
             "name": "population",
             "type": "integer"
           },
           {
-            "line": 7961,
+            "line": 7987,
             "name": "target",
             "type": "TripointCoord"
           }
@@ -3919,17 +3919,17 @@
       {
         "fields": [
           {
-            "line": 8058,
+            "line": 8084,
             "name": "after",
             "type": "CcbHordeLegacyGroupSnapshot"
           },
           {
-            "line": 8057,
+            "line": 8083,
             "name": "before",
             "type": "CcbHordeLegacyGroupSnapshot"
           },
           {
-            "line": 8056,
+            "line": 8082,
             "name": "status",
             "type": "\"committed\""
           }
@@ -3939,27 +3939,27 @@
       {
         "fields": [
           {
-            "line": 7997,
+            "line": 8023,
             "name": "items",
             "type": "CcbHordeLegacyMonsterSnapshot[]"
           },
           {
-            "line": 7999,
+            "line": 8025,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 8000,
+            "line": 8026,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 7998,
+            "line": 8024,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 8001,
+            "line": 8027,
             "name": "truncated",
             "type": "boolean"
           }
@@ -3969,17 +3969,17 @@
       {
         "fields": [
           {
-            "line": 7992,
+            "line": 8018,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 7993,
+            "line": 8019,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 7994,
+            "line": 8020,
             "name": "position",
             "type": "TripointCoord"
           }
@@ -3989,17 +3989,17 @@
       {
         "fields": [
           {
-            "line": 7942,
+            "line": 7968,
             "name": "horde_only",
             "type": "boolean"
           },
           {
-            "line": 7940,
+            "line": 7966,
             "name": "radius",
             "type": "integer"
           },
           {
-            "line": 7941,
+            "line": 7967,
             "name": "radius_z",
             "type": "integer"
           }
@@ -4009,42 +4009,42 @@
       {
         "fields": [
           {
-            "line": 7905,
+            "line": 7931,
             "name": "existing_only",
             "type": "boolean"
           },
           {
-            "line": 7904,
+            "line": 7930,
             "name": "flavors",
             "type": "string[]"
           },
           {
-            "line": 7903,
+            "line": 7929,
             "name": "maximum_legacy_population",
             "type": "integer"
           },
           {
-            "line": 7900,
+            "line": 7926,
             "name": "maximum_limit",
             "type": "integer"
           },
           {
-            "line": 7901,
+            "line": 7927,
             "name": "maximum_offset",
             "type": "integer"
           },
           {
-            "line": 7898,
+            "line": 7924,
             "name": "maximum_radius",
             "type": "integer"
           },
           {
-            "line": 7899,
+            "line": 7925,
             "name": "maximum_radius_z",
             "type": "integer"
           },
           {
-            "line": 7902,
+            "line": 7928,
             "name": "maximum_tracking_intensity",
             "type": "integer"
           }
@@ -4054,42 +4054,42 @@
       {
         "fields": [
           {
-            "line": 8127,
+            "line": 8153,
             "name": "group",
             "type": "GameId"
           },
           {
-            "line": 8133,
+            "line": 8159,
             "name": "has_more",
             "type": "boolean"
           },
           {
-            "line": 8126,
+            "line": 8152,
             "name": "items",
             "type": "GameId[]"
           },
           {
-            "line": 8130,
+            "line": 8156,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 8129,
+            "line": 8155,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 8128,
+            "line": 8154,
             "name": "recursive",
             "type": "boolean"
           },
           {
-            "line": 8132,
+            "line": 8158,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 8131,
+            "line": 8157,
             "name": "total",
             "type": "integer"
           }
@@ -4099,12 +4099,12 @@
       {
         "fields": [
           {
-            "line": 7931,
+            "line": 7957,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7930,
+            "line": 7956,
             "name": "offset",
             "type": "integer"
           }
@@ -4114,27 +4114,27 @@
       {
         "fields": [
           {
-            "line": 8079,
+            "line": 8105,
             "name": "items",
             "type": "string[]"
           },
           {
-            "line": 8081,
+            "line": 8107,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 8082,
+            "line": 8108,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 8080,
+            "line": 8106,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 8083,
+            "line": 8109,
             "name": "truncated",
             "type": "boolean"
           }
@@ -4144,57 +4144,57 @@
       {
         "fields": [
           {
-            "line": 8037,
+            "line": 8063,
             "name": "active",
             "type": "integer"
           },
           {
-            "line": 8039,
+            "line": 8065,
             "name": "dormant",
             "type": "integer"
           },
           {
-            "line": 8036,
+            "line": 8062,
             "name": "entities",
             "type": "integer"
           },
           {
-            "line": 8043,
+            "line": 8069,
             "name": "estimated_size",
             "type": "integer"
           },
           {
-            "line": 8045,
+            "line": 8071,
             "name": "existing_only",
             "type": "boolean"
           },
           {
-            "line": 8044,
+            "line": 8070,
             "name": "has_horde",
             "type": "boolean"
           },
           {
-            "line": 8038,
+            "line": 8064,
             "name": "idle",
             "type": "integer"
           },
           {
-            "line": 8040,
+            "line": 8066,
             "name": "immobile",
             "type": "integer"
           },
           {
-            "line": 8041,
+            "line": 8067,
             "name": "legacy_hordes",
             "type": "integer"
           },
           {
-            "line": 8042,
+            "line": 8068,
             "name": "legacy_population",
             "type": "integer"
           },
           {
-            "line": 8035,
+            "line": 8061,
             "name": "position",
             "type": "TripointCoord"
           }
@@ -4242,7 +4242,7 @@
       {
         "fields": [
           {
-            "line": 8835,
+            "line": 8861,
             "name": "target",
             "type": "TripointCoord"
           }
@@ -4252,32 +4252,32 @@
       {
         "fields": [
           {
-            "line": 8838,
+            "line": 8864,
             "name": "accepted",
             "type": "boolean"
           },
           {
-            "line": 8839,
+            "line": 8865,
             "name": "destroyed",
             "type": "boolean"
           },
           {
-            "line": 8843,
+            "line": 8869,
             "name": "handle",
             "type": "GameHandle"
           },
           {
-            "line": 8842,
+            "line": 8868,
             "name": "item",
             "type": "table<string,"
           },
           {
-            "line": 8841,
+            "line": 8867,
             "name": "method",
             "type": "string"
           },
           {
-            "line": 8840,
+            "line": 8866,
             "name": "stale",
             "type": "boolean"
           }
@@ -4287,22 +4287,22 @@
       {
         "fields": [
           {
-            "line": 8849,
+            "line": 8875,
             "name": "activity",
             "type": "table<string,"
           },
           {
-            "line": 8848,
+            "line": 8874,
             "name": "input_handle_retired",
             "type": "boolean"
           },
           {
-            "line": 8847,
+            "line": 8873,
             "name": "item_uid",
             "type": "integer"
           },
           {
-            "line": 8846,
+            "line": 8872,
             "name": "quantity",
             "type": "integer"
           }
@@ -4316,12 +4316,12 @@
       {
         "fields": [
           {
-            "line": 8881,
+            "line": 8907,
             "name": "count",
             "type": "integer"
           },
           {
-            "line": 8880,
+            "line": 8906,
             "name": "items",
             "type": "CcbItemCategorySpawnRateResult[]"
           }
@@ -4331,12 +4331,12 @@
       {
         "fields": [
           {
-            "line": 8870,
+            "line": 8896,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 8871,
+            "line": 8897,
             "name": "spawn_rate",
             "type": "number"
           }
@@ -4346,22 +4346,22 @@
       {
         "fields": [
           {
-            "line": 8876,
+            "line": 8902,
             "name": "after",
             "type": "number"
           },
           {
-            "line": 8875,
+            "line": 8901,
             "name": "before",
             "type": "number"
           },
           {
-            "line": 8877,
+            "line": 8903,
             "name": "changed",
             "type": "boolean"
           },
           {
-            "line": 8874,
+            "line": 8900,
             "name": "id",
             "type": "GameId"
           }
@@ -4371,17 +4371,17 @@
       {
         "fields": [
           {
-            "line": 8863,
+            "line": 8889,
             "name": "force",
             "type": "boolean"
           },
           {
-            "line": 8865,
+            "line": 8891,
             "name": "holder",
             "type": "GameHandle"
           },
           {
-            "line": 8864,
+            "line": 8890,
             "name": "message",
             "type": "boolean"
           }
@@ -4391,42 +4391,42 @@
       {
         "fields": [
           {
-            "line": 8782,
+            "line": 8808,
             "name": "character",
             "type": "GameHandle"
           },
           {
-            "line": 8785,
+            "line": 8811,
             "name": "container",
             "type": "GameHandle"
           },
           {
-            "line": 8781,
+            "line": 8807,
             "name": "kind",
             "type": "'character'|'map_tile'|'container_pocket'|'vehicle_cargo'"
           },
           {
-            "line": 8788,
+            "line": 8814,
             "name": "part",
             "type": "GameHandle"
           },
           {
-            "line": 8786,
+            "line": 8812,
             "name": "pocket_index",
             "type": "integer"
           },
           {
-            "line": 8783,
+            "line": 8809,
             "name": "slot",
             "type": "'inventory'|'worn'|'wielded'"
           },
           {
-            "line": 8784,
+            "line": 8810,
             "name": "tile",
             "type": "MapTileToken"
           },
           {
-            "line": 8787,
+            "line": 8813,
             "name": "vehicle",
             "type": "GameHandle"
           }
@@ -4436,37 +4436,37 @@
       {
         "fields": [
           {
-            "line": 8772,
+            "line": 8798,
             "name": "continuation_id",
             "type": "integer"
           },
           {
-            "line": 8773,
+            "line": 8799,
             "name": "holder",
             "type": "CcbItemHolder"
           },
           {
-            "line": 8775,
+            "line": 8801,
             "name": "max_depth",
             "type": "integer"
           },
           {
-            "line": 8774,
+            "line": 8800,
             "name": "page_size",
             "type": "integer"
           },
           {
-            "line": 8778,
+            "line": 8804,
             "name": "reason",
             "type": "'page'|'node_budget'"
           },
           {
-            "line": 8776,
+            "line": 8802,
             "name": "recursive",
             "type": "boolean"
           },
           {
-            "line": 8777,
+            "line": 8803,
             "name": "same_runtime_world_holder",
             "type": "boolean"
           }
@@ -4476,32 +4476,32 @@
       {
         "fields": [
           {
-            "line": 8794,
+            "line": 8820,
             "name": "depth",
             "type": "integer"
           },
           {
-            "line": 8791,
+            "line": 8817,
             "name": "handle",
             "type": "GameHandle"
           },
           {
-            "line": 8793,
+            "line": 8819,
             "name": "holder",
             "type": "CcbItemHolder"
           },
           {
-            "line": 8796,
+            "line": 8822,
             "name": "parent_uid",
             "type": "integer"
           },
           {
-            "line": 8792,
+            "line": 8818,
             "name": "snapshot",
             "type": "table<string,"
           },
           {
-            "line": 8795,
+            "line": 8821,
             "name": "uid",
             "type": "integer"
           }
@@ -4511,57 +4511,57 @@
       {
         "fields": [
           {
-            "line": 8803,
+            "line": 8829,
             "name": "complete",
             "type": "boolean"
           },
           {
-            "line": 8808,
+            "line": 8834,
             "name": "continuation",
             "type": "CcbItemPageContinuation"
           },
           {
-            "line": 8800,
+            "line": 8826,
             "name": "holder",
             "type": "CcbItemHolder"
           },
           {
-            "line": 8799,
+            "line": 8825,
             "name": "items",
             "type": "CcbItemPageEntry[]"
           },
           {
-            "line": 8806,
+            "line": 8832,
             "name": "max_depth",
             "type": "integer"
           },
           {
-            "line": 8809,
+            "line": 8835,
             "name": "next",
             "type": "CcbItemPageContinuation"
           },
           {
-            "line": 8801,
+            "line": 8827,
             "name": "page_size",
             "type": "integer"
           },
           {
-            "line": 8807,
+            "line": 8833,
             "name": "recursive",
             "type": "boolean"
           },
           {
-            "line": 8802,
+            "line": 8828,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 8805,
+            "line": 8831,
             "name": "stop_reason",
             "type": "'empty'|'complete'|'page'|'node_budget'|'max_depth'|'cycle'|'repeated_item'|'invalid_pocket'|'stale_cursor'"
           },
           {
-            "line": 8804,
+            "line": 8830,
             "name": "truncated",
             "type": "boolean"
           }
@@ -4571,47 +4571,47 @@
       {
         "fields": [
           {
-            "line": 8852,
+            "line": 8878,
             "name": "accepted",
             "type": "boolean"
           },
           {
-            "line": 8853,
+            "line": 8879,
             "name": "changed",
             "type": "boolean"
           },
           {
-            "line": 8857,
+            "line": 8883,
             "name": "handle",
             "type": "GameHandle"
           },
           {
-            "line": 8859,
+            "line": 8885,
             "name": "holder",
             "type": "CcbItemHolder"
           },
           {
-            "line": 8860,
+            "line": 8886,
             "name": "item",
             "type": "table<string,"
           },
           {
-            "line": 8856,
+            "line": 8882,
             "name": "old_handle_stale",
             "type": "boolean"
           },
           {
-            "line": 8854,
+            "line": 8880,
             "name": "quantity",
             "type": "integer"
           },
           {
-            "line": 8855,
+            "line": 8881,
             "name": "source_handle_stale",
             "type": "boolean"
           },
           {
-            "line": 8858,
+            "line": 8884,
             "name": "source_holder",
             "type": "CcbItemHolder"
           }
@@ -4621,17 +4621,17 @@
       {
         "fields": [
           {
-            "line": 8824,
+            "line": 8850,
             "name": "active",
             "type": "boolean"
           },
           {
-            "line": 8825,
+            "line": 8851,
             "name": "browsed",
             "type": "boolean"
           },
           {
-            "line": 8823,
+            "line": 8849,
             "name": "carrier",
             "type": "GameHandle"
           }
@@ -4641,27 +4641,27 @@
       {
         "fields": [
           {
-            "line": 8829,
+            "line": 8855,
             "name": "after",
             "type": "table<string,"
           },
           {
-            "line": 8828,
+            "line": 8854,
             "name": "before",
             "type": "table<string,"
           },
           {
-            "line": 8830,
+            "line": 8856,
             "name": "changed",
             "type": "boolean"
           },
           {
-            "line": 8832,
+            "line": 8858,
             "name": "handle",
             "type": "GameHandle"
           },
           {
-            "line": 8831,
+            "line": 8857,
             "name": "old_handle_stale",
             "type": "boolean"
           }
@@ -4671,47 +4671,47 @@
       {
         "fields": [
           {
-            "line": 8817,
+            "line": 8843,
             "name": "active",
             "type": "boolean"
           },
           {
-            "line": 8818,
+            "line": 8844,
             "name": "browsed",
             "type": "boolean"
           },
           {
-            "line": 8815,
+            "line": 8841,
             "name": "burnt",
             "type": "integer"
           },
           {
-            "line": 8812,
+            "line": 8838,
             "name": "charges",
             "type": "integer"
           },
           {
-            "line": 8813,
+            "line": 8839,
             "name": "damage",
             "type": "integer"
           },
           {
-            "line": 8814,
+            "line": 8840,
             "name": "degradation",
             "type": "integer"
           },
           {
-            "line": 8816,
+            "line": 8842,
             "name": "favorite",
             "type": "boolean"
           },
           {
-            "line": 8819,
+            "line": 8845,
             "name": "relative_rot",
             "type": "number"
           },
           {
-            "line": 8820,
+            "line": 8846,
             "name": "rot",
             "type": "TimeDuration"
           }
@@ -4958,47 +4958,47 @@
       {
         "fields": [
           {
-            "line": 8588,
+            "line": 8614,
             "name": "abandoned",
             "type": "CcbMissionSnapshot"
           },
           {
-            "line": 8586,
+            "line": 8612,
             "name": "after",
             "type": "CcbMissionSnapshot"
           },
           {
-            "line": 8585,
+            "line": 8611,
             "name": "before",
             "type": "CcbMissionSnapshot"
           },
           {
-            "line": 8587,
+            "line": 8613,
             "name": "cancelled",
             "type": "CcbMissionSnapshot"
           },
           {
-            "line": 8591,
+            "line": 8617,
             "name": "changed",
             "type": "boolean"
           },
           {
-            "line": 8590,
+            "line": 8616,
             "name": "cleared",
             "type": "boolean"
           },
           {
-            "line": 8593,
+            "line": 8619,
             "name": "forced",
             "type": "boolean"
           },
           {
-            "line": 8589,
+            "line": 8615,
             "name": "removed",
             "type": "boolean"
           },
           {
-            "line": 8592,
+            "line": 8618,
             "name": "step",
             "type": "integer"
           }
@@ -5008,42 +5008,42 @@
       {
         "fields": [
           {
-            "line": 8580,
+            "line": 8606,
             "name": "has_more",
             "type": "boolean"
           },
           {
-            "line": 8575,
+            "line": 8601,
             "name": "items",
             "type": "CcbMissionSnapshot[]"
           },
           {
-            "line": 8578,
+            "line": 8604,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 8577,
+            "line": 8603,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 8581,
+            "line": 8607,
             "name": "owner",
             "type": "GameHandle"
           },
           {
-            "line": 8579,
+            "line": 8605,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 8582,
+            "line": 8608,
             "name": "status",
             "type": "'all'|'reserved'|'active'|'success'|'failure'"
           },
           {
-            "line": 8576,
+            "line": 8602,
             "name": "total",
             "type": "integer"
           }
@@ -5073,107 +5073,107 @@
       {
         "fields": [
           {
-            "line": 8558,
+            "line": 8584,
             "name": "assigned",
             "type": "boolean"
           },
           {
-            "line": 8570,
+            "line": 8596,
             "name": "assigned_player_id",
             "type": "integer"
           },
           {
-            "line": 8563,
+            "line": 8589,
             "name": "deadline",
             "type": "TimePoint"
           },
           {
-            "line": 8556,
+            "line": 8582,
             "name": "description",
             "type": "string"
           },
           {
-            "line": 8560,
+            "line": 8586,
             "name": "failed",
             "type": "boolean"
           },
           {
-            "line": 8566,
+            "line": 8592,
             "name": "follow_up",
             "type": "GameId"
           },
           {
-            "line": 8562,
+            "line": 8588,
             "name": "has_deadline",
             "type": "boolean"
           },
           {
-            "line": 8572,
+            "line": 8598,
             "name": "has_generic_rewards",
             "type": "boolean"
           },
           {
-            "line": 8564,
+            "line": 8590,
             "name": "has_target",
             "type": "boolean"
           },
           {
-            "line": 8554,
+            "line": 8580,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 8559,
+            "line": 8585,
             "name": "in_progress",
             "type": "boolean"
           },
           {
-            "line": 8568,
+            "line": 8594,
             "name": "item",
             "type": "GameId"
           },
           {
-            "line": 8571,
+            "line": 8597,
             "name": "likely_rewards",
             "type": "table"
           },
           {
-            "line": 8555,
+            "line": 8581,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 8569,
+            "line": 8595,
             "name": "npc_id",
             "type": "integer"
           },
           {
-            "line": 8561,
+            "line": 8587,
             "name": "selected",
             "type": "boolean"
           },
           {
-            "line": 8557,
+            "line": 8583,
             "name": "status",
             "type": "'reserved'|'active'|'success'|'failure'"
           },
           {
-            "line": 8565,
+            "line": 8591,
             "name": "target",
             "type": "TripointCoord"
           },
           {
-            "line": 8552,
+            "line": 8578,
             "name": "token",
             "type": "MissionToken"
           },
           {
-            "line": 8553,
+            "line": 8579,
             "name": "uid",
             "type": "integer"
           },
           {
-            "line": 8567,
+            "line": 8593,
             "name": "value",
             "type": "integer"
           }
@@ -5187,17 +5187,17 @@
       {
         "fields": [
           {
-            "line": 9893,
+            "line": 9919,
             "name": "capped",
             "type": "boolean"
           },
           {
-            "line": 9892,
+            "line": 9918,
             "name": "decay_start",
             "type": "TimeDuration"
           },
           {
-            "line": 9891,
+            "line": 9917,
             "name": "duration",
             "type": "TimeDuration"
           }
@@ -5211,22 +5211,22 @@
       {
         "fields": [
           {
-            "line": 10559,
+            "line": 10585,
             "name": "count",
             "type": "integer"
           },
           {
-            "line": 10560,
+            "line": 10586,
             "name": "current_id",
             "type": "string"
           },
           {
-            "line": 10561,
+            "line": 10587,
             "name": "desired_id",
             "type": "string"
           },
           {
-            "line": 10558,
+            "line": 10584,
             "name": "items",
             "type": "table"
           }
@@ -5236,17 +5236,17 @@
       {
         "fields": [
           {
-            "line": 9881,
+            "line": 9907,
             "name": "removed",
             "type": "GameId[]"
           },
           {
-            "line": 9882,
+            "line": 9908,
             "name": "removed_count",
             "type": "integer"
           },
           {
-            "line": 9880,
+            "line": 9906,
             "name": "type",
             "type": "string"
           }
@@ -5264,17 +5264,17 @@
       {
         "fields": [
           {
-            "line": 9393,
+            "line": 9419,
             "name": "completed",
             "type": "boolean"
           },
           {
-            "line": 9392,
+            "line": 9418,
             "name": "started",
             "type": "boolean"
           },
           {
-            "line": 9391,
+            "line": 9417,
             "name": "status",
             "type": "CcbNpcDialogueStatus"
           }
@@ -5292,42 +5292,42 @@
       {
         "fields": [
           {
-            "line": 9282,
+            "line": 9308,
             "name": "action",
             "type": "'assign'|'success'|'failure'|'clear'|'reward'"
           },
           {
-            "line": 9287,
+            "line": 9313,
             "name": "after",
             "type": "CcbNpcMissionsState"
           },
           {
-            "line": 9286,
+            "line": 9312,
             "name": "before",
             "type": "CcbNpcMissionsState"
           },
           {
-            "line": 9284,
+            "line": 9310,
             "name": "forced",
             "type": "boolean"
           },
           {
-            "line": 9285,
+            "line": 9311,
             "name": "owed_delta",
             "type": "integer"
           },
           {
-            "line": 9283,
+            "line": 9309,
             "name": "owner",
             "type": "GameHandle"
           },
           {
-            "line": 9289,
+            "line": 9315,
             "name": "provider_after",
             "type": "CcbNpcProviderState"
           },
           {
-            "line": 9288,
+            "line": 9314,
             "name": "provider_before",
             "type": "CcbNpcProviderState"
           }
@@ -5337,22 +5337,22 @@
       {
         "fields": [
           {
-            "line": 9279,
+            "line": 9305,
             "name": "after",
             "type": "CcbNpcMissionsState"
           },
           {
-            "line": 9278,
+            "line": 9304,
             "name": "before",
             "type": "CcbNpcMissionsState"
           },
           {
-            "line": 9276,
+            "line": 9302,
             "name": "mission",
             "type": "CcbNpcMissionSnapshot"
           },
           {
-            "line": 9277,
+            "line": 9303,
             "name": "owner",
             "type": "GameHandle"
           }
@@ -5362,17 +5362,17 @@
       {
         "fields": [
           {
-            "line": 9273,
+            "line": 9299,
             "name": "after",
             "type": "CcbNpcMissionsState"
           },
           {
-            "line": 9272,
+            "line": 9298,
             "name": "before",
             "type": "CcbNpcMissionsState"
           },
           {
-            "line": 9271,
+            "line": 9297,
             "name": "mission",
             "type": "CcbNpcMissionSnapshot"
           }
@@ -5382,22 +5382,22 @@
       {
         "fields": [
           {
-            "line": 9234,
+            "line": 9260,
             "name": "items",
             "type": "CcbNpcMissionSnapshot[]"
           },
           {
-            "line": 9236,
+            "line": 9262,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 9235,
+            "line": 9261,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 9237,
+            "line": 9263,
             "name": "truncated",
             "type": "boolean"
           }
@@ -5407,57 +5407,57 @@
       {
         "fields": [
           {
-            "line": 9226,
+            "line": 9252,
             "name": "assigned",
             "type": "boolean"
           },
           {
-            "line": 9228,
+            "line": 9254,
             "name": "failed",
             "type": "boolean"
           },
           {
-            "line": 9231,
+            "line": 9257,
             "name": "follow_up",
             "type": "GameId"
           },
           {
-            "line": 9230,
+            "line": 9256,
             "name": "generic_reward_claimed",
             "type": "boolean"
           },
           {
-            "line": 9229,
+            "line": 9255,
             "name": "has_generic_rewards",
             "type": "boolean"
           },
           {
-            "line": 9223,
+            "line": 9249,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 9227,
+            "line": 9253,
             "name": "in_progress",
             "type": "boolean"
           },
           {
-            "line": 9224,
+            "line": 9250,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 9225,
+            "line": 9251,
             "name": "status",
             "type": "CcbNpcMissionStatus"
           },
           {
-            "line": 9221,
+            "line": 9247,
             "name": "token",
             "type": "MissionToken"
           },
           {
-            "line": 9222,
+            "line": 9248,
             "name": "uid",
             "type": "integer"
           }
@@ -5471,32 +5471,32 @@
       {
         "fields": [
           {
-            "line": 9242,
+            "line": 9268,
             "name": "assigned",
             "type": "CcbNpcMissionPage"
           },
           {
-            "line": 9241,
+            "line": 9267,
             "name": "available",
             "type": "CcbNpcMissionPage"
           },
           {
-            "line": 9240,
+            "line": 9266,
             "name": "provider_id",
             "type": "integer"
           },
           {
-            "line": 9243,
+            "line": 9269,
             "name": "selected",
             "type": "CcbNpcMissionSnapshot"
           },
           {
-            "line": 9245,
+            "line": 9271,
             "name": "selected_invalid",
             "type": "boolean"
           },
           {
-            "line": 9244,
+            "line": 9270,
             "name": "selected_stale",
             "type": "boolean"
           }
@@ -5506,12 +5506,12 @@
       {
         "fields": [
           {
-            "line": 9268,
+            "line": 9294,
             "name": "after",
             "type": "CcbNpcMissionsState"
           },
           {
-            "line": 9267,
+            "line": 9293,
             "name": "before",
             "type": "CcbNpcMissionsState"
           }
@@ -5521,32 +5521,32 @@
       {
         "fields": [
           {
-            "line": 9196,
+            "line": 9222,
             "name": "anger",
             "type": "integer"
           },
           {
-            "line": 9194,
+            "line": 9220,
             "name": "fear",
             "type": "integer"
           },
           {
-            "line": 9197,
+            "line": 9223,
             "name": "owed",
             "type": "integer"
           },
           {
-            "line": 9198,
+            "line": 9224,
             "name": "sold",
             "type": "integer"
           },
           {
-            "line": 9193,
+            "line": 9219,
             "name": "trust",
             "type": "integer"
           },
           {
-            "line": 9195,
+            "line": 9221,
             "name": "value",
             "type": "integer"
           }
@@ -5556,87 +5556,87 @@
       {
         "fields": [
           {
-            "line": 9260,
+            "line": 9286,
             "name": "activity",
             "type": "GameId"
           },
           {
-            "line": 9262,
+            "line": 9288,
             "name": "attitude",
             "type": "integer"
           },
           {
-            "line": 9250,
+            "line": 9276,
             "name": "avatar",
             "type": "boolean"
           },
           {
-            "line": 9253,
+            "line": 9279,
             "name": "bionics",
             "type": "integer"
           },
           {
-            "line": 9257,
+            "line": 9283,
             "name": "bitten",
             "type": "boolean"
           },
           {
-            "line": 9256,
+            "line": 9282,
             "name": "bleeding",
             "type": "boolean"
           },
           {
-            "line": 9263,
+            "line": 9289,
             "name": "busy_turns",
             "type": "integer"
           },
           {
-            "line": 9264,
+            "line": 9290,
             "name": "current_activity",
             "type": "string"
           },
           {
-            "line": 9251,
+            "line": 9277,
             "name": "hp",
             "type": "integer"
           },
           {
-            "line": 9248,
+            "line": 9274,
             "name": "id",
             "type": "integer"
           },
           {
-            "line": 9258,
+            "line": 9284,
             "name": "infected",
             "type": "boolean"
           },
           {
-            "line": 9259,
+            "line": 9285,
             "name": "inventory_stacks",
             "type": "integer"
           },
           {
-            "line": 9252,
+            "line": 9278,
             "name": "maximum_hp",
             "type": "integer"
           },
           {
-            "line": 9255,
+            "line": 9281,
             "name": "mounted",
             "type": "boolean"
           },
           {
-            "line": 9254,
+            "line": 9280,
             "name": "mutations",
             "type": "integer"
           },
           {
-            "line": 9249,
+            "line": 9275,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 9261,
+            "line": 9287,
             "name": "owed",
             "type": "integer"
           }
@@ -5666,82 +5666,82 @@
       {
         "fields": [
           {
-            "line": 9216,
+            "line": 9242,
             "name": "ai_rules",
             "type": "table<string,"
           },
           {
-            "line": 9210,
+            "line": 9236,
             "name": "attitude",
             "type": "GameId"
           },
           {
-            "line": 9211,
+            "line": 9237,
             "name": "attitude_name",
             "type": "string"
           },
           {
-            "line": 9207,
+            "line": 9233,
             "name": "class",
             "type": "GameId"
           },
           {
-            "line": 9212,
+            "line": 9238,
             "name": "dead",
             "type": "boolean"
           },
           {
-            "line": 9205,
+            "line": 9231,
             "name": "display_name",
             "type": "string"
           },
           {
-            "line": 9209,
+            "line": 9235,
             "name": "faction",
             "type": "GameId|nil"
           },
           {
-            "line": 9214,
+            "line": 9240,
             "name": "first_topic",
             "type": "string"
           },
           {
-            "line": 9201,
+            "line": 9227,
             "name": "handle",
             "type": "GameHandle"
           },
           {
-            "line": 9202,
+            "line": 9228,
             "name": "id",
             "type": "integer"
           },
           {
-            "line": 9204,
+            "line": 9230,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 9215,
+            "line": 9241,
             "name": "opinion",
             "type": "CcbNpcOpinion"
           },
           {
-            "line": 9213,
+            "line": 9239,
             "name": "player_ally",
             "type": "boolean"
           },
           {
-            "line": 9206,
+            "line": 9232,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 9208,
+            "line": 9234,
             "name": "template",
             "type": "GameId|nil"
           },
           {
-            "line": 9203,
+            "line": 9229,
             "name": "unique_id",
             "type": "string"
           }
@@ -5755,27 +5755,27 @@
       {
         "fields": [
           {
-            "line": 9545,
+            "line": 9571,
             "name": "dialogue",
             "type": "CcbNpcDialogueActionsApi"
           },
           {
-            "line": 9542,
+            "line": 9568,
             "name": "grooming",
             "type": "CcbNpcGroomingApi"
           },
           {
-            "line": 9541,
+            "line": 9567,
             "name": "medical",
             "type": "CcbNpcMedicalApi"
           },
           {
-            "line": 9544,
+            "line": 9570,
             "name": "missions",
             "type": "CcbNpcMissionsApi"
           },
           {
-            "line": 9543,
+            "line": 9569,
             "name": "training",
             "type": "CcbNpcTrainingApi"
           }
@@ -5785,22 +5785,22 @@
       {
         "fields": [
           {
-            "line": 9896,
+            "line": 9922,
             "name": "items",
             "type": "GameId[]"
           },
           {
-            "line": 9898,
+            "line": 9924,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 9897,
+            "line": 9923,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 9899,
+            "line": 9925,
             "name": "truncated",
             "type": "boolean"
           }
@@ -6077,12 +6077,12 @@
       {
         "fields": [
           {
-            "line": 9809,
+            "line": 9835,
             "name": "activity",
             "type": "CcbPlatformActivitySnapshot"
           },
           {
-            "line": 9808,
+            "line": 9834,
             "name": "changed",
             "type": "boolean"
           }
@@ -6092,57 +6092,57 @@
       {
         "fields": [
           {
-            "line": 9795,
+            "line": 9821,
             "name": "active",
             "type": "boolean"
           },
           {
-            "line": 9802,
+            "line": 9828,
             "name": "auto_resume",
             "type": "boolean"
           },
           {
-            "line": 9796,
+            "line": 9822,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 9800,
+            "line": 9826,
             "name": "interruptible",
             "type": "boolean"
           },
           {
-            "line": 9801,
+            "line": 9827,
             "name": "interruptible_with_keyboard",
             "type": "boolean"
           },
           {
-            "line": 9799,
+            "line": 9825,
             "name": "moves_left",
             "type": "integer"
           },
           {
-            "line": 9798,
+            "line": 9824,
             "name": "moves_total",
             "type": "integer"
           },
           {
-            "line": 9805,
+            "line": 9831,
             "name": "progress",
             "type": "number"
           },
           {
-            "line": 9804,
+            "line": 9830,
             "name": "resumable",
             "type": "boolean"
           },
           {
-            "line": 9803,
+            "line": 9829,
             "name": "rooted",
             "type": "boolean"
           },
           {
-            "line": 9797,
+            "line": 9823,
             "name": "verb",
             "type": "string"
           }
@@ -6182,22 +6182,22 @@
       {
         "fields": [
           {
-            "line": 10178,
+            "line": 10204,
             "name": "has_capacity",
             "type": "boolean"
           },
           {
-            "line": 10175,
+            "line": 10201,
             "name": "installed_count",
             "type": "integer"
           },
           {
-            "line": 10177,
+            "line": 10203,
             "name": "maximum_power",
             "type": "UnitValue"
           },
           {
-            "line": 10176,
+            "line": 10202,
             "name": "power",
             "type": "UnitValue"
           }
@@ -6493,27 +6493,27 @@
       {
         "fields": [
           {
-            "line": 10518,
+            "line": 10544,
             "name": "environment",
             "type": "CcbPlatformEnvironmentQueries"
           },
           {
-            "line": 10517,
+            "line": 10543,
             "name": "math",
             "type": "CcbPlatformMathApi"
           },
           {
-            "line": 10516,
+            "line": 10542,
             "name": "mods",
             "type": "CcbPlatformModQueries"
           },
           {
-            "line": 10519,
+            "line": 10545,
             "name": "options",
             "type": "CcbPlatformGameplayOptionsApi"
           },
           {
-            "line": 10515,
+            "line": 10541,
             "name": "strings",
             "type": "CcbPlatformStringPredicates"
           }
@@ -6654,17 +6654,17 @@
       {
         "fields": [
           {
-            "line": 10382,
+            "line": 10408,
             "name": "capped",
             "type": "boolean"
           },
           {
-            "line": 10381,
+            "line": 10407,
             "name": "decay_start",
             "type": "TimeDuration"
           },
           {
-            "line": 10380,
+            "line": 10406,
             "name": "duration",
             "type": "TimeDuration"
           }
@@ -6746,32 +6746,32 @@
       {
         "fields": [
           {
-            "line": 10298,
+            "line": 10324,
             "name": "category",
             "type": "GameId"
           },
           {
-            "line": 10294,
+            "line": 10320,
             "name": "changed",
             "type": "boolean"
           },
           {
-            "line": 10295,
+            "line": 10321,
             "name": "forgotten_count",
             "type": "integer"
           },
           {
-            "line": 10297,
+            "line": 10323,
             "name": "known_after",
             "type": "integer"
           },
           {
-            "line": 10296,
+            "line": 10322,
             "name": "known_before",
             "type": "integer"
           },
           {
-            "line": 10299,
+            "line": 10325,
             "name": "subcategory",
             "type": "string"
           }
@@ -6804,307 +6804,307 @@
       {
         "fields": [
           {
-            "line": 8215,
+            "line": 8241,
             "name": "achievements",
             "type": "CcbPlatformAchievementsApi"
           },
           {
-            "line": 8216,
+            "line": 8242,
             "name": "activities",
             "type": "CcbPlatformActivitiesApi"
           },
           {
-            "line": 8217,
+            "line": 8243,
             "name": "addictions",
             "type": "CcbAddictionsApi"
           },
           {
-            "line": 8218,
+            "line": 8244,
             "name": "bionics",
             "type": "CcbPlatformBionicsApi"
           },
           {
-            "line": 8219,
+            "line": 8245,
             "name": "camps",
             "type": "CcbCampsApi"
           },
           {
-            "line": 8220,
+            "line": 8246,
             "name": "characters",
             "type": "CcbCharactersApi"
           },
           {
-            "line": 8221,
+            "line": 8247,
             "name": "constants",
             "type": "CcbConstantsApi"
           },
           {
-            "line": 8222,
+            "line": 8248,
             "name": "coords",
             "type": "CcbCoordsApi"
           },
           {
-            "line": 8223,
+            "line": 8249,
             "name": "crafting",
             "type": "CcbCraftingApi"
           },
           {
-            "line": 8224,
+            "line": 8250,
             "name": "creatures",
             "type": "CcbCreaturesApi"
           },
           {
-            "line": 8225,
+            "line": 8251,
             "name": "effects",
             "type": "CcbEffectsApi"
           },
           {
-            "line": 8226,
+            "line": 8252,
             "name": "enums",
             "type": "CcbEnumsApi"
           },
           {
-            "line": 8270,
+            "line": 8296,
             "name": "equipment",
             "type": "CcbEquipmentApi"
           },
           {
-            "line": 8227,
+            "line": 8253,
             "name": "factions",
             "type": "CcbFactionsApi"
           },
           {
-            "line": 8228,
+            "line": 8254,
             "name": "followers",
             "type": "CcbFollowersApi"
           },
           {
-            "line": 8269,
+            "line": 8295,
             "name": "gameplay",
             "type": "CcbPlatformGameplayApi"
           },
           {
-            "line": 8229,
+            "line": 8255,
             "name": "handles",
             "type": "CcbHandlesApi"
           },
           {
-            "line": 8231,
+            "line": 8257,
             "name": "hordes",
             "type": "CcbHordesApi"
           },
           {
-            "line": 8230,
+            "line": 8256,
             "name": "interaction",
             "type": "CcbPlatformInteractionApi"
           },
           {
-            "line": 8232,
+            "line": 8258,
             "name": "inventory",
             "type": "CcbPlatformInventoryApi"
           },
           {
-            "line": 8234,
+            "line": 8260,
             "name": "item_categories",
             "type": "CcbItemCategoriesApi"
           },
           {
-            "line": 8233,
+            "line": 8259,
             "name": "items",
             "type": "CcbItemsApi"
           },
           {
-            "line": 8210,
+            "line": 8236,
             "name": "lore",
             "type": "CcbPlatformLoreApi"
           },
           {
-            "line": 8240,
+            "line": 8266,
             "name": "map",
             "type": "CcbMapApi"
           },
           {
-            "line": 8239,
+            "line": 8265,
             "name": "mapgen",
             "type": "CcbMapgenApi"
           },
           {
-            "line": 8235,
+            "line": 8261,
             "name": "martial_arts",
             "type": "CcbPlatformMartialArtsApi"
           },
           {
-            "line": 8236,
+            "line": 8262,
             "name": "messages",
             "type": "CcbPlatformMessagesApi"
           },
           {
-            "line": 8237,
+            "line": 8263,
             "name": "missions",
             "type": "CcbMissionsApi"
           },
           {
-            "line": 8238,
+            "line": 8264,
             "name": "morale",
             "type": "CcbPlatformMoraleApi"
           },
           {
-            "line": 8241,
+            "line": 8267,
             "name": "mutations",
             "type": "CcbMutationsApi"
           },
           {
-            "line": 8211,
+            "line": 8237,
             "name": "native_events",
             "type": "CcbPlatformNativeEventsApi"
           },
           {
-            "line": 8242,
+            "line": 8268,
             "name": "needs",
             "type": "CcbNeedsApi"
           },
           {
-            "line": 8243,
+            "line": 8269,
             "name": "npcs",
             "type": "CcbNpcsApi"
           },
           {
-            "line": 8244,
+            "line": 8270,
             "name": "overmap",
             "type": "CcbOvermapApi"
           },
           {
-            "line": 8245,
+            "line": 8271,
             "name": "proficiencies",
             "type": "CcbProficienciesApi"
           },
           {
-            "line": 8246,
+            "line": 8272,
             "name": "random",
             "type": "CcbPlatformRandomApi"
           },
           {
-            "line": 8247,
+            "line": 8273,
             "name": "recipes",
             "type": "CcbPlatformRecipesApi"
           },
           {
-            "line": 8250,
+            "line": 8276,
             "name": "registry",
             "type": "CcbRegistryApi"
           },
           {
-            "line": 8248,
+            "line": 8274,
             "name": "relocation",
             "type": "CcbRelocationApi"
           },
           {
-            "line": 8249,
+            "line": 8275,
             "name": "requirements",
             "type": "CcbRequirementsApi"
           },
           {
-            "line": 8251,
+            "line": 8277,
             "name": "serde",
             "type": "CcbSerdeApi"
           },
           {
-            "line": 8252,
+            "line": 8278,
             "name": "skills",
             "type": "CcbSkillsApi"
           },
           {
-            "line": 8212,
+            "line": 8238,
             "name": "snippets",
             "type": "CcbPlatformSnippetsApi"
           },
           {
-            "line": 8253,
+            "line": 8279,
             "name": "sound",
             "type": "CcbPlatformSoundApi"
           },
           {
-            "line": 8254,
+            "line": 8280,
             "name": "spawns",
             "type": "CcbSpawnsApi"
           },
           {
-            "line": 8255,
+            "line": 8281,
             "name": "spells",
             "type": "CcbSpellsApi"
           },
           {
-            "line": 8256,
+            "line": 8282,
             "name": "statistics",
             "type": "CcbStatisticsApi"
           },
           {
-            "line": 8257,
+            "line": 8283,
             "name": "targeting",
             "type": "CcbTargetingApi"
           },
           {
-            "line": 8213,
+            "line": 8239,
             "name": "text",
             "type": "CcbPlatformTextApi"
           },
           {
-            "line": 8214,
+            "line": 8240,
             "name": "tileset",
             "type": "CcbPlatformTilesetApi"
           },
           {
-            "line": 8258,
+            "line": 8284,
             "name": "time",
             "type": "CcbTimeApi"
           },
           {
-            "line": 8259,
+            "line": 8285,
             "name": "trade",
             "type": "CcbTradeApi"
           },
           {
-            "line": 8260,
+            "line": 8286,
             "name": "types",
             "type": "CcbTypesApi"
           },
           {
-            "line": 8261,
+            "line": 8287,
             "name": "units",
             "type": "CcbUnitsApi"
           },
           {
-            "line": 8262,
+            "line": 8288,
             "name": "variables",
             "type": "CcbVariablesApi"
           },
           {
-            "line": 8263,
+            "line": 8289,
             "name": "vehicles",
             "type": "CcbVehiclesApi"
           },
           {
-            "line": 8264,
+            "line": 8290,
             "name": "vitamins",
             "type": "CcbVitaminsApi"
           },
           {
-            "line": 8265,
+            "line": 8291,
             "name": "weather",
             "type": "CcbWeatherApi"
           },
           {
-            "line": 8267,
+            "line": 8293,
             "name": "world",
             "type": "CcbWorldApi"
           },
           {
-            "line": 8266,
+            "line": 8292,
             "name": "wounds",
             "type": "CcbPlatformWoundsApi"
           },
           {
-            "line": 8268,
+            "line": 8294,
             "name": "zones",
             "type": "CcbZonesApi"
           }
@@ -7377,47 +7377,47 @@
       {
         "fields": [
           {
-            "line": 10708,
+            "line": 10734,
             "name": "ModDefinition",
             "type": "fun(options:"
           },
           {
-            "line": 10709,
+            "line": 10735,
             "name": "content",
             "type": "CcbPlatformContent"
           },
           {
-            "line": 10711,
+            "line": 10737,
             "name": "dialogue",
             "type": "CcbPlatformDialogueApi"
           },
           {
-            "line": 10707,
+            "line": 10733,
             "name": "platform_version",
             "type": "1"
           },
           {
-            "line": 10714,
+            "line": 10740,
             "name": "presentation",
             "type": "CcbPlatformPresentation"
           },
           {
-            "line": 10710,
+            "line": 10736,
             "name": "runtime",
             "type": "CcbPlatformRuntime"
           },
           {
-            "line": 10715,
+            "line": 10741,
             "name": "services",
             "type": "CcbPlatformServices"
           },
           {
-            "line": 10712,
+            "line": 10738,
             "name": "state",
             "type": "CcbPlatformState"
           },
           {
-            "line": 10713,
+            "line": 10739,
             "name": "tasks",
             "type": "CcbPlatformTasks"
           }
@@ -7427,17 +7427,17 @@
       {
         "fields": [
           {
-            "line": 9844,
+            "line": 9870,
             "name": "after",
             "type": "CcbPlatformWoundSnapshot[]"
           },
           {
-            "line": 9843,
+            "line": 9869,
             "name": "before",
             "type": "CcbPlatformWoundSnapshot[]"
           },
           {
-            "line": 9842,
+            "line": 9868,
             "name": "changed",
             "type": "boolean"
           }
@@ -7447,32 +7447,32 @@
       {
         "fields": [
           {
-            "line": 9835,
+            "line": 9861,
             "name": "base_pain",
             "type": "integer"
           },
           {
-            "line": 9836,
+            "line": 9862,
             "name": "current_pain",
             "type": "integer"
           },
           {
-            "line": 9839,
+            "line": 9865,
             "name": "healing_fraction",
             "type": "number"
           },
           {
-            "line": 9838,
+            "line": 9864,
             "name": "healing_progress",
             "type": "TimeDuration"
           },
           {
-            "line": 9837,
+            "line": 9863,
             "name": "healing_time",
             "type": "TimeDuration"
           },
           {
-            "line": 9834,
+            "line": 9860,
             "name": "id",
             "type": "GameId"
           }
@@ -7486,37 +7486,37 @@
       {
         "fields": [
           {
-            "line": 10215,
+            "line": 10241,
             "name": "batch",
             "type": "integer"
           },
           {
-            "line": 10214,
+            "line": 10240,
             "name": "has_more",
             "type": "boolean"
           },
           {
-            "line": 10209,
+            "line": 10235,
             "name": "items",
             "type": "table"
           },
           {
-            "line": 10212,
+            "line": 10238,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 10211,
+            "line": 10237,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 10213,
+            "line": 10239,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 10210,
+            "line": 10236,
             "name": "total",
             "type": "integer"
           }
@@ -7526,47 +7526,47 @@
       {
         "fields": [
           {
-            "line": 10200,
+            "line": 10226,
             "name": "batch",
             "type": "integer"
           },
           {
-            "line": 10203,
+            "line": 10229,
             "name": "craftable",
             "type": "boolean"
           },
           {
-            "line": 10206,
+            "line": 10232,
             "name": "flag",
             "type": "string"
           },
           {
-            "line": 10201,
+            "line": 10227,
             "name": "include_obsolete",
             "type": "boolean"
           },
           {
-            "line": 10202,
+            "line": 10228,
             "name": "known",
             "type": "boolean"
           },
           {
-            "line": 10199,
+            "line": 10225,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 10198,
+            "line": 10224,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 10205,
+            "line": 10231,
             "name": "result",
             "type": "GameId"
           },
           {
-            "line": 10204,
+            "line": 10230,
             "name": "skill",
             "type": "GameId"
           }
@@ -7584,7 +7584,7 @@
       {
         "fields": [
           {
-            "line": 7487,
+            "line": 7513,
             "name": "strict",
             "type": "true"
           }
@@ -7594,12 +7594,12 @@
       {
         "fields": [
           {
-            "line": 7498,
+            "line": 7524,
             "name": "error",
             "type": "CcbPlatformResultError"
           },
           {
-            "line": 7497,
+            "line": 7523,
             "name": "value",
             "type": "CcbRelocationMoveValue"
           }
@@ -7609,27 +7609,27 @@
       {
         "fields": [
           {
-            "line": 7490,
+            "line": 7516,
             "name": "changed",
             "type": "boolean"
           },
           {
-            "line": 7492,
+            "line": 7518,
             "name": "handle",
             "type": "GameHandle"
           },
           {
-            "line": 7494,
+            "line": 7520,
             "name": "overmap_terrain",
             "type": "TripointCoord"
           },
           {
-            "line": 7493,
+            "line": 7519,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 7491,
+            "line": 7517,
             "name": "scope",
             "type": "'monster'|'avatar'|'npc'|'vehicle'"
           }
@@ -7639,17 +7639,17 @@
       {
         "fields": [
           {
-            "line": 10220,
+            "line": 10246,
             "name": "batch",
             "type": "integer"
           },
           {
-            "line": 10219,
+            "line": 10245,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 10218,
+            "line": 10244,
             "name": "offset",
             "type": "integer"
           }
@@ -7687,172 +7687,247 @@
       {
         "fields": [
           {
-            "line": 10353,
-            "name": "area",
-            "type": "string"
+            "line": 7419,
+            "name": "accepted",
+            "type": "boolean"
           },
           {
-            "line": 10355,
-            "name": "attack_vectors",
-            "type": "CcbTechniqueIdPage"
+            "line": 7421,
+            "name": "attack_vector",
+            "type": "GameId"
           },
           {
-            "line": 10328,
-            "name": "avatar_message",
-            "type": "string"
+            "line": 7423,
+            "name": "attacker",
+            "type": "GameHandle"
           },
           {
-            "line": 10338,
+            "line": 7422,
+            "name": "contact_area",
+            "type": "GameId"
+          },
+          {
+            "line": 7418,
+            "name": "found",
+            "type": "boolean"
+          },
+          {
+            "line": 7424,
+            "name": "target",
+            "type": "GameHandle"
+          },
+          {
+            "line": 7420,
+            "name": "technique",
+            "type": "GameId"
+          }
+        ],
+        "name": "CcbTechniqueChoice"
+      },
+      {
+        "fields": [
+          {
+            "line": 7415,
+            "name": "blacklist",
+            "type": "(string|GameId)[]"
+          },
+          {
+            "line": 7414,
             "name": "block_counter",
             "type": "boolean"
           },
           {
-            "line": 10334,
-            "name": "critical_compatible",
+            "line": 7412,
+            "name": "critical",
             "type": "boolean"
           },
           {
-            "line": 10333,
-            "name": "critical_only",
+            "line": 7413,
+            "name": "dodge_counter",
             "type": "boolean"
-          },
+          }
+        ],
+        "name": "CcbTechniqueChoiceOptions"
+      },
+      {
+        "fields": [
           {
-            "line": 10330,
-            "name": "defensive",
-            "type": "boolean"
-          },
+            "line": 7427,
+            "name": "value",
+            "type": "CcbTechniqueChoice|nil"
+          }
+        ],
+        "name": "CcbTechniqueChoiceResult"
+      },
+      {
+        "fields": [
           {
-            "line": 10325,
-            "name": "description",
+            "line": 10379,
+            "name": "area",
             "type": "string"
           },
           {
-            "line": 10341,
-            "name": "disarms",
-            "type": "boolean"
-          },
-          {
-            "line": 10337,
-            "name": "dodge_counter",
-            "type": "boolean"
-          },
-          {
-            "line": 10348,
-            "name": "down_duration",
-            "type": "integer"
-          },
-          {
-            "line": 10332,
-            "name": "dummy",
-            "type": "boolean"
-          },
-          {
-            "line": 10356,
-            "name": "eocs",
+            "line": 10381,
+            "name": "attack_vectors",
             "type": "CcbTechniqueIdPage"
           },
           {
             "line": 10354,
-            "name": "flags",
-            "type": "CcbTechniqueFlagPage"
-          },
-          {
-            "line": 10326,
-            "name": "flavor_description",
+            "name": "avatar_message",
             "type": "string"
           },
           {
-            "line": 10327,
-            "name": "goal",
-            "type": "string"
-          },
-          {
-            "line": 10340,
-            "name": "grab_break",
+            "line": 10364,
+            "name": "block_counter",
             "type": "boolean"
           },
           {
-            "line": 10323,
-            "name": "id",
-            "type": "GameId"
+            "line": 10360,
+            "name": "critical_compatible",
+            "type": "boolean"
           },
           {
-            "line": 10350,
-            "name": "knockback_distance",
-            "type": "integer"
+            "line": 10359,
+            "name": "critical_only",
+            "type": "boolean"
           },
           {
-            "line": 10352,
-            "name": "knockback_follow",
+            "line": 10356,
+            "name": "defensive",
             "type": "boolean"
           },
           {
             "line": 10351,
-            "name": "knockback_spread",
-            "type": "number"
-          },
-          {
-            "line": 10339,
-            "name": "miss_recovery",
-            "type": "boolean"
-          },
-          {
-            "line": 10324,
-            "name": "name",
+            "name": "description",
             "type": "string"
           },
           {
-            "line": 10343,
-            "name": "needs_ammo",
+            "line": 10367,
+            "name": "disarms",
             "type": "boolean"
           },
           {
-            "line": 10329,
-            "name": "npc_message",
+            "line": 10363,
+            "name": "dodge_counter",
+            "type": "boolean"
+          },
+          {
+            "line": 10374,
+            "name": "down_duration",
+            "type": "integer"
+          },
+          {
+            "line": 10358,
+            "name": "dummy",
+            "type": "boolean"
+          },
+          {
+            "line": 10382,
+            "name": "eocs",
+            "type": "CcbTechniqueIdPage"
+          },
+          {
+            "line": 10380,
+            "name": "flags",
+            "type": "CcbTechniqueFlagPage"
+          },
+          {
+            "line": 10352,
+            "name": "flavor_description",
             "type": "string"
           },
           {
-            "line": 10336,
-            "name": "reach_compatible",
-            "type": "boolean"
+            "line": 10353,
+            "name": "goal",
+            "type": "string"
           },
           {
-            "line": 10335,
-            "name": "reach_only",
-            "type": "boolean"
-          },
-          {
-            "line": 10347,
-            "name": "repeat_max",
-            "type": "integer"
-          },
-          {
-            "line": 10346,
-            "name": "repeat_min",
-            "type": "integer"
-          },
-          {
-            "line": 10331,
-            "name": "side_switch",
+            "line": 10366,
+            "name": "grab_break",
             "type": "boolean"
           },
           {
             "line": 10349,
+            "name": "id",
+            "type": "GameId"
+          },
+          {
+            "line": 10376,
+            "name": "knockback_distance",
+            "type": "integer"
+          },
+          {
+            "line": 10378,
+            "name": "knockback_follow",
+            "type": "boolean"
+          },
+          {
+            "line": 10377,
+            "name": "knockback_spread",
+            "type": "number"
+          },
+          {
+            "line": 10365,
+            "name": "miss_recovery",
+            "type": "boolean"
+          },
+          {
+            "line": 10350,
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "line": 10369,
+            "name": "needs_ammo",
+            "type": "boolean"
+          },
+          {
+            "line": 10355,
+            "name": "npc_message",
+            "type": "string"
+          },
+          {
+            "line": 10362,
+            "name": "reach_compatible",
+            "type": "boolean"
+          },
+          {
+            "line": 10361,
+            "name": "reach_only",
+            "type": "boolean"
+          },
+          {
+            "line": 10373,
+            "name": "repeat_max",
+            "type": "integer"
+          },
+          {
+            "line": 10372,
+            "name": "repeat_min",
+            "type": "integer"
+          },
+          {
+            "line": 10357,
+            "name": "side_switch",
+            "type": "boolean"
+          },
+          {
+            "line": 10375,
             "name": "stun_duration",
             "type": "integer"
           },
           {
-            "line": 10342,
+            "line": 10368,
             "name": "take_weapon",
             "type": "boolean"
           },
           {
-            "line": 10344,
+            "line": 10370,
             "name": "wall_adjacent",
             "type": "boolean"
           },
           {
-            "line": 10345,
+            "line": 10371,
             "name": "weight",
             "type": "integer"
           }
@@ -7862,22 +7937,22 @@
       {
         "fields": [
           {
-            "line": 10317,
+            "line": 10343,
             "name": "items",
             "type": "string[]"
           },
           {
-            "line": 10319,
+            "line": 10345,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 10318,
+            "line": 10344,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 10320,
+            "line": 10346,
             "name": "truncated",
             "type": "boolean"
           }
@@ -7887,22 +7962,22 @@
       {
         "fields": [
           {
-            "line": 10311,
+            "line": 10337,
             "name": "items",
             "type": "GameId[]"
           },
           {
-            "line": 10313,
+            "line": 10339,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 10312,
+            "line": 10338,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 10314,
+            "line": 10340,
             "name": "truncated",
             "type": "boolean"
           }
@@ -7912,22 +7987,22 @@
       {
         "fields": [
           {
-            "line": 10602,
+            "line": 10628,
             "name": "season_id",
             "type": "string"
           },
           {
-            "line": 10603,
+            "line": 10629,
             "name": "season_name",
             "type": "string"
           },
           {
-            "line": 10600,
+            "line": 10626,
             "name": "turn",
             "type": "integer"
           },
           {
-            "line": 10601,
+            "line": 10627,
             "name": "year",
             "type": "integer"
           }
@@ -7941,7 +8016,7 @@
       {
         "fields": [
           {
-            "line": 9694,
+            "line": 9720,
             "name": "code",
             "type": "CcbTradeCommitErrorCode"
           }
@@ -7951,27 +8026,27 @@
       {
         "fields": [
           {
-            "line": 9697,
+            "line": 9723,
             "name": "direction",
             "type": "'seller_to_buyer'|'buyer_to_seller'"
           },
           {
-            "line": 9698,
+            "line": 9724,
             "name": "item_uid",
             "type": "integer"
           },
           {
-            "line": 9700,
+            "line": 9726,
             "name": "quantity",
             "type": "integer"
           },
           {
-            "line": 9701,
+            "line": 9727,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 9699,
+            "line": 9725,
             "name": "transferred_item_uid",
             "type": "integer"
           }
@@ -7981,12 +8056,12 @@
       {
         "fields": [
           {
-            "line": 9723,
+            "line": 9749,
             "name": "error",
             "type": "CcbTradeCommitError"
           },
           {
-            "line": 9722,
+            "line": 9748,
             "name": "value",
             "type": "CcbTradeCommitValue"
           }
@@ -7996,82 +8071,82 @@
       {
         "fields": [
           {
-            "line": 9717,
+            "line": 9743,
             "name": "buyer_cash_after",
             "type": "integer"
           },
           {
-            "line": 9715,
+            "line": 9741,
             "name": "buyer_cash_before",
             "type": "integer"
           },
           {
-            "line": 9707,
+            "line": 9733,
             "name": "commit_generation",
             "type": "integer"
           },
           {
-            "line": 9704,
+            "line": 9730,
             "name": "committed",
             "type": "true"
           },
           {
-            "line": 9705,
+            "line": 9731,
             "name": "consumed",
             "type": "true"
           },
           {
-            "line": 9709,
+            "line": 9735,
             "name": "currency",
             "type": "'cash'"
           },
           {
-            "line": 9712,
+            "line": 9738,
             "name": "debt_after",
             "type": "integer"
           },
           {
-            "line": 9711,
+            "line": 9737,
             "name": "debt_before",
             "type": "integer"
           },
           {
-            "line": 9719,
+            "line": 9745,
             "name": "lines",
             "type": "CcbTradeCommitLineResult[]"
           },
           {
-            "line": 9706,
+            "line": 9732,
             "name": "quote_id",
             "type": "integer"
           },
           {
-            "line": 9718,
+            "line": 9744,
             "name": "seller_cash_after",
             "type": "integer"
           },
           {
-            "line": 9716,
+            "line": 9742,
             "name": "seller_cash_before",
             "type": "integer"
           },
           {
-            "line": 9710,
+            "line": 9736,
             "name": "settlement_amount",
             "type": "integer"
           },
           {
-            "line": 9708,
+            "line": 9734,
             "name": "settlement_strategy",
             "type": "CcbTradeCommitSettlementStrategy"
           },
           {
-            "line": 9714,
+            "line": 9740,
             "name": "sold_after",
             "type": "integer"
           },
           {
-            "line": 9713,
+            "line": 9739,
             "name": "sold_before",
             "type": "integer"
           }
@@ -8081,12 +8156,12 @@
       {
         "fields": [
           {
-            "line": 9575,
+            "line": 9601,
             "name": "currency",
             "type": "'cash'"
           },
           {
-            "line": 9574,
+            "line": 9600,
             "name": "strategy",
             "type": "'npc_debt'"
           }
@@ -8096,17 +8171,17 @@
       {
         "fields": [
           {
-            "line": 9583,
+            "line": 9609,
             "name": "character",
             "type": "GameHandle"
           },
           {
-            "line": 9582,
+            "line": 9608,
             "name": "kind",
             "type": "'character'"
           },
           {
-            "line": 9584,
+            "line": 9610,
             "name": "slot",
             "type": "'inventory'|'worn'|'wielded'"
           }
@@ -8116,12 +8191,12 @@
       {
         "fields": [
           {
-            "line": 9587,
+            "line": 9613,
             "name": "locator",
             "type": "table<string,"
           },
           {
-            "line": 9588,
+            "line": 9614,
             "name": "mutation_generation",
             "type": "integer"
           }
@@ -8131,27 +8206,27 @@
       {
         "fields": [
           {
-            "line": 9595,
+            "line": 9621,
             "name": "destination_holder",
             "type": "CcbTradeQuoteHolder"
           },
           {
-            "line": 9591,
+            "line": 9617,
             "name": "direction",
             "type": "'seller_to_buyer'|'buyer_to_seller'"
           },
           {
-            "line": 9592,
+            "line": 9618,
             "name": "item",
             "type": "GameHandle"
           },
           {
-            "line": 9593,
+            "line": 9619,
             "name": "quantity",
             "type": "integer"
           },
           {
-            "line": 9594,
+            "line": 9620,
             "name": "source_holder",
             "type": "CcbTradeQuoteHolder"
           }
@@ -8161,77 +8236,77 @@
       {
         "fields": [
           {
-            "line": 9615,
+            "line": 9641,
             "name": "accepted",
             "type": "boolean"
           },
           {
-            "line": 9607,
+            "line": 9633,
             "name": "charges_at_quote",
             "type": "integer"
           },
           {
-            "line": 9609,
+            "line": 9635,
             "name": "destination_holder",
             "type": "CcbTradeQuoteHolderSnapshot"
           },
           {
-            "line": 9611,
+            "line": 9637,
             "name": "destination_holder_mutation_generation",
             "type": "integer"
           },
           {
-            "line": 9602,
+            "line": 9628,
             "name": "direction",
             "type": "'seller_to_buyer'|'buyer_to_seller'"
           },
           {
-            "line": 9603,
+            "line": 9629,
             "name": "item",
             "type": "GameHandle"
           },
           {
-            "line": 9605,
+            "line": 9631,
             "name": "item_identity_generation",
             "type": "integer"
           },
           {
-            "line": 9604,
+            "line": 9630,
             "name": "item_uid",
             "type": "integer"
           },
           {
-            "line": 9606,
+            "line": 9632,
             "name": "quantity",
             "type": "integer"
           },
           {
-            "line": 9616,
+            "line": 9642,
             "name": "rejection_reason",
             "type": "string"
           },
           {
-            "line": 9608,
+            "line": 9634,
             "name": "source_holder",
             "type": "CcbTradeQuoteHolderSnapshot"
           },
           {
-            "line": 9610,
+            "line": 9636,
             "name": "source_holder_mutation_generation",
             "type": "integer"
           },
           {
-            "line": 9614,
+            "line": 9640,
             "name": "tax",
             "type": "integer"
           },
           {
-            "line": 9613,
+            "line": 9639,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 9612,
+            "line": 9638,
             "name": "unit_price",
             "type": "integer"
           }
@@ -8241,12 +8316,12 @@
       {
         "fields": [
           {
-            "line": 9599,
+            "line": 9625,
             "name": "expiry_turns",
             "type": "integer"
           },
           {
-            "line": 9598,
+            "line": 9624,
             "name": "settlement",
             "type": "CcbTradeQuoteSettlement"
           }
@@ -8256,12 +8331,12 @@
       {
         "fields": [
           {
-            "line": 9569,
+            "line": 9595,
             "name": "currency",
             "type": "'cash'"
           },
           {
-            "line": 9568,
+            "line": 9594,
             "name": "strategy",
             "type": "CcbTradeQuoteSettlementStrategy"
           }
@@ -8271,157 +8346,157 @@
       {
         "fields": [
           {
-            "line": 9647,
+            "line": 9673,
             "name": "available_settlement_modes",
             "type": "string[]"
           },
           {
-            "line": 9621,
+            "line": 9647,
             "name": "buyer",
             "type": "GameHandle"
           },
           {
-            "line": 9642,
+            "line": 9668,
             "name": "buyer_cash_before",
             "type": "integer"
           },
           {
-            "line": 9625,
+            "line": 9651,
             "name": "buyer_identity_generation",
             "type": "integer"
           },
           {
-            "line": 9623,
+            "line": 9649,
             "name": "buyer_stable_id",
             "type": "integer"
           },
           {
-            "line": 9634,
+            "line": 9660,
             "name": "buyer_to_seller_total",
             "type": "integer"
           },
           {
-            "line": 9632,
+            "line": 9658,
             "name": "currency",
             "type": "'cash'"
           },
           {
-            "line": 9639,
+            "line": 9665,
             "name": "debt_after",
             "type": "integer|nil"
           },
           {
-            "line": 9638,
+            "line": 9664,
             "name": "debt_before",
             "type": "integer|nil"
           },
           {
-            "line": 9629,
+            "line": 9655,
             "name": "debt_generation",
             "type": "integer"
           },
           {
-            "line": 9646,
+            "line": 9672,
             "name": "expires_turn",
             "type": "integer"
           },
           {
-            "line": 9628,
+            "line": 9654,
             "name": "faction_generation",
             "type": "integer"
           },
           {
-            "line": 9644,
+            "line": 9670,
             "name": "free_exchange",
             "type": "boolean"
           },
           {
-            "line": 9626,
+            "line": 9652,
             "name": "holder_mutation_generation",
             "type": "integer"
           },
           {
-            "line": 9645,
+            "line": 9671,
             "name": "issued_turn",
             "type": "integer"
           },
           {
-            "line": 9648,
+            "line": 9674,
             "name": "lines",
             "type": "CcbTradeQuoteLineSnapshot[]"
           },
           {
-            "line": 9635,
+            "line": 9661,
             "name": "net",
             "type": "integer"
           },
           {
-            "line": 9630,
+            "line": 9656,
             "name": "opinion_generation",
             "type": "integer"
           },
           {
-            "line": 9627,
+            "line": 9653,
             "name": "pricing_generation",
             "type": "integer"
           },
           {
-            "line": 9649,
+            "line": 9675,
             "name": "rejection_reasons",
             "type": "string[]"
           },
           {
-            "line": 9620,
+            "line": 9646,
             "name": "seller",
             "type": "GameHandle"
           },
           {
-            "line": 9643,
+            "line": 9669,
             "name": "seller_cash_before",
             "type": "integer"
           },
           {
-            "line": 9624,
+            "line": 9650,
             "name": "seller_identity_generation",
             "type": "integer"
           },
           {
-            "line": 9622,
+            "line": 9648,
             "name": "seller_stable_id",
             "type": "integer"
           },
           {
-            "line": 9633,
+            "line": 9659,
             "name": "seller_to_buyer_total",
             "type": "integer"
           },
           {
-            "line": 9637,
+            "line": 9663,
             "name": "settlement_amount",
             "type": "integer"
           },
           {
-            "line": 9631,
+            "line": 9657,
             "name": "settlement_strategy",
             "type": "CcbTradeQuoteSettlementStrategy"
           },
           {
-            "line": 9641,
+            "line": 9667,
             "name": "sold_after",
             "type": "integer|nil"
           },
           {
-            "line": 9640,
+            "line": 9666,
             "name": "sold_before",
             "type": "integer|nil"
           },
           {
-            "line": 9636,
+            "line": 9662,
             "name": "tax",
             "type": "integer"
           },
           {
-            "line": 9619,
+            "line": 9645,
             "name": "token",
             "type": "TradeQuoteToken"
           }
@@ -8435,7 +8510,7 @@
       {
         "fields": [
           {
-            "line": 9971,
+            "line": 9997,
             "name": "value",
             "type": "CcbVariableReadValue"
           }
@@ -8445,12 +8520,12 @@
       {
         "fields": [
           {
-            "line": 9967,
+            "line": 9993,
             "name": "exists",
             "type": "boolean"
           },
           {
-            "line": 9968,
+            "line": 9994,
             "name": "value",
             "type": "any"
           }
@@ -8484,37 +8559,37 @@
       {
         "fields": [
           {
-            "line": 8439,
+            "line": 8465,
             "name": "after",
             "type": "CcbVehiclePartSnapshot"
           },
           {
-            "line": 8438,
+            "line": 8464,
             "name": "before",
             "type": "CcbVehiclePartSnapshot"
           },
           {
-            "line": 8437,
+            "line": 8463,
             "name": "changed",
             "type": "boolean"
           },
           {
-            "line": 8441,
+            "line": 8467,
             "name": "part",
             "type": "GameHandle"
           },
           {
-            "line": 8443,
+            "line": 8469,
             "name": "part_error",
             "type": "string"
           },
           {
-            "line": 8442,
+            "line": 8468,
             "name": "part_stale",
             "type": "boolean"
           },
           {
-            "line": 8440,
+            "line": 8466,
             "name": "vehicle",
             "type": "GameHandle"
           }
@@ -8539,7 +8614,7 @@
       {
         "fields": [
           {
-            "line": 8446,
+            "line": 8472,
             "name": "status",
             "type": "\"cancelled\"|\"no_vehicle\"|\"no_value\"|\"no_output\"|\"payment_cancelled\"|\"invalidated\"|\"repairing\"|\"removing\"|\"installing\""
           }
@@ -8549,102 +8624,102 @@
       {
         "fields": [
           {
-            "line": 8402,
+            "line": 8428,
             "name": "ammo",
             "type": "table<string,"
           },
           {
-            "line": 8397,
+            "line": 8423,
             "name": "available",
             "type": "boolean"
           },
           {
-            "line": 8396,
+            "line": 8422,
             "name": "broken",
             "type": "boolean"
           },
           {
-            "line": 8395,
+            "line": 8421,
             "name": "damage_percent",
             "type": "number"
           },
           {
-            "line": 8394,
+            "line": 8420,
             "name": "durability",
             "type": "integer"
           },
           {
-            "line": 8398,
+            "line": 8424,
             "name": "enabled",
             "type": "boolean"
           },
           {
-            "line": 8400,
+            "line": 8426,
             "name": "fake",
             "type": "boolean"
           },
           {
-            "line": 8401,
+            "line": 8427,
             "name": "features",
             "type": "table<string,"
           },
           {
-            "line": 8383,
+            "line": 8409,
             "name": "handle",
             "type": "GameHandle"
           },
           {
-            "line": 8393,
+            "line": 8419,
             "name": "hp",
             "type": "integer"
           },
           {
-            "line": 8387,
+            "line": 8413,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 8386,
+            "line": 8412,
             "name": "index",
             "type": "integer"
           },
           {
-            "line": 8388,
+            "line": 8414,
             "name": "location",
             "type": "GameId"
           },
           {
-            "line": 8390,
+            "line": 8416,
             "name": "mount",
             "type": "table<string,"
           },
           {
-            "line": 8389,
+            "line": 8415,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 8385,
+            "line": 8411,
             "name": "part_uid",
             "type": "integer"
           },
           {
-            "line": 8391,
+            "line": 8417,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 8399,
+            "line": 8425,
             "name": "removed",
             "type": "boolean"
           },
           {
-            "line": 8392,
+            "line": 8418,
             "name": "variant",
             "type": "string"
           },
           {
-            "line": 8384,
+            "line": 8410,
             "name": "vehicle",
             "type": "GameHandle"
           }
@@ -8654,42 +8729,42 @@
       {
         "fields": [
           {
-            "line": 8410,
+            "line": 8436,
             "name": "has_more",
             "type": "boolean"
           },
           {
-            "line": 8411,
+            "line": 8437,
             "name": "include_fake",
             "type": "boolean"
           },
           {
-            "line": 8412,
+            "line": 8438,
             "name": "include_removed",
             "type": "boolean"
           },
           {
-            "line": 8405,
+            "line": 8431,
             "name": "items",
             "type": "CcbVehiclePartSnapshot[]"
           },
           {
-            "line": 8407,
+            "line": 8433,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 8406,
+            "line": 8432,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 8409,
+            "line": 8435,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 8408,
+            "line": 8434,
             "name": "total",
             "type": "integer"
           }
@@ -8699,47 +8774,47 @@
       {
         "fields": [
           {
-            "line": 8416,
+            "line": 8442,
             "name": "display_name",
             "type": "string"
           },
           {
-            "line": 8423,
+            "line": 8449,
             "name": "lift",
             "type": "table<string,"
           },
           {
-            "line": 8422,
+            "line": 8448,
             "name": "motion",
             "type": "table<string,"
           },
           {
-            "line": 8415,
+            "line": 8441,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 8419,
+            "line": 8445,
             "name": "parts",
             "type": "integer"
           },
           {
-            "line": 8418,
+            "line": 8444,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 8417,
+            "line": 8443,
             "name": "prototype",
             "type": "GameId"
           },
           {
-            "line": 8420,
+            "line": 8446,
             "name": "real_parts",
             "type": "integer"
           },
           {
-            "line": 8421,
+            "line": 8447,
             "name": "state",
             "type": "table<string,"
           }
@@ -8749,27 +8824,27 @@
       {
         "fields": [
           {
-            "line": 8427,
+            "line": 8453,
             "name": "fuel_percent",
             "type": "integer"
           },
           {
-            "line": 8429,
+            "line": 8455,
             "name": "merge_wrecks",
             "type": "boolean"
           },
           {
-            "line": 8430,
+            "line": 8456,
             "name": "owner",
             "type": "GameId"
           },
           {
-            "line": 8426,
+            "line": 8452,
             "name": "rotation_degrees",
             "type": "integer"
           },
           {
-            "line": 8428,
+            "line": 8454,
             "name": "status",
             "type": "integer"
           }
@@ -8779,12 +8854,12 @@
       {
         "fields": [
           {
-            "line": 8433,
+            "line": 8459,
             "name": "handle",
             "type": "GameHandle"
           },
           {
-            "line": 8434,
+            "line": 8460,
             "name": "vehicle",
             "type": "CcbVehicleSnapshot"
           }
@@ -8822,72 +8897,72 @@
       {
         "fields": [
           {
-            "line": 7597,
+            "line": 7623,
             "name": "changed",
             "type": "boolean"
           },
           {
-            "line": 7598,
+            "line": 7624,
             "name": "lightning_active",
             "type": "boolean"
           },
           {
-            "line": 7596,
+            "line": 7622,
             "name": "next_update",
             "type": "TimePoint"
           },
           {
-            "line": 7603,
+            "line": 7629,
             "name": "precise",
             "type": "CcbWeatherPointSnapshot"
           },
           {
-            "line": 7592,
+            "line": 7618,
             "name": "temperature",
             "type": "UnitValue"
           },
           {
-            "line": 7593,
+            "line": 7619,
             "name": "temperature_c",
             "type": "number"
           },
           {
-            "line": 7600,
+            "line": 7626,
             "name": "temperature_override",
             "type": "UnitValue"
           },
           {
-            "line": 7591,
+            "line": 7617,
             "name": "type",
             "type": "CcbWeatherTypeSnapshot"
           },
           {
-            "line": 7590,
+            "line": 7616,
             "name": "weather",
             "type": "GameId"
           },
           {
-            "line": 7599,
+            "line": 7625,
             "name": "weather_override",
             "type": "GameId"
           },
           {
-            "line": 7595,
+            "line": 7621,
             "name": "wind_direction_degrees",
             "type": "integer"
           },
           {
-            "line": 7602,
+            "line": 7628,
             "name": "wind_direction_override_degrees",
             "type": "integer"
           },
           {
-            "line": 7594,
+            "line": 7620,
             "name": "wind_speed_mph",
             "type": "integer"
           },
           {
-            "line": 7601,
+            "line": 7627,
             "name": "wind_speed_override_mph",
             "type": "integer"
           }
@@ -8897,27 +8972,27 @@
       {
         "fields": [
           {
-            "line": 7639,
+            "line": 7665,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7637,
+            "line": 7663,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 7640,
+            "line": 7666,
             "name": "respect_override",
             "type": "boolean"
           },
           {
-            "line": 7636,
+            "line": 7662,
             "name": "start",
             "type": "TimePoint"
           },
           {
-            "line": 7638,
+            "line": 7664,
             "name": "step",
             "type": "TimeDuration"
           }
@@ -8927,37 +9002,37 @@
       {
         "fields": [
           {
-            "line": 7643,
+            "line": 7669,
             "name": "items",
             "type": "CcbWeatherPointSnapshot[]"
           },
           {
-            "line": 7645,
+            "line": 7671,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7648,
+            "line": 7674,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 7649,
+            "line": 7675,
             "name": "respected_override",
             "type": "boolean"
           },
           {
-            "line": 7644,
+            "line": 7670,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 7646,
+            "line": 7672,
             "name": "start",
             "type": "TimePoint"
           },
           {
-            "line": 7647,
+            "line": 7673,
             "name": "step",
             "type": "TimeDuration"
           }
@@ -8967,62 +9042,62 @@
       {
         "fields": [
           {
-            "line": 7625,
+            "line": 7651,
             "name": "base_humidity",
             "type": "number"
           },
           {
-            "line": 7626,
+            "line": 7652,
             "name": "base_pressure",
             "type": "number"
           },
           {
-            "line": 7624,
+            "line": 7650,
             "name": "base_temperature_c",
             "type": "number"
           },
           {
-            "line": 7627,
+            "line": 7653,
             "name": "base_wind_mph",
             "type": "number"
           },
           {
-            "line": 7631,
+            "line": 7657,
             "name": "blacklist",
             "type": "CcbWeatherStringPage"
           },
           {
-            "line": 7622,
+            "line": 7648,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 7623,
+            "line": 7649,
             "name": "loaded",
             "type": "boolean"
           },
           {
-            "line": 7630,
+            "line": 7656,
             "name": "seasonal",
             "type": "CcbWeatherSeasonalSnapshot"
           },
           {
-            "line": 7633,
+            "line": 7659,
             "name": "sorted_weather",
             "type": "CcbWeatherTypeIdPage"
           },
           {
-            "line": 7632,
+            "line": 7658,
             "name": "whitelist",
             "type": "CcbWeatherStringPage"
           },
           {
-            "line": 7628,
+            "line": 7654,
             "name": "wind_distribution_peaks",
             "type": "integer"
           },
           {
-            "line": 7629,
+            "line": 7655,
             "name": "wind_season_variation",
             "type": "integer"
           }
@@ -9032,32 +9107,32 @@
       {
         "fields": [
           {
-            "line": 7702,
+            "line": 7728,
             "name": "accepted",
             "type": "boolean"
           },
           {
-            "line": 7699,
+            "line": 7725,
             "name": "duration",
             "type": "TimeDuration"
           },
           {
-            "line": 7700,
+            "line": 7726,
             "name": "expires_at",
             "type": "TimePoint"
           },
           {
-            "line": 7701,
+            "line": 7727,
             "name": "key",
             "type": "string"
           },
           {
-            "line": 7698,
+            "line": 7724,
             "name": "level",
             "type": "integer"
           },
           {
-            "line": 7703,
+            "line": 7729,
             "name": "replaced",
             "type": "boolean"
           }
@@ -9067,72 +9142,72 @@
       {
         "fields": [
           {
-            "line": 7652,
+            "line": 7678,
             "name": "catalog_limit",
             "type": "integer"
           },
           {
-            "line": 7655,
+            "line": 7681,
             "name": "forecast_limit",
             "type": "integer"
           },
           {
-            "line": 7658,
+            "line": 7684,
             "name": "forecast_maximum_horizon",
             "type": "TimeDuration"
           },
           {
-            "line": 7657,
+            "line": 7683,
             "name": "forecast_maximum_step",
             "type": "TimeDuration"
           },
           {
-            "line": 7656,
+            "line": 7682,
             "name": "forecast_minimum_step",
             "type": "TimeDuration"
           },
           {
-            "line": 7653,
+            "line": 7679,
             "name": "maximum_catalog_offset",
             "type": "integer"
           },
           {
-            "line": 7663,
+            "line": 7689,
             "name": "maximum_custom_light_duration",
             "type": "TimeDuration"
           },
           {
-            "line": 7664,
+            "line": 7690,
             "name": "maximum_custom_light_key_bytes",
             "type": "integer"
           },
           {
-            "line": 7662,
+            "line": 7688,
             "name": "maximum_custom_light_level",
             "type": "integer"
           },
           {
-            "line": 7654,
+            "line": 7680,
             "name": "maximum_nested_values",
             "type": "integer"
           },
           {
-            "line": 7665,
+            "line": 7691,
             "name": "maximum_pending_custom_light_events",
             "type": "integer"
           },
           {
-            "line": 7661,
+            "line": 7687,
             "name": "maximum_temperature_kelvin",
             "type": "number"
           },
           {
-            "line": 7660,
+            "line": 7686,
             "name": "maximum_wind_direction_degrees",
             "type": "integer"
           },
           {
-            "line": 7659,
+            "line": 7685,
             "name": "maximum_wind_speed_mph",
             "type": "integer"
           }
@@ -9142,27 +9217,27 @@
       {
         "fields": [
           {
-            "line": 7560,
+            "line": 7586,
             "name": "dangerous",
             "type": "boolean"
           },
           {
-            "line": 7558,
+            "line": 7584,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7557,
+            "line": 7583,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 7559,
+            "line": 7585,
             "name": "query",
             "type": "string"
           },
           {
-            "line": 7561,
+            "line": 7587,
             "name": "rains",
             "type": "boolean"
           }
@@ -9172,32 +9247,32 @@
       {
         "fields": [
           {
-            "line": 7564,
+            "line": 7590,
             "name": "items",
             "type": "CcbWeatherTypeSnapshot[]"
           },
           {
-            "line": 7568,
+            "line": 7594,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7567,
+            "line": 7593,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 7566,
+            "line": 7592,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 7565,
+            "line": 7591,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 7569,
+            "line": 7595,
             "name": "truncated",
             "type": "boolean"
           }
@@ -9207,82 +9282,82 @@
       {
         "fields": [
           {
-            "line": 7572,
+            "line": 7598,
             "name": "at",
             "type": "TimePoint"
           },
           {
-            "line": 7576,
+            "line": 7602,
             "name": "humidity",
             "type": "number"
           },
           {
-            "line": 7586,
+            "line": 7612,
             "name": "is_day",
             "type": "boolean"
           },
           {
-            "line": 7587,
+            "line": 7613,
             "name": "is_night",
             "type": "boolean"
           },
           {
-            "line": 7585,
+            "line": 7611,
             "name": "moonlight",
             "type": "number"
           },
           {
-            "line": 7581,
+            "line": 7607,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 7582,
+            "line": 7608,
             "name": "precipitation_mm_per_hour",
             "type": "number"
           },
           {
-            "line": 7577,
+            "line": 7603,
             "name": "pressure",
             "type": "number"
           },
           {
-            "line": 7584,
+            "line": 7610,
             "name": "sun_irradiance",
             "type": "number"
           },
           {
-            "line": 7583,
+            "line": 7609,
             "name": "sunlight",
             "type": "number"
           },
           {
-            "line": 7574,
+            "line": 7600,
             "name": "temperature",
             "type": "UnitValue"
           },
           {
-            "line": 7575,
+            "line": 7601,
             "name": "temperature_c",
             "type": "number"
           },
           {
-            "line": 7573,
+            "line": 7599,
             "name": "weather",
             "type": "GameId"
           },
           {
-            "line": 7580,
+            "line": 7606,
             "name": "wind_description",
             "type": "string"
           },
           {
-            "line": 7579,
+            "line": 7605,
             "name": "wind_direction_degrees",
             "type": "integer"
           },
           {
-            "line": 7578,
+            "line": 7604,
             "name": "wind_speed_mph",
             "type": "number"
           }
@@ -9292,12 +9367,12 @@
       {
         "fields": [
           {
-            "line": 7613,
+            "line": 7639,
             "name": "humidity_modifier",
             "type": "integer"
           },
           {
-            "line": 7612,
+            "line": 7638,
             "name": "temperature_modifier",
             "type": "integer"
           }
@@ -9307,22 +9382,22 @@
       {
         "fields": [
           {
-            "line": 7618,
+            "line": 7644,
             "name": "autumn",
             "type": "CcbWeatherSeasonModifiers"
           },
           {
-            "line": 7616,
+            "line": 7642,
             "name": "spring",
             "type": "CcbWeatherSeasonModifiers"
           },
           {
-            "line": 7617,
+            "line": 7643,
             "name": "summer",
             "type": "CcbWeatherSeasonModifiers"
           },
           {
-            "line": 7619,
+            "line": 7645,
             "name": "winter",
             "type": "CcbWeatherSeasonModifiers"
           }
@@ -9332,22 +9407,22 @@
       {
         "fields": [
           {
-            "line": 10606,
+            "line": 10632,
             "name": "id",
             "type": "string"
           },
           {
-            "line": 10607,
+            "line": 10633,
             "name": "temperature_c",
             "type": "number"
           },
           {
-            "line": 10609,
+            "line": 10635,
             "name": "wind_direction",
             "type": "number"
           },
           {
-            "line": 10608,
+            "line": 10634,
             "name": "wind_speed",
             "type": "number"
           }
@@ -9357,22 +9432,22 @@
       {
         "fields": [
           {
-            "line": 7526,
+            "line": 7552,
             "name": "items",
             "type": "CcbWeatherSourceSnapshot[]"
           },
           {
-            "line": 7528,
+            "line": 7554,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 7527,
+            "line": 7553,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 7529,
+            "line": 7555,
             "name": "truncated",
             "type": "boolean"
           }
@@ -9382,12 +9457,12 @@
       {
         "fields": [
           {
-            "line": 7523,
+            "line": 7549,
             "name": "mod",
             "type": "string"
           },
           {
-            "line": 7522,
+            "line": 7548,
             "name": "weather",
             "type": "GameId"
           }
@@ -9397,22 +9472,22 @@
       {
         "fields": [
           {
-            "line": 7606,
+            "line": 7632,
             "name": "items",
             "type": "string[]"
           },
           {
-            "line": 7608,
+            "line": 7634,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 7607,
+            "line": 7633,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 7609,
+            "line": 7635,
             "name": "truncated",
             "type": "boolean"
           }
@@ -9422,22 +9497,22 @@
       {
         "fields": [
           {
-            "line": 7516,
+            "line": 7542,
             "name": "items",
             "type": "GameId[]"
           },
           {
-            "line": 7518,
+            "line": 7544,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 7517,
+            "line": 7543,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 7519,
+            "line": 7545,
             "name": "truncated",
             "type": "boolean"
           }
@@ -9447,117 +9522,117 @@
       {
         "fields": [
           {
-            "line": 7543,
+            "line": 7569,
             "name": "dangerous",
             "type": "boolean"
           },
           {
-            "line": 7552,
+            "line": 7578,
             "name": "duration_max",
             "type": "TimeDuration"
           },
           {
-            "line": 7551,
+            "line": 7577,
             "name": "duration_min",
             "type": "TimeDuration"
           },
           {
-            "line": 7532,
+            "line": 7558,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 7539,
+            "line": 7565,
             "name": "light_modifier",
             "type": "integer"
           },
           {
-            "line": 7540,
+            "line": 7566,
             "name": "light_multiplier",
             "type": "number"
           },
           {
-            "line": 7534,
+            "line": 7560,
             "name": "loaded",
             "type": "boolean"
           },
           {
-            "line": 7533,
+            "line": 7559,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 7544,
+            "line": 7570,
             "name": "precipitation",
             "type": "'none'|'very_light'|'light'|'heavy'"
           },
           {
-            "line": 7545,
+            "line": 7571,
             "name": "precipitation_mm_per_hour",
             "type": "number"
           },
           {
-            "line": 7548,
+            "line": 7574,
             "name": "priority",
             "type": "integer"
           },
           {
-            "line": 7546,
+            "line": 7572,
             "name": "rains",
             "type": "boolean"
           },
           {
-            "line": 7537,
+            "line": 7563,
             "name": "ranged_penalty",
             "type": "integer"
           },
           {
-            "line": 7553,
+            "line": 7579,
             "name": "required_weathers",
             "type": "CcbWeatherTypeIdPage"
           },
           {
-            "line": 7538,
+            "line": 7564,
             "name": "sight_penalty",
             "type": "number"
           },
           {
-            "line": 7542,
+            "line": 7568,
             "name": "sound_attenuation",
             "type": "integer"
           },
           {
-            "line": 7550,
+            "line": 7576,
             "name": "sound_category",
             "type": "'silent'|'drizzle'|'rainy'|'rainstorm'|'thunder'|'flurries'|'snowstorm'|'snow'|'portal_storm'|'clear'|'sunny'|'cloudy'"
           },
           {
-            "line": 7554,
+            "line": 7580,
             "name": "sources",
             "type": "CcbWeatherSourcePage"
           },
           {
-            "line": 7541,
+            "line": 7567,
             "name": "sun_multiplier",
             "type": "number"
           },
           {
-            "line": 7536,
+            "line": 7562,
             "name": "sun_symbol",
             "type": "string"
           },
           {
-            "line": 7535,
+            "line": 7561,
             "name": "symbol",
             "type": "string"
           },
           {
-            "line": 7547,
+            "line": 7573,
             "name": "temperature_modifier_c",
             "type": "number"
           },
           {
-            "line": 7549,
+            "line": 7575,
             "name": "tiles_animation",
             "type": "string"
           }
@@ -9567,22 +9642,22 @@
       {
         "fields": [
           {
-            "line": 7695,
+            "line": 7721,
             "name": "clear_direction",
             "type": "boolean"
           },
           {
-            "line": 7694,
+            "line": 7720,
             "name": "clear_speed",
             "type": "boolean"
           },
           {
-            "line": 7693,
+            "line": 7719,
             "name": "direction_degrees",
             "type": "integer"
           },
           {
-            "line": 7692,
+            "line": 7718,
             "name": "speed_mph",
             "type": "integer"
           }
@@ -9592,42 +9667,42 @@
       {
         "fields": [
           {
-            "line": 7826,
+            "line": 7852,
             "name": "enabled",
             "type": "boolean"
           },
           {
-            "line": 7824,
+            "line": 7850,
             "name": "end",
             "type": "TripointCoord"
           },
           {
-            "line": 7822,
+            "line": 7848,
             "name": "faction",
             "type": "GameId"
           },
           {
-            "line": 7825,
+            "line": 7851,
             "name": "invert",
             "type": "boolean"
           },
           {
-            "line": 7827,
+            "line": 7853,
             "name": "kind",
             "type": "'global'|'personal'"
           },
           {
-            "line": 7820,
+            "line": 7846,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 7823,
+            "line": 7849,
             "name": "start",
             "type": "TripointCoord"
           },
           {
-            "line": 7821,
+            "line": 7847,
             "name": "type",
             "type": "GameId"
           }
@@ -9637,32 +9712,32 @@
       {
         "fields": [
           {
-            "line": 7772,
+            "line": 7798,
             "name": "faction",
             "type": "GameId"
           },
           {
-            "line": 7774,
+            "line": 7800,
             "name": "kind",
             "type": "'global'|'personal'|'vehicle'"
           },
           {
-            "line": 7770,
+            "line": 7796,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7769,
+            "line": 7795,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 7771,
+            "line": 7797,
             "name": "query",
             "type": "string"
           },
           {
-            "line": 7773,
+            "line": 7799,
             "name": "type",
             "type": "GameId"
           }
@@ -9672,42 +9747,42 @@
       {
         "fields": [
           {
-            "line": 7811,
+            "line": 7837,
             "name": "faction",
             "type": "GameId"
           },
           {
-            "line": 7817,
+            "line": 7843,
             "name": "has_more",
             "type": "boolean"
           },
           {
-            "line": 7810,
+            "line": 7836,
             "name": "items",
             "type": "CcbZoneSnapshot[]"
           },
           {
-            "line": 7814,
+            "line": 7840,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7813,
+            "line": 7839,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 7812,
+            "line": 7838,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 7816,
+            "line": 7842,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 7815,
+            "line": 7841,
             "name": "total",
             "type": "integer"
           }
@@ -9717,12 +9792,12 @@
       {
         "fields": [
           {
-            "line": 7830,
+            "line": 7856,
             "name": "changed",
             "type": "boolean"
           },
           {
-            "line": 7831,
+            "line": 7857,
             "name": "zone",
             "type": "CcbZoneSnapshot"
           }
@@ -9732,12 +9807,12 @@
       {
         "fields": [
           {
-            "line": 7777,
+            "line": 7803,
             "name": "label",
             "type": "string"
           },
           {
-            "line": 7778,
+            "line": 7804,
             "name": "value",
             "type": "string"
           }
@@ -9747,22 +9822,22 @@
       {
         "fields": [
           {
-            "line": 7781,
+            "line": 7807,
             "name": "items",
             "type": "CcbZoneOptionDescription[]"
           },
           {
-            "line": 7783,
+            "line": 7809,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 7782,
+            "line": 7808,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 7784,
+            "line": 7810,
             "name": "truncated",
             "type": "boolean"
           }
@@ -9772,12 +9847,12 @@
       {
         "fields": [
           {
-            "line": 7834,
+            "line": 7860,
             "name": "removed",
             "type": "boolean"
           },
           {
-            "line": 7835,
+            "line": 7861,
             "name": "zone",
             "type": "CcbZoneSnapshot"
           }
@@ -9787,92 +9862,92 @@
       {
         "fields": [
           {
-            "line": 7799,
+            "line": 7825,
             "name": "center",
             "type": "TripointCoord"
           },
           {
-            "line": 7802,
+            "line": 7828,
             "name": "displayed",
             "type": "boolean"
           },
           {
-            "line": 7805,
+            "line": 7831,
             "name": "enabled",
             "type": "boolean"
           },
           {
-            "line": 7796,
+            "line": 7822,
             "name": "end",
             "type": "TripointCoord"
           },
           {
-            "line": 7794,
+            "line": 7820,
             "name": "faction",
             "type": "GameId"
           },
           {
-            "line": 7806,
+            "line": 7832,
             "name": "has_options",
             "type": "boolean"
           },
           {
-            "line": 7800,
+            "line": 7826,
             "name": "invert",
             "type": "boolean"
           },
           {
-            "line": 7804,
+            "line": 7830,
             "name": "kind",
             "type": "'global'|'personal'|'vehicle'"
           },
           {
-            "line": 7791,
+            "line": 7817,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 7807,
+            "line": 7833,
             "name": "options",
             "type": "CcbZoneOptionPage"
           },
           {
-            "line": 7798,
+            "line": 7824,
             "name": "relative_end",
             "type": "TripointCoord"
           },
           {
-            "line": 7797,
+            "line": 7823,
             "name": "relative_start",
             "type": "TripointCoord"
           },
           {
-            "line": 7795,
+            "line": 7821,
             "name": "start",
             "type": "TripointCoord"
           },
           {
-            "line": 7801,
+            "line": 7827,
             "name": "temporarily_disabled",
             "type": "boolean"
           },
           {
-            "line": 7790,
+            "line": 7816,
             "name": "token",
             "type": "ZoneToken"
           },
           {
-            "line": 7792,
+            "line": 7818,
             "name": "type",
             "type": "GameId"
           },
           {
-            "line": 7793,
+            "line": 7819,
             "name": "type_name",
             "type": "string"
           },
           {
-            "line": 7803,
+            "line": 7829,
             "name": "vehicle",
             "type": "boolean"
           }
@@ -9882,17 +9957,17 @@
       {
         "fields": [
           {
-            "line": 7757,
+            "line": 7783,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7756,
+            "line": 7782,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 7758,
+            "line": 7784,
             "name": "query",
             "type": "string"
           }
@@ -9902,32 +9977,32 @@
       {
         "fields": [
           {
-            "line": 7766,
+            "line": 7792,
             "name": "has_more",
             "type": "boolean"
           },
           {
-            "line": 7761,
+            "line": 7787,
             "name": "items",
             "type": "CcbZoneTypeSnapshot[]"
           },
           {
-            "line": 7763,
+            "line": 7789,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7762,
+            "line": 7788,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 7765,
+            "line": 7791,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 7764,
+            "line": 7790,
             "name": "total",
             "type": "integer"
           }
@@ -9937,12 +10012,12 @@
       {
         "fields": [
           {
-            "line": 7752,
+            "line": 7778,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 7753,
+            "line": 7779,
             "name": "name",
             "type": "string"
           }
@@ -12400,42 +12475,42 @@
       {
         "fields": [
           {
-            "line": 7915,
+            "line": 7941,
             "name": "__tostring",
             "type": "fun(self:"
           },
           {
-            "line": 7913,
+            "line": 7939,
             "name": "identity_generation",
             "type": "integer"
           },
           {
-            "line": 7914,
+            "line": 7940,
             "name": "is_valid",
             "type": "fun(self:"
           },
           {
-            "line": 7909,
+            "line": 7935,
             "name": "monster",
             "type": "GameId"
           },
           {
-            "line": 7912,
+            "line": 7938,
             "name": "owner_generation",
             "type": "integer"
           },
           {
-            "line": 7908,
+            "line": 7934,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 7910,
+            "line": 7936,
             "name": "runtime_generation",
             "type": "integer"
           },
           {
-            "line": 7911,
+            "line": 7937,
             "name": "world_generation",
             "type": "integer"
           }
@@ -12765,42 +12840,42 @@
       {
         "fields": [
           {
-            "line": 7926,
+            "line": 7952,
             "name": "__tostring",
             "type": "fun(self:"
           },
           {
-            "line": 7920,
+            "line": 7946,
             "name": "group",
             "type": "GameId"
           },
           {
-            "line": 7924,
+            "line": 7950,
             "name": "identity_generation",
             "type": "integer"
           },
           {
-            "line": 7925,
+            "line": 7951,
             "name": "is_valid",
             "type": "fun(self:"
           },
           {
-            "line": 7923,
+            "line": 7949,
             "name": "owner_generation",
             "type": "integer"
           },
           {
-            "line": 7919,
+            "line": 7945,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 7921,
+            "line": 7947,
             "name": "runtime_generation",
             "type": "integer"
           },
           {
-            "line": 7922,
+            "line": 7948,
             "name": "world_generation",
             "type": "integer"
           }
@@ -13433,27 +13508,27 @@
       {
         "fields": [
           {
-            "line": 8546,
+            "line": 8572,
             "name": "identity_generation",
             "type": "integer"
           },
           {
-            "line": 8549,
+            "line": 8575,
             "name": "is_valid",
             "type": "fun(self:"
           },
           {
-            "line": 8547,
+            "line": 8573,
             "name": "runtime_generation",
             "type": "integer"
           },
           {
-            "line": 8545,
+            "line": 8571,
             "name": "uid",
             "type": "integer"
           },
           {
-            "line": 8548,
+            "line": 8574,
             "name": "world_generation",
             "type": "integer"
           }
@@ -18170,82 +18245,82 @@
       {
         "fields": [
           {
-            "line": 9554,
+            "line": 9580,
             "name": "buyer_identity_generation",
             "type": "integer"
           },
           {
-            "line": 9552,
+            "line": 9578,
             "name": "buyer_stable_id",
             "type": "integer"
           },
           {
-            "line": 9558,
+            "line": 9584,
             "name": "debt_generation",
             "type": "integer"
           },
           {
-            "line": 9561,
+            "line": 9587,
             "name": "expires_turn",
             "type": "integer"
           },
           {
-            "line": 9557,
+            "line": 9583,
             "name": "faction_generation",
             "type": "integer"
           },
           {
-            "line": 9555,
+            "line": 9581,
             "name": "holder_mutation_generation",
             "type": "integer"
           },
           {
-            "line": 9563,
+            "line": 9589,
             "name": "is_valid",
             "type": "fun(self:"
           },
           {
-            "line": 9560,
+            "line": 9586,
             "name": "issued_turn",
             "type": "integer"
           },
           {
-            "line": 9559,
+            "line": 9585,
             "name": "opinion_generation",
             "type": "integer"
           },
           {
-            "line": 9556,
+            "line": 9582,
             "name": "pricing_generation",
             "type": "integer"
           },
           {
-            "line": 9548,
+            "line": 9574,
             "name": "quote_id",
             "type": "integer"
           },
           {
-            "line": 9562,
+            "line": 9588,
             "name": "registered",
             "type": "boolean"
           },
           {
-            "line": 9549,
+            "line": 9575,
             "name": "runtime_generation",
             "type": "integer"
           },
           {
-            "line": 9553,
+            "line": 9579,
             "name": "seller_identity_generation",
             "type": "integer"
           },
           {
-            "line": 9551,
+            "line": 9577,
             "name": "seller_stable_id",
             "type": "integer"
           },
           {
-            "line": 9550,
+            "line": 9576,
             "name": "world_generation",
             "type": "integer"
           }
@@ -19855,57 +19930,57 @@
       {
         "fields": [
           {
-            "line": 7743,
+            "line": 7769,
             "name": "end",
             "type": "TripointCoord"
           },
           {
-            "line": 7739,
+            "line": 7765,
             "name": "faction",
             "type": "GameId"
           },
           {
-            "line": 7748,
+            "line": 7774,
             "name": "is_valid",
             "type": "fun(self:"
           },
           {
-            "line": 7747,
+            "line": 7773,
             "name": "kind",
             "type": "'global'|'personal'|'vehicle'"
           },
           {
-            "line": 7741,
+            "line": 7767,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 7745,
+            "line": 7771,
             "name": "relative_end",
             "type": "TripointCoord"
           },
           {
-            "line": 7744,
+            "line": 7770,
             "name": "relative_start",
             "type": "TripointCoord"
           },
           {
-            "line": 7742,
+            "line": 7768,
             "name": "start",
             "type": "TripointCoord"
           },
           {
-            "line": 7749,
+            "line": 7775,
             "name": "status",
             "type": "fun(self:"
           },
           {
-            "line": 7740,
+            "line": 7766,
             "name": "type",
             "type": "GameId"
           },
           {
-            "line": 7746,
+            "line": 7772,
             "name": "vehicle",
             "type": "boolean"
           }
@@ -19958,7 +20033,7 @@
         "name": "ZoneTypeDefinitionOptions"
       }
     ],
-    "function_count": 1277,
+    "function_count": 1278,
     "functions": [
       {
         "line": "2713",
@@ -20207,25 +20282,25 @@
         "parameters": "speed, size, butcher, requirement_id"
       },
       {
-        "line": "9946",
+        "line": "9972",
         "name": "grant",
         "owner": "CcbBionicsApi",
         "parameters": "character, bionic"
       },
       {
-        "line": "9940",
+        "line": "9966",
         "name": "has",
         "owner": "CcbBionicsApi",
         "parameters": "character, bionic"
       },
       {
-        "line": "9952",
+        "line": "9978",
         "name": "remove_type",
         "owner": "CcbBionicsApi",
         "parameters": "character, bionic"
       },
       {
-        "line": "9934",
+        "line": "9960",
         "name": "summary",
         "owner": "CcbBionicsApi",
         "parameters": "character"
@@ -20411,229 +20486,235 @@
         "parameters": "camp, manager, owner"
       },
       {
-        "line": "7444",
+        "line": "7470",
         "name": "attack",
         "owner": "CcbCharactersApi",
         "parameters": "attacker, target, technique, options"
       },
       {
-        "line": "7416",
+        "line": "7442",
         "name": "avatar",
         "owner": "CcbCharactersApi",
         "parameters": ""
       },
       {
-        "line": "7421",
+        "line": "7447",
         "name": "body_parts",
         "owner": "CcbCharactersApi",
         "parameters": "character"
       },
       {
-        "line": "7471",
+        "line": "7497",
         "name": "cast_spell",
         "owner": "CcbCharactersApi",
         "parameters": "character, spell, options"
       },
       {
-        "line": "7476",
+        "line": "7437",
+        "name": "choose_technique",
+        "owner": "CcbCharactersApi",
+        "parameters": "attacker, target, options"
+      },
+      {
+        "line": "7502",
         "name": "die",
         "owner": "CcbCharactersApi",
         "parameters": "character, options"
       },
       {
-        "line": "7465",
+        "line": "7491",
         "name": "emit",
         "owner": "CcbCharactersApi",
         "parameters": "character, emission, chance"
       },
       {
-        "line": "7459",
+        "line": "7485",
         "name": "explosion",
         "owner": "CcbCharactersApi",
         "parameters": "character, options"
       },
       {
-        "line": "7454",
+        "line": "7480",
         "name": "knockback",
         "owner": "CcbCharactersApi",
         "parameters": "character, options"
       },
       {
-        "line": "7437",
+        "line": "7463",
         "name": "nearby",
         "owner": "CcbCharactersApi",
         "parameters": "observer, options"
       },
       {
-        "line": "7480",
+        "line": "7506",
         "name": "prevent_death",
         "owner": "CcbCharactersApi",
         "parameters": "character"
       },
       {
-        "line": "7427",
+        "line": "7453",
         "name": "random_body_part",
         "owner": "CcbCharactersApi",
         "parameters": "character, main_parts_only"
       },
       {
-        "line": "7449",
+        "line": "7475",
         "name": "ranged_attack",
         "owner": "CcbCharactersApi",
         "parameters": "attacker, target"
       },
       {
-        "line": "7484",
+        "line": "7510",
         "name": "recalculate_enchantments",
         "owner": "CcbCharactersApi",
         "parameters": "character"
       },
       {
-        "line": "7432",
+        "line": "7458",
         "name": "snapshot",
         "owner": "CcbCharactersApi",
         "parameters": "character, body_part_limit"
       },
       {
-        "line": "10592",
+        "line": "10618",
         "name": "nearby",
         "owner": "CcbCreaturesApi",
         "parameters": "observer, options"
       },
       {
-        "line": "10587",
+        "line": "10613",
         "name": "snapshot",
         "owner": "CcbCreaturesApi",
         "parameters": "handle"
       },
       {
-        "line": "10597",
+        "line": "10623",
         "name": "visible_monsters",
         "owner": "CcbCreaturesApi",
         "parameters": "observer, direction"
       },
       {
-        "line": "10070",
+        "line": "10096",
         "name": "add",
         "owner": "CcbEffectsApi",
         "parameters": "character, effect, duration, options"
       },
       {
-        "line": "10085",
+        "line": "10111",
         "name": "get",
         "owner": "CcbEffectsApi",
         "parameters": "character, effect, body_part"
       },
       {
-        "line": "10078",
+        "line": "10104",
         "name": "has",
         "owner": "CcbEffectsApi",
         "parameters": "character, effect, body_part, intensity"
       },
       {
-        "line": "10092",
+        "line": "10118",
         "name": "remove",
         "owner": "CcbEffectsApi",
         "parameters": "character, effect, body_part"
       },
       {
-        "line": "9190",
+        "line": "9216",
         "name": "unequip",
         "owner": "CcbEquipmentApi",
         "parameters": "actor, item, destination_holder"
       },
       {
-        "line": "9184",
+        "line": "9210",
         "name": "wear",
         "owner": "CcbEquipmentApi",
         "parameters": "actor, item, source_holder, displaced_destination"
       },
       {
-        "line": "9177",
+        "line": "9203",
         "name": "wield",
         "owner": "CcbEquipmentApi",
         "parameters": "actor, item, source_holder, displaced_destination"
       },
       {
-        "line": "8740",
+        "line": "8766",
         "name": "food",
         "owner": "CcbFactionsApi",
         "parameters": "id, options"
       },
       {
-        "line": "8724",
+        "line": "8750",
         "name": "for_character",
         "owner": "CcbFactionsApi",
         "parameters": "character"
       },
       {
-        "line": "8721",
+        "line": "8747",
         "name": "get",
         "owner": "CcbFactionsApi",
         "parameters": "id"
       },
       {
-        "line": "8718",
+        "line": "8744",
         "name": "list",
         "owner": "CcbFactionsApi",
         "parameters": "options"
       },
       {
-        "line": "8728",
+        "line": "8754",
         "name": "members",
         "owner": "CcbFactionsApi",
         "parameters": "id, options"
       },
       {
-        "line": "8760",
+        "line": "8786",
         "name": "modify_food",
         "owner": "CcbFactionsApi",
         "parameters": "id, kcal"
       },
       {
-        "line": "8752",
+        "line": "8778",
         "name": "modify_reputation",
         "owner": "CcbFactionsApi",
         "parameters": "id, deltas"
       },
       {
-        "line": "8756",
+        "line": "8782",
         "name": "modify_resources",
         "owner": "CcbFactionsApi",
         "parameters": "id, deltas"
       },
       {
-        "line": "8736",
+        "line": "8762",
         "name": "relationship",
         "owner": "CcbFactionsApi",
         "parameters": "id, target"
       },
       {
-        "line": "8732",
+        "line": "8758",
         "name": "relationships",
         "owner": "CcbFactionsApi",
         "parameters": "id, options"
       },
       {
-        "line": "8744",
+        "line": "8770",
         "name": "rename",
         "owner": "CcbFactionsApi",
         "parameters": "id, name"
       },
       {
-        "line": "8748",
+        "line": "8774",
         "name": "set_known",
         "owner": "CcbFactionsApi",
         "parameters": "id, known"
       },
       {
-        "line": "8764",
+        "line": "8790",
         "name": "set_policy",
         "owner": "CcbFactionsApi",
         "parameters": "id, options"
       },
       {
-        "line": "8769",
+        "line": "8795",
         "name": "set_relationship",
         "owner": "CcbFactionsApi",
         "parameters": "id, target, options"
@@ -20645,379 +20726,379 @@
         "parameters": ""
       },
       {
-        "line": "8190",
+        "line": "8216",
         "name": "alert_entity",
         "owner": "CcbHordesApi",
         "parameters": "token, destination, intensity"
       },
       {
-        "line": "8157",
+        "line": "8183",
         "name": "contains",
         "owner": "CcbHordesApi",
         "parameters": "group, monster"
       },
       {
-        "line": "8146",
+        "line": "8172",
         "name": "definition",
         "owner": "CcbHordesApi",
         "parameters": "id, options"
       },
       {
-        "line": "8141",
+        "line": "8167",
         "name": "definitions",
         "owner": "CcbHordesApi",
         "parameters": "options"
       },
       {
-        "line": "8162",
+        "line": "8188",
         "name": "entities",
         "owner": "CcbHordesApi",
         "parameters": "center, options"
       },
       {
-        "line": "8166",
+        "line": "8192",
         "name": "entity",
         "owner": "CcbHordesApi",
         "parameters": "token"
       },
       {
-        "line": "8175",
+        "line": "8201",
         "name": "legacy_group",
         "owner": "CcbHordesApi",
         "parameters": "token"
       },
       {
-        "line": "8171",
+        "line": "8197",
         "name": "legacy_groups",
         "owner": "CcbHordesApi",
         "parameters": "center, options"
       },
       {
-        "line": "8137",
+        "line": "8163",
         "name": "limits",
         "owner": "CcbHordesApi",
         "parameters": ""
       },
       {
-        "line": "8152",
+        "line": "8178",
         "name": "monsters",
         "owner": "CcbHordesApi",
         "parameters": "id, recursive, options"
       },
       {
-        "line": "8194",
+        "line": "8220",
         "name": "remove_entity",
         "owner": "CcbHordesApi",
         "parameters": "token"
       },
       {
-        "line": "8207",
+        "line": "8233",
         "name": "remove_legacy_group",
         "owner": "CcbHordesApi",
         "parameters": "token"
       },
       {
-        "line": "8184",
+        "line": "8210",
         "name": "spawn_entity",
         "owner": "CcbHordesApi",
         "parameters": "position, monster"
       },
       {
-        "line": "8198",
+        "line": "8224",
         "name": "spawn_legacy_group",
         "owner": "CcbHordesApi",
         "parameters": "options"
       },
       {
-        "line": "8179",
+        "line": "8205",
         "name": "summary",
         "owner": "CcbHordesApi",
         "parameters": "position"
       },
       {
-        "line": "8203",
+        "line": "8229",
         "name": "update_legacy_group",
         "owner": "CcbHordesApi",
         "parameters": "token, options"
       },
       {
-        "line": "9066",
+        "line": "9092",
         "name": "category_count",
         "owner": "CcbInventoryApi",
         "parameters": "character, category"
       },
       {
-        "line": "9019",
+        "line": "9045",
         "name": "choose",
         "owner": "CcbInventoryApi",
         "parameters": "character, candidates, title"
       },
       {
-        "line": "9024",
+        "line": "9050",
         "name": "choose_many",
         "owner": "CcbInventoryApi",
         "parameters": "character, candidates, title"
       },
       {
-        "line": "9034",
+        "line": "9060",
         "name": "choose_many_map",
         "owner": "CcbInventoryApi",
         "parameters": "character, candidates, options"
       },
       {
-        "line": "9029",
+        "line": "9055",
         "name": "choose_map",
         "owner": "CcbInventoryApi",
         "parameters": "character, candidates, options"
       },
       {
-        "line": "9099",
+        "line": "9125",
         "name": "consume",
         "owner": "CcbInventoryApi",
         "parameters": "character, item_type, count, charges"
       },
       {
-        "line": "9110",
+        "line": "9136",
         "name": "consume_sum",
         "owner": "CcbInventoryApi",
         "parameters": "character, entries"
       },
       {
-        "line": "9088",
+        "line": "9114",
         "name": "give",
         "owner": "CcbInventoryApi",
         "parameters": "character, item_type, quantity, options"
       },
       {
-        "line": "9093",
+        "line": "9119",
         "name": "give_group",
         "owner": "CcbInventoryApi",
         "parameters": "character, group, options"
       },
       {
-        "line": "9106",
+        "line": "9132",
         "name": "hand_in",
         "owner": "CcbInventoryApi",
         "parameters": "character, recipient, item_type, count, charges"
       },
       {
-        "line": "9062",
+        "line": "9088",
         "name": "has_item_flag",
         "owner": "CcbInventoryApi",
         "parameters": "character, flag"
       },
       {
-        "line": "9043",
+        "line": "9069",
         "name": "has_items_sum",
         "owner": "CcbInventoryApi",
         "parameters": "character, entries"
       },
       {
-        "line": "9049",
+        "line": "9075",
         "name": "has_software",
         "owner": "CcbInventoryApi",
         "parameters": "character, software, minimum_charges, device"
       },
       {
-        "line": "9079",
+        "line": "9105",
         "name": "has_stolen_from",
         "owner": "CcbInventoryApi",
         "parameters": "holder, owner"
       },
       {
-        "line": "9054",
+        "line": "9080",
         "name": "has_worn_flag",
         "owner": "CcbInventoryApi",
         "parameters": "character, flag, body_part"
       },
       {
-        "line": "9058",
+        "line": "9084",
         "name": "is_wearing",
         "owner": "CcbInventoryApi",
         "parameters": "character, item_type"
       },
       {
-        "line": "9071",
+        "line": "9097",
         "name": "item_radiation",
         "owner": "CcbInventoryApi",
         "parameters": "character, flag, aggregate"
       },
       {
-        "line": "9039",
+        "line": "9065",
         "name": "resources",
         "owner": "CcbInventoryApi",
         "parameters": "character, item_type, quantity"
       },
       {
-        "line": "9082",
+        "line": "9108",
         "name": "weapon_state",
         "owner": "CcbInventoryApi",
         "parameters": "character"
       },
       {
-        "line": "9075",
+        "line": "9101",
         "name": "wielded_matches",
         "owner": "CcbInventoryApi",
         "parameters": "character, criterion"
       },
       {
-        "line": "8893",
+        "line": "8919",
         "name": "set_spawn_rate",
         "owner": "CcbItemCategoriesApi",
         "parameters": "id, rate"
       },
       {
-        "line": "8897",
+        "line": "8923",
         "name": "set_spawn_rates",
         "owner": "CcbItemCategoriesApi",
         "parameters": "updates"
       },
       {
-        "line": "8888",
+        "line": "8914",
         "name": "spawn_rate",
         "owner": "CcbItemCategoriesApi",
         "parameters": "id"
       },
       {
-        "line": "8979",
+        "line": "9005",
         "name": "activate",
         "owner": "CcbItemsApi",
         "parameters": "item_handle, character_handle, method, options"
       },
       {
-        "line": "8968",
+        "line": "8994",
         "name": "ammo_sufficient",
         "owner": "CcbItemsApi",
         "parameters": "item_handle, character, method, quantity"
       },
       {
-        "line": "9010",
+        "line": "9036",
         "name": "clear_old_owner",
         "owner": "CcbItemsApi",
         "parameters": "item_handle"
       },
       {
-        "line": "9007",
+        "line": "9033",
         "name": "clear_owner",
         "owner": "CcbItemsApi",
         "parameters": "item_handle, remember_previous"
       },
       {
-        "line": "8958",
+        "line": "8984",
         "name": "erase_var",
         "owner": "CcbItemsApi",
         "parameters": "handle, key"
       },
       {
-        "line": "8919",
+        "line": "8945",
         "name": "food_fun",
         "owner": "CcbItemsApi",
         "parameters": "id"
       },
       {
-        "line": "8949",
+        "line": "8975",
         "name": "get_var",
         "owner": "CcbItemsApi",
         "parameters": "handle, key"
       },
       {
-        "line": "8935",
+        "line": "8961",
         "name": "gun_damage",
         "owner": "CcbItemsApi",
         "parameters": "handle, damage_type, with_ammo"
       },
       {
-        "line": "8962",
+        "line": "8988",
         "name": "has_flag",
         "owner": "CcbItemsApi",
         "parameters": "handle, flag"
       },
       {
-        "line": "8993",
+        "line": "9019",
         "name": "has_technique",
         "owner": "CcbItemsApi",
         "parameters": "handle, technique"
       },
       {
-        "line": "8930",
+        "line": "8956",
         "name": "melee_damage",
         "owner": "CcbItemsApi",
         "parameters": "handle, damage_type"
       },
       {
-        "line": "8912",
+        "line": "8938",
         "name": "page",
         "owner": "CcbItemsApi",
         "parameters": "holder, options, continuation"
       },
       {
-        "line": "8922",
+        "line": "8948",
         "name": "possible_from_group",
         "owner": "CcbItemsApi",
         "parameters": "group"
       },
       {
-        "line": "8940",
+        "line": "8966",
         "name": "quality",
         "owner": "CcbItemsApi",
         "parameters": "handle, quality, strict"
       },
       {
-        "line": "8984",
+        "line": "9010",
         "name": "set_fault",
         "owner": "CcbItemsApi",
         "parameters": "handle, fault, options"
       },
       {
-        "line": "8973",
+        "line": "8999",
         "name": "set_flag",
         "owner": "CcbItemsApi",
         "parameters": "handle, flag, enabled"
       },
       {
-        "line": "9003",
+        "line": "9029",
         "name": "set_owner",
         "owner": "CcbItemsApi",
         "parameters": "item_handle, owner, remember_previous"
       },
       {
-        "line": "8989",
+        "line": "9015",
         "name": "set_random_fault",
         "owner": "CcbItemsApi",
         "parameters": "handle, fault_type, options"
       },
       {
-        "line": "8998",
+        "line": "9024",
         "name": "set_technique",
         "owner": "CcbItemsApi",
         "parameters": "handle, technique, enabled"
       },
       {
-        "line": "8954",
+        "line": "8980",
         "name": "set_var",
         "owner": "CcbItemsApi",
         "parameters": "handle, key, value"
       },
       {
-        "line": "8916",
+        "line": "8942",
         "name": "snapshot",
         "owner": "CcbItemsApi",
         "parameters": "handle, relation_limit"
       },
       {
-        "line": "8907",
+        "line": "8933",
         "name": "transfer",
         "owner": "CcbItemsApi",
         "parameters": "item_handle, source_holder, destination_holder, quantity"
       },
       {
-        "line": "8945",
+        "line": "8971",
         "name": "transform",
         "owner": "CcbItemsApi",
         "parameters": "handle, target, options"
       },
       {
-        "line": "8926",
+        "line": "8952",
         "name": "update",
         "owner": "CcbItemsApi",
         "parameters": "handle, updates"
@@ -21047,13 +21128,13 @@
         "parameters": "target, update, options"
       },
       {
-        "line": "8342",
+        "line": "8368",
         "name": "define",
         "owner": "CcbMapgenApi",
         "parameters": "descriptor"
       },
       {
-        "line": "8344",
+        "line": "8370",
         "name": "limits",
         "owner": "CcbMapgenApi",
         "parameters": ""
@@ -21071,7 +21152,7 @@
         "parameters": "handler_id, options"
       },
       {
-        "line": "8347",
+        "line": "8373",
         "name": "register_palette",
         "owner": "CcbMapgenApi",
         "parameters": "descriptor"
@@ -21083,589 +21164,589 @@
         "parameters": "id"
       },
       {
-        "line": "8668",
+        "line": "8694",
         "name": "abandon",
         "owner": "CcbMissionsApi",
         "parameters": "owner, token"
       },
       {
-        "line": "8634",
+        "line": "8660",
         "name": "assign",
         "owner": "CcbMissionsApi",
         "parameters": "owner, token"
       },
       {
-        "line": "8664",
+        "line": "8690",
         "name": "cancel",
         "owner": "CcbMissionsApi",
         "parameters": "token"
       },
       {
-        "line": "8661",
+        "line": "8687",
         "name": "complete",
         "owner": "CcbMissionsApi",
         "parameters": "owner, token, force"
       },
       {
-        "line": "8603",
+        "line": "8629",
         "name": "definition",
         "owner": "CcbMissionsApi",
         "parameters": "id"
       },
       {
-        "line": "8600",
+        "line": "8626",
         "name": "definitions",
         "owner": "CcbMissionsApi",
         "parameters": "options"
       },
       {
-        "line": "8656",
+        "line": "8682",
         "name": "fail",
         "owner": "CcbMissionsApi",
         "parameters": "owner, token"
       },
       {
-        "line": "8610",
+        "line": "8636",
         "name": "get",
         "owner": "CcbMissionsApi",
         "parameters": "token"
       },
       {
-        "line": "8617",
+        "line": "8643",
         "name": "has_active",
         "owner": "CcbMissionsApi",
         "parameters": "owner, id"
       },
       {
-        "line": "8647",
+        "line": "8673",
         "name": "is_complete",
         "owner": "CcbMissionsApi",
         "parameters": "owner, token, npc_id"
       },
       {
-        "line": "8607",
+        "line": "8633",
         "name": "list",
         "owner": "CcbMissionsApi",
         "parameters": "owner, options"
       },
       {
-        "line": "8621",
+        "line": "8647",
         "name": "random_definition",
         "owner": "CcbMissionsApi",
         "parameters": "origin, position"
       },
       {
-        "line": "8625",
+        "line": "8651",
         "name": "reserve",
         "owner": "CcbMissionsApi",
         "parameters": "id, npc_id"
       },
       {
-        "line": "8630",
+        "line": "8656",
         "name": "reserve_random",
         "owner": "CcbMissionsApi",
         "parameters": "origin, position, npc_id"
       },
       {
-        "line": "8642",
+        "line": "8668",
         "name": "select",
         "owner": "CcbMissionsApi",
         "parameters": "owner, token"
       },
       {
-        "line": "8613",
+        "line": "8639",
         "name": "selected",
         "owner": "CcbMissionsApi",
         "parameters": "owner"
       },
       {
-        "line": "8638",
+        "line": "8664",
         "name": "set_deadline",
         "owner": "CcbMissionsApi",
         "parameters": "token, deadline"
       },
       {
-        "line": "8652",
+        "line": "8678",
         "name": "step_complete",
         "owner": "CcbMissionsApi",
         "parameters": "owner, token, step"
       },
       {
-        "line": "9920",
+        "line": "9946",
         "name": "add",
         "owner": "CcbMoraleApi",
         "parameters": "character, morale, bonus, max_bonus, options"
       },
       {
-        "line": "9926",
+        "line": "9952",
         "name": "remove",
         "owner": "CcbMoraleApi",
         "parameters": "character, morale"
       },
       {
-        "line": "10131",
+        "line": "10157",
         "name": "grant",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation, variant"
       },
       {
-        "line": "10101",
+        "line": "10127",
         "name": "has",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation"
       },
       {
-        "line": "10115",
+        "line": "10141",
         "name": "is_purifiable",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation"
       },
       {
-        "line": "10108",
+        "line": "10134",
         "name": "is_visible_to",
         "owner": "CcbMutationsApi",
         "parameters": "observed, observer, mutation"
       },
       {
-        "line": "10160",
+        "line": "10186",
         "name": "mutate_category",
         "owner": "CcbMutationsApi",
         "parameters": "character, category, use_vitamins, true_random"
       },
       {
-        "line": "10138",
+        "line": "10164",
         "name": "remove",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation"
       },
       {
-        "line": "10152",
+        "line": "10178",
         "name": "remove_category",
         "owner": "CcbMutationsApi",
         "parameters": "character, category"
       },
       {
-        "line": "10169",
+        "line": "10195",
         "name": "remove_type",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation_type"
       },
       {
-        "line": "10146",
+        "line": "10172",
         "name": "set_active",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation, active"
       },
       {
-        "line": "10123",
+        "line": "10149",
         "name": "set_purifiable",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation, purifiable"
       },
       {
-        "line": "9383",
+        "line": "9409",
         "name": "finish",
         "owner": "CcbNpcDialogueActionsApi",
         "parameters": "handle"
       },
       {
-        "line": "9386",
+        "line": "9412",
         "name": "provoke_combat",
         "owner": "CcbNpcDialogueActionsApi",
         "parameters": "handle"
       },
       {
-        "line": "9355",
+        "line": "9381",
         "name": "open_style",
         "owner": "CcbNpcGroomingApi",
         "parameters": "provider, client, area"
       },
       {
-        "line": "9360",
+        "line": "9386",
         "name": "provide",
         "owner": "CcbNpcGroomingApi",
         "parameters": "provider, client, service"
       },
       {
-        "line": "9343",
+        "line": "9369",
         "name": "open_bionic_service",
         "owner": "CcbNpcMedicalApi",
         "parameters": "provider, operation, patient"
       },
       {
-        "line": "9338",
+        "line": "9364",
         "name": "provide_aid",
         "owner": "CcbNpcMedicalApi",
         "parameters": "provider, patient, level, include_allies"
       },
       {
-        "line": "9347",
+        "line": "9373",
         "name": "repair_bionic_limbs",
         "owner": "CcbNpcMedicalApi",
         "parameters": "provider, patient"
       },
       {
-        "line": "9308",
+        "line": "9334",
         "name": "add_assigned",
         "owner": "CcbNpcMissionsApi",
         "parameters": "provider, owner, mission"
       },
       {
-        "line": "9312",
+        "line": "9338",
         "name": "assign_selected",
         "owner": "CcbNpcMissionsApi",
         "parameters": "provider, owner"
       },
       {
-        "line": "9329",
+        "line": "9355",
         "name": "claim_selected_reward",
         "owner": "CcbNpcMissionsApi",
         "parameters": "provider, owner"
       },
       {
-        "line": "9325",
+        "line": "9351",
         "name": "clear_selected",
         "owner": "CcbNpcMissionsApi",
         "parameters": "provider, owner"
       },
       {
-        "line": "9321",
+        "line": "9347",
         "name": "fail_selected",
         "owner": "CcbNpcMissionsApi",
         "parameters": "provider, owner"
       },
       {
-        "line": "9303",
+        "line": "9329",
         "name": "offer",
         "owner": "CcbNpcMissionsApi",
         "parameters": "provider, mission"
       },
       {
-        "line": "9299",
+        "line": "9325",
         "name": "select",
         "owner": "CcbNpcMissionsApi",
         "parameters": "provider, token"
       },
       {
-        "line": "9295",
+        "line": "9321",
         "name": "state",
         "owner": "CcbNpcMissionsApi",
         "parameters": "provider"
       },
       {
-        "line": "9317",
+        "line": "9343",
         "name": "succeed_selected",
         "owner": "CcbNpcMissionsApi",
         "parameters": "provider, owner, force"
       },
       {
-        "line": "9367",
+        "line": "9393",
         "name": "offerings",
         "owner": "CcbNpcTrainingApi",
         "parameters": "teacher, student"
       },
       {
-        "line": "9372",
+        "line": "9398",
         "name": "start",
         "owner": "CcbNpcTrainingApi",
         "parameters": "teacher, students, subject"
       },
       {
-        "line": "9377",
+        "line": "9403",
         "name": "start_selected",
         "owner": "CcbNpcTrainingApi",
         "parameters": "provider, student, mode"
       },
       {
-        "line": "9440",
+        "line": "9466",
         "name": "add_debt",
         "owner": "CcbNpcsApi",
         "parameters": "handle, amount"
       },
       {
-        "line": "9444",
+        "line": "9470",
         "name": "add_faction_rep",
         "owner": "CcbNpcsApi",
         "parameters": "handle, amount"
       },
       {
-        "line": "9463",
+        "line": "9489",
         "name": "ai_rule_catalog",
         "owner": "CcbNpcsApi",
         "parameters": ""
       },
       {
-        "line": "9540",
+        "line": "9566",
         "name": "ai_rules",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9508",
+        "line": "9534",
         "name": "become_hostile",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9402",
+        "line": "9428",
         "name": "class",
         "owner": "CcbNpcsApi",
         "parameters": "id"
       },
       {
-        "line": "9399",
+        "line": "9425",
         "name": "classes",
         "owner": "CcbNpcsApi",
         "parameters": "options"
       },
       {
-        "line": "9510",
+        "line": "9536",
         "name": "clear_stolen_item_claim",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9519",
+        "line": "9545",
         "name": "companion_state",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9482",
+        "line": "9508",
         "name": "copy_ai_rules",
         "owner": "CcbNpcsApi",
         "parameters": "target, source"
       },
       {
-        "line": "9414",
+        "line": "9440",
         "name": "count_allies",
         "owner": "CcbNpcsApi",
         "parameters": "global"
       },
       {
-        "line": "9512",
+        "line": "9538",
         "name": "destinations",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9411",
+        "line": "9437",
         "name": "find_unique",
         "owner": "CcbNpcsApi",
         "parameters": "unique_id"
       },
       {
-        "line": "9493",
+        "line": "9519",
         "name": "follow_temporarily",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9408",
+        "line": "9434",
         "name": "get",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9424",
+        "line": "9450",
         "name": "has_follower_nearby",
         "owner": "CcbNpcsApi",
         "parameters": "origin, class, radius"
       },
       {
-        "line": "9419",
+        "line": "9445",
         "name": "has_role_nearby",
         "owner": "CcbNpcsApi",
         "parameters": "origin, role, radius"
       },
       {
-        "line": "9501",
+        "line": "9527",
         "name": "join_player",
         "owner": "CcbNpcsApi",
         "parameters": "handle, avatar"
       },
       {
-        "line": "9517",
+        "line": "9543",
         "name": "lead_to",
         "owner": "CcbNpcsApi",
         "parameters": "handle, goal"
       },
       {
-        "line": "9504",
+        "line": "9530",
         "name": "leave_player",
         "owner": "CcbNpcsApi",
         "parameters": "handle, avatar"
       },
       {
-        "line": "9405",
+        "line": "9431",
         "name": "list",
         "owner": "CcbNpcsApi",
         "parameters": "options"
       },
       {
-        "line": "9495",
+        "line": "9521",
         "name": "make_neutral",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9485",
+        "line": "9511",
         "name": "make_thankful",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9436",
+        "line": "9462",
         "name": "modify_opinion",
         "owner": "CcbNpcsApi",
         "parameters": "handle, deltas"
       },
       {
-        "line": "9526",
+        "line": "9552",
         "name": "offer_item",
         "owner": "CcbNpcsApi",
         "parameters": "recipient, giver, item, use_item"
       },
       {
-        "line": "9521",
+        "line": "9547",
         "name": "open_companion_missions",
         "owner": "CcbNpcsApi",
         "parameters": "handle, role"
       },
       {
-        "line": "9534",
+        "line": "9560",
         "name": "open_control_menu",
         "owner": "CcbNpcsApi",
         "parameters": "avatar"
       },
       {
-        "line": "9531",
+        "line": "9557",
         "name": "open_dialogue",
         "owner": "CcbNpcsApi",
         "parameters": "npc, speaker, topic"
       },
       {
-        "line": "9532",
+        "line": "9558",
         "name": "open_rules",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9515",
+        "line": "9541",
         "name": "plan_travel",
         "owner": "CcbNpcsApi",
         "parameters": "handle, goal"
       },
       {
-        "line": "9489",
+        "line": "9515",
         "name": "record_refusal",
         "owner": "CcbNpcsApi",
         "parameters": "handle, request"
       },
       {
-        "line": "9428",
+        "line": "9454",
         "name": "rename",
         "owner": "CcbNpcsApi",
         "parameters": "handle, name"
       },
       {
-        "line": "9468",
+        "line": "9494",
         "name": "set_ai_policy",
         "owner": "CcbNpcsApi",
         "parameters": "handle, family, rule"
       },
       {
-        "line": "9478",
+        "line": "9504",
         "name": "set_ally_override",
         "owner": "CcbNpcsApi",
         "parameters": "handle, rule, state"
       },
       {
-        "line": "9473",
+        "line": "9499",
         "name": "set_ally_rule",
         "owner": "CcbNpcsApi",
         "parameters": "handle, rule, enabled"
       },
       {
-        "line": "9432",
+        "line": "9458",
         "name": "set_attitude",
         "owner": "CcbNpcsApi",
         "parameters": "handle, attitude"
       },
       {
-        "line": "9448",
+        "line": "9474",
         "name": "set_class",
         "owner": "CcbNpcsApi",
         "parameters": "handle, class"
       },
       {
-        "line": "9520",
+        "line": "9546",
         "name": "set_companion_role",
         "owner": "CcbNpcsApi",
         "parameters": "handle, role"
       },
       {
-        "line": "9452",
+        "line": "9478",
         "name": "set_faction",
         "owner": "CcbNpcsApi",
         "parameters": "handle, faction"
       },
       {
-        "line": "9456",
+        "line": "9482",
         "name": "set_first_topic",
         "owner": "CcbNpcsApi",
         "parameters": "handle, topic"
       },
       {
-        "line": "9516",
+        "line": "9542",
         "name": "set_goal",
         "owner": "CcbNpcsApi",
         "parameters": "handle, goal"
       },
       {
-        "line": "9518",
+        "line": "9544",
         "name": "set_guard_position",
         "owner": "CcbNpcsApi",
         "parameters": "handle, position"
       },
       {
-        "line": "9507",
+        "line": "9533",
         "name": "set_guarding",
         "owner": "CcbNpcsApi",
         "parameters": "handle, enabled"
       },
       {
-        "line": "9461",
+        "line": "9487",
         "name": "set_radio_representative",
         "owner": "CcbNpcsApi",
         "parameters": "handle, avatar, enabled"
       },
       {
-        "line": "9496",
+        "line": "9522",
         "name": "start_fleeing",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9497",
+        "line": "9523",
         "name": "start_mugging",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9494",
+        "line": "9520",
         "name": "stop_temporary_following",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9537",
+        "line": "9563",
         "name": "take_control",
         "owner": "CcbNpcsApi",
         "parameters": "handle, avatar"
       },
       {
-        "line": "9509",
+        "line": "9535",
         "name": "warn_player_departure",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
@@ -21689,139 +21770,139 @@
         "parameters": "position"
       },
       {
-        "line": "9792",
+        "line": "9818",
         "name": "complete",
         "owner": "CcbPlatformAchievementsApi",
         "parameters": "id"
       },
       {
-        "line": "8275",
+        "line": "8301",
         "name": "assign_npc_job",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "handle, job"
       },
       {
-        "line": "9826",
+        "line": "9852",
         "name": "assign_timed",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "character, id, duration"
       },
       {
-        "line": "9831",
+        "line": "9857",
         "name": "cancel",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "character"
       },
       {
-        "line": "8278",
+        "line": "8304",
         "name": "clear_backlog",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "character_handle"
       },
       {
-        "line": "8281",
+        "line": "8307",
         "name": "dismount",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "npc_handle"
       },
       {
-        "line": "8288",
+        "line": "8314",
         "name": "drop_item",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "character_handle, item_handle, quantity, placement, force_ground"
       },
       {
-        "line": "8291",
+        "line": "8317",
         "name": "drop_nonfavorite_items",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "npc_handle"
       },
       {
-        "line": "8294",
+        "line": "8320",
         "name": "offer_interruption",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "reason"
       },
       {
-        "line": "8297",
+        "line": "8323",
         "name": "offer_portal_storm_interruption",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "message"
       },
       {
-        "line": "8303",
+        "line": "8329",
         "name": "pickup_item",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "character_handle, item_handle, quantity, autopickup"
       },
       {
-        "line": "8311",
+        "line": "8337",
         "name": "read",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "character_handle, book_handle, duration, ereader_handle, continuous, learner_handle"
       },
       {
-        "line": "8314",
+        "line": "8340",
         "name": "resume",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "character_handle"
       },
       {
-        "line": "8317",
+        "line": "8343",
         "name": "revert_npc_job",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "handle"
       },
       {
-        "line": "9817",
+        "line": "9843",
         "name": "snapshot",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "character"
       },
       {
-        "line": "8322",
+        "line": "8348",
         "name": "socialize",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "character_handle, partner_handle, duration"
       },
       {
-        "line": "8328",
+        "line": "8354",
         "name": "start_training",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "teacher_handle, trainee_handles, subject_id, duration"
       },
       {
-        "line": "8331",
+        "line": "8357",
         "name": "suspend",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "character_handle"
       },
       {
-        "line": "8334",
+        "line": "8360",
         "name": "target_practice",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "character_handle"
       },
       {
-        "line": "8339",
+        "line": "8365",
         "name": "wait_for_npc",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "character_handle, npc_handle, duration"
       },
       {
-        "line": "10189",
+        "line": "10215",
         "name": "grant",
         "owner": "CcbPlatformBionicsApi",
         "parameters": "character, id"
       },
       {
-        "line": "10195",
+        "line": "10221",
         "name": "remove_type",
         "owner": "CcbPlatformBionicsApi",
         "parameters": "character, id"
       },
       {
-        "line": "10183",
+        "line": "10209",
         "name": "summary",
         "owner": "CcbPlatformBionicsApi",
         "parameters": "character"
@@ -23561,67 +23642,67 @@
         "parameters": "dimension"
       },
       {
-        "line": "10459",
+        "line": "10485",
         "name": "dimension",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": ""
       },
       {
-        "line": "10497",
+        "line": "10523",
         "name": "field_exists",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position, field_id"
       },
       {
-        "line": "10480",
+        "line": "10506",
         "name": "furniture_has_flag",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position, flag"
       },
       {
-        "line": "10492",
+        "line": "10518",
         "name": "furniture_id",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position"
       },
       {
-        "line": "10507",
+        "line": "10533",
         "name": "is_indoor_tile",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position"
       },
       {
-        "line": "10463",
+        "line": "10489",
         "name": "is_night",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": ""
       },
       {
-        "line": "10467",
+        "line": "10493",
         "name": "is_outside",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position"
       },
       {
-        "line": "10474",
+        "line": "10500",
         "name": "line_of_sight",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "from, to, range, with_fields"
       },
       {
-        "line": "10512",
+        "line": "10538",
         "name": "safe_mode_dangerous",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "direction"
       },
       {
-        "line": "10502",
+        "line": "10528",
         "name": "terrain_has_flag",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position, flag"
       },
       {
-        "line": "10486",
+        "line": "10512",
         "name": "terrain_id",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position"
@@ -23669,13 +23750,13 @@
         "parameters": "title, options"
       },
       {
-        "line": "9784",
+        "line": "9810",
         "name": "is_wearing",
         "owner": "CcbPlatformInventoryApi",
         "parameters": "character, item"
       },
       {
-        "line": "9775",
+        "line": "9801",
         "name": "wielded",
         "owner": "CcbPlatformInventoryApi",
         "parameters": "character"
@@ -23699,31 +23780,31 @@
         "parameters": "id"
       },
       {
-        "line": "10377",
+        "line": "10403",
         "name": "forget",
         "owner": "CcbPlatformMartialArtsApi",
         "parameters": "character, id"
       },
       {
-        "line": "10371",
+        "line": "10397",
         "name": "learn",
         "owner": "CcbPlatformMartialArtsApi",
         "parameters": "character, id"
       },
       {
-        "line": "10364",
+        "line": "10390",
         "name": "technique_definition",
         "owner": "CcbPlatformMartialArtsApi",
         "parameters": "id"
       },
       {
-        "line": "10539",
+        "line": "10565",
         "name": "apply",
         "owner": "CcbPlatformMathApi",
         "parameters": "expression, actor, context"
       },
       {
-        "line": "10532",
+        "line": "10558",
         "name": "evaluate",
         "owner": "CcbPlatformMathApi",
         "parameters": "expression, actor, context"
@@ -23747,25 +23828,25 @@
         "parameters": "message, type"
       },
       {
-        "line": "10453",
+        "line": "10479",
         "name": "is_loaded",
         "owner": "CcbPlatformModQueries",
         "parameters": "mod_id"
       },
       {
-        "line": "8350",
+        "line": "8376",
         "name": "load_order",
         "owner": "CcbPlatformModQueries",
         "parameters": "id"
       },
       {
-        "line": "10394",
+        "line": "10420",
         "name": "add",
         "owner": "CcbPlatformMoraleApi",
         "parameters": "character, id, bonus, max_bonus, options"
       },
       {
-        "line": "10400",
+        "line": "10426",
         "name": "remove",
         "owner": "CcbPlatformMoraleApi",
         "parameters": "character, id"
@@ -23807,19 +23888,19 @@
         "parameters": "message"
       },
       {
-        "line": "8374",
+        "line": "8400",
         "name": "notice_any_key",
         "owner": "CcbPlatformPresentation",
         "parameters": "message"
       },
       {
-        "line": "8377",
+        "line": "8403",
         "name": "notice_large",
         "owner": "CcbPlatformPresentation",
         "parameters": "message"
       },
       {
-        "line": "8380",
+        "line": "8406",
         "name": "notice_top",
         "owner": "CcbPlatformPresentation",
         "parameters": "message"
@@ -23831,97 +23912,97 @@
         "parameters": "file, volume"
       },
       {
-        "line": "10413",
+        "line": "10439",
         "name": "chance",
         "owner": "CcbPlatformRandomApi",
         "parameters": "numerator, denominator"
       },
       {
-        "line": "10435",
+        "line": "10461",
         "name": "contested",
         "owner": "CcbPlatformRandomApi",
         "parameters": "check, difficulty, die_size"
       },
       {
-        "line": "10408",
+        "line": "10434",
         "name": "int",
         "owner": "CcbPlatformRandomApi",
         "parameters": "minimum, maximum"
       },
       {
-        "line": "10417",
+        "line": "10443",
         "name": "one_in",
         "owner": "CcbPlatformRandomApi",
         "parameters": "denominator"
       },
       {
-        "line": "10422",
+        "line": "10448",
         "name": "probability",
         "owner": "CcbPlatformRandomApi",
         "parameters": "numerator, denominator"
       },
       {
-        "line": "10429",
+        "line": "10455",
         "name": "sample_integers",
         "owner": "CcbPlatformRandomApi",
         "parameters": "minimum, maximum, count, with_replacement"
       },
       {
-        "line": "10239",
+        "line": "10265",
         "name": "all",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, options"
       },
       {
-        "line": "10249",
+        "line": "10275",
         "name": "by_flag",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "flag, character, options"
       },
       {
-        "line": "10244",
+        "line": "10270",
         "name": "by_skill",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "skill, character, options"
       },
       {
-        "line": "10291",
+        "line": "10317",
         "name": "forget",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, id"
       },
       {
-        "line": "10308",
+        "line": "10334",
         "name": "forget_category",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, category, subcategory"
       },
       {
-        "line": "10254",
+        "line": "10280",
         "name": "get",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, id, batch"
       },
       {
-        "line": "10258",
+        "line": "10284",
         "name": "has_flag",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "id, flag"
       },
       {
-        "line": "10279",
+        "line": "10305",
         "name": "knows",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, id"
       },
       {
-        "line": "10285",
+        "line": "10311",
         "name": "learn",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, id"
       },
       {
-        "line": "10235",
+        "line": "10261",
         "name": "list",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, options"
@@ -23963,115 +24044,115 @@
         "parameters": "event_name, handler_id"
       },
       {
-        "line": "10698",
+        "line": "10724",
         "name": "activity_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10688",
+        "line": "10714",
         "name": "bionics_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10635",
+        "line": "10661",
         "name": "character_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character"
       },
       {
-        "line": "10678",
+        "line": "10704",
         "name": "current_tile_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, field_limit"
       },
       {
-        "line": "10656",
+        "line": "10682",
         "name": "effects_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10666",
+        "line": "10692",
         "name": "equipment_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10651",
+        "line": "10677",
         "name": "inventory_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10673",
+        "line": "10699",
         "name": "item_contents_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, item_handle, offset, limit"
       },
       {
-        "line": "10611",
+        "line": "10637",
         "name": "message",
         "owner": "CcbPlatformServices",
         "parameters": "text"
       },
       {
-        "line": "10693",
+        "line": "10719",
         "name": "missions_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10639",
+        "line": "10665",
         "name": "movement_modes_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character"
       },
       {
-        "line": "10683",
+        "line": "10709",
         "name": "mutations_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10704",
+        "line": "10730",
         "name": "nearby_creatures_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, radius, limit"
       },
       {
-        "line": "10661",
+        "line": "10687",
         "name": "skills_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10642",
+        "line": "10668",
         "name": "time_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": ""
       },
       {
-        "line": "10618",
+        "line": "10644",
         "name": "translate",
         "owner": "CcbPlatformServices",
         "parameters": "text, context"
       },
       {
-        "line": "10628",
+        "line": "10654",
         "name": "translate_plural",
         "owner": "CcbPlatformServices",
         "parameters": "singular, plural, count, context"
       },
       {
-        "line": "10631",
+        "line": "10657",
         "name": "turn",
         "owner": "CcbPlatformServices",
         "parameters": ""
       },
       {
-        "line": "10645",
+        "line": "10671",
         "name": "weather_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": ""
@@ -24143,13 +24224,13 @@
         "parameters": "key, value"
       },
       {
-        "line": "10446",
+        "line": "10472",
         "name": "all_equal",
         "owner": "CcbPlatformStringPredicates",
         "parameters": "values"
       },
       {
-        "line": "10442",
+        "line": "10468",
         "name": "any_equal",
         "owner": "CcbPlatformStringPredicates",
         "parameters": "values"
@@ -24167,25 +24248,25 @@
         "parameters": "task_id"
       },
       {
-        "line": "8359",
+        "line": "8385",
         "name": "every",
         "owner": "CcbPlatformTasks",
         "parameters": "interval_turns, handler_id, payload, payload_version, scope, actor, participants"
       },
       {
-        "line": "8362",
+        "line": "8388",
         "name": "get",
         "owner": "CcbPlatformTasks",
         "parameters": "id"
       },
       {
-        "line": "8367",
+        "line": "8393",
         "name": "list",
         "owner": "CcbPlatformTasks",
         "parameters": "handler_id, scope, requested_limit"
       },
       {
-        "line": "8371",
+        "line": "8397",
         "name": "next",
         "owner": "CcbPlatformTasks",
         "parameters": "handler_id, scope"
@@ -24209,433 +24290,433 @@
         "parameters": "descriptor"
       },
       {
-        "line": "9868",
+        "line": "9894",
         "name": "add",
         "owner": "CcbPlatformWoundsApi",
         "parameters": "character, body_part, wound"
       },
       {
-        "line": "9877",
+        "line": "9903",
         "name": "remove",
         "owner": "CcbPlatformWoundsApi",
         "parameters": "character, body_part, wound"
       },
       {
-        "line": "9856",
+        "line": "9882",
         "name": "snapshot",
         "owner": "CcbPlatformWoundsApi",
         "parameters": "character, body_part"
       },
       {
-        "line": "7507",
+        "line": "7533",
         "name": "move",
         "owner": "CcbRelocationApi",
         "parameters": "entity, target, options"
       },
       {
-        "line": "7513",
+        "line": "7539",
         "name": "travel_to_omt",
         "owner": "CcbRelocationApi",
         "parameters": "avatar, target, options"
       },
       {
-        "line": "10273",
+        "line": "10299",
         "name": "for_recipe",
         "owner": "CcbRequirementsApi",
         "parameters": "character, id, batch"
       },
       {
-        "line": "10268",
+        "line": "10294",
         "name": "get",
         "owner": "CcbRequirementsApi",
         "parameters": "character, id, batch"
       },
       {
-        "line": "10263",
+        "line": "10289",
         "name": "list",
         "owner": "CcbRequirementsApi",
         "parameters": "character, options"
       },
       {
-        "line": "9908",
+        "line": "9934",
         "name": "offered",
         "owner": "CcbSkillsApi",
         "parameters": "teacher, student"
       },
       {
-        "line": "9765",
+        "line": "9791",
         "name": "commit",
         "owner": "CcbTradeApi",
         "parameters": "token, settlement"
       },
       {
-        "line": "9760",
+        "line": "9786",
         "name": "get",
         "owner": "CcbTradeApi",
         "parameters": "token"
       },
       {
-        "line": "9734",
+        "line": "9760",
         "name": "open",
         "owner": "CcbTradeApi",
         "parameters": "seller, buyer, cost, title"
       },
       {
-        "line": "9749",
+        "line": "9775",
         "name": "order_price",
         "owner": "CcbTradeApi",
         "parameters": "seller, buyer, item_type, count"
       },
       {
-        "line": "9741",
+        "line": "9767",
         "name": "pay",
         "owner": "CcbTradeApi",
         "parameters": "seller, buyer, cost"
       },
       {
-        "line": "9756",
+        "line": "9782",
         "name": "quote",
         "owner": "CcbTradeApi",
         "parameters": "seller, buyer, lines, options"
       },
       {
-        "line": "9961",
+        "line": "9987",
         "name": "id",
         "owner": "CcbTypesApi",
         "parameters": "kind, value"
       },
       {
-        "line": "9964",
+        "line": "9990",
         "name": "id_kinds",
         "owner": "CcbTypesApi",
         "parameters": ""
       },
       {
-        "line": "9979",
+        "line": "10005",
         "name": "get",
         "owner": "CcbVariablesApi",
         "parameters": "character, key"
       },
       {
-        "line": "9995",
+        "line": "10021",
         "name": "get_global",
         "owner": "CcbVariablesApi",
         "parameters": "key"
       },
       {
-        "line": "9991",
+        "line": "10017",
         "name": "remove",
         "owner": "CcbVariablesApi",
         "parameters": "character, key"
       },
       {
-        "line": "10004",
+        "line": "10030",
         "name": "remove_global",
         "owner": "CcbVariablesApi",
         "parameters": "key"
       },
       {
-        "line": "10013",
+        "line": "10039",
         "name": "resolve",
         "owner": "CcbVariablesApi",
         "parameters": "context, actor, scope, key"
       },
       {
-        "line": "9986",
+        "line": "10012",
         "name": "set",
         "owner": "CcbVariablesApi",
         "parameters": "character, key, value"
       },
       {
-        "line": "10000",
+        "line": "10026",
         "name": "set_global",
         "owner": "CcbVariablesApi",
         "parameters": "key, value"
       },
       {
-        "line": "10021",
+        "line": "10047",
         "name": "set_resolved",
         "owner": "CcbVariablesApi",
         "parameters": "context, actor, scope, key, value"
       },
       {
-        "line": "8456",
+        "line": "8482",
         "name": "definition",
         "owner": "CcbVehiclesApi",
         "parameters": "id"
       },
       {
-        "line": "8453",
+        "line": "8479",
         "name": "definitions",
         "owner": "CcbVehiclesApi",
         "parameters": "options"
       },
       {
-        "line": "8511",
+        "line": "8537",
         "name": "destroy",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle"
       },
       {
-        "line": "8466",
+        "line": "8492",
         "name": "fuels",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle"
       },
       {
-        "line": "8459",
+        "line": "8485",
         "name": "get",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle"
       },
       {
-        "line": "8503",
+        "line": "8529",
         "name": "has_part_flag",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle, flag, enabled"
       },
       {
-        "line": "8498",
+        "line": "8524",
         "name": "is_player_controlling",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle"
       },
       {
-        "line": "8542",
+        "line": "8568",
         "name": "open_part_service",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle, mechanic, repair_multiplier, install_multiplier"
       },
       {
-        "line": "8463",
+        "line": "8489",
         "name": "parts",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle, options"
       },
       {
-        "line": "8491",
+        "line": "8517",
         "name": "prototype_value",
         "owner": "CcbVehiclesApi",
         "parameters": "id, post_cataclysm"
       },
       {
-        "line": "8520",
+        "line": "8546",
         "name": "quote_full_repair",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle, mechanic, repair_multiplier"
       },
       {
-        "line": "8470",
+        "line": "8496",
         "name": "rename",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle, name"
       },
       {
-        "line": "8474",
+        "line": "8500",
         "name": "set_cruise_velocity",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle, velocity"
       },
       {
-        "line": "8515",
+        "line": "8541",
         "name": "set_owner",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle, owner"
       },
       {
-        "line": "8487",
+        "line": "8513",
         "name": "set_part_enabled",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle, part, enabled"
       },
       {
-        "line": "8482",
+        "line": "8508",
         "name": "set_tracking",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle, enabled"
       },
       {
-        "line": "8508",
+        "line": "8534",
         "name": "spawn",
         "owner": "CcbVehiclesApi",
         "parameters": "prototype, position, options"
       },
       {
-        "line": "8525",
+        "line": "8551",
         "name": "start_full_repair",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle, mechanic, repair_multiplier"
       },
       {
-        "line": "8478",
+        "line": "8504",
         "name": "stop",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle, options"
       },
       {
-        "line": "8495",
+        "line": "8521",
         "name": "value",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle, options"
       },
       {
-        "line": "7730",
+        "line": "7756",
         "name": "activate_lightning",
         "owner": "CcbWeatherApi",
         "parameters": ""
       },
       {
-        "line": "7710",
+        "line": "7736",
         "name": "clear_override",
         "owner": "CcbWeatherApi",
         "parameters": ""
       },
       {
-        "line": "7724",
+        "line": "7750",
         "name": "clear_overrides",
         "owner": "CcbWeatherApi",
         "parameters": ""
       },
       {
-        "line": "7717",
+        "line": "7743",
         "name": "clear_temperature_override",
         "owner": "CcbWeatherApi",
         "parameters": ""
       },
       {
-        "line": "7679",
+        "line": "7705",
         "name": "current",
         "owner": "CcbWeatherApi",
         "parameters": ""
       },
       {
-        "line": "7686",
+        "line": "7712",
         "name": "forecast",
         "owner": "CcbWeatherApi",
         "parameters": "options"
       },
       {
-        "line": "7682",
+        "line": "7708",
         "name": "generator",
         "owner": "CcbWeatherApi",
         "parameters": ""
       },
       {
-        "line": "7689",
+        "line": "7715",
         "name": "limits",
         "owner": "CcbWeatherApi",
         "parameters": ""
       },
       {
-        "line": "7736",
+        "line": "7762",
         "name": "override_light",
         "owner": "CcbWeatherApi",
         "parameters": "level, duration, key"
       },
       {
-        "line": "7727",
+        "line": "7753",
         "name": "refresh",
         "owner": "CcbWeatherApi",
         "parameters": ""
       },
       {
-        "line": "7707",
+        "line": "7733",
         "name": "set_override",
         "owner": "CcbWeatherApi",
         "parameters": "id"
       },
       {
-        "line": "7714",
+        "line": "7740",
         "name": "set_temperature_override",
         "owner": "CcbWeatherApi",
         "parameters": "temperature"
       },
       {
-        "line": "7721",
+        "line": "7747",
         "name": "set_wind",
         "owner": "CcbWeatherApi",
         "parameters": "options"
       },
       {
-        "line": "7676",
+        "line": "7702",
         "name": "type",
         "owner": "CcbWeatherApi",
         "parameters": "id"
       },
       {
-        "line": "7672",
+        "line": "7698",
         "name": "types",
         "owner": "CcbWeatherApi",
         "parameters": "options"
       },
       {
-        "line": "7855",
+        "line": "7881",
         "name": "at",
         "owner": "CcbZonesApi",
         "parameters": "position, options"
       },
       {
-        "line": "7864",
+        "line": "7890",
         "name": "contains",
         "owner": "CcbZonesApi",
         "parameters": "token, position"
       },
       {
-        "line": "7869",
+        "line": "7895",
         "name": "create",
         "owner": "CcbZonesApi",
         "parameters": "options"
       },
       {
-        "line": "7859",
+        "line": "7885",
         "name": "get",
         "owner": "CcbZonesApi",
         "parameters": "token"
       },
       {
-        "line": "7850",
+        "line": "7876",
         "name": "list",
         "owner": "CcbZonesApi",
         "parameters": "options"
       },
       {
-        "line": "7895",
+        "line": "7921",
         "name": "remove",
         "owner": "CcbZonesApi",
         "parameters": "token"
       },
       {
-        "line": "7874",
+        "line": "7900",
         "name": "rename",
         "owner": "CcbZonesApi",
         "parameters": "token, name"
       },
       {
-        "line": "7879",
+        "line": "7905",
         "name": "set_enabled",
         "owner": "CcbZonesApi",
         "parameters": "token, enabled"
       },
       {
-        "line": "7891",
+        "line": "7917",
         "name": "set_position",
         "owner": "CcbZonesApi",
         "parameters": "token, start, finish"
       },
       {
-        "line": "7884",
+        "line": "7910",
         "name": "set_temporary_disabled",
         "owner": "CcbZonesApi",
         "parameters": "token, disabled"
       },
       {
-        "line": "7846",
+        "line": "7872",
         "name": "type",
         "owner": "CcbZonesApi",
         "parameters": "id"
       },
       {
-        "line": "7842",
+        "line": "7868",
         "name": "types",
         "owner": "CcbZonesApi",
         "parameters": "options"
@@ -30259,47 +30340,47 @@
   "public_root": {
     "fields": [
       {
-        "line": 10708,
+        "line": 10734,
         "name": "ModDefinition",
         "type": "fun(options:"
       },
       {
-        "line": 10709,
+        "line": 10735,
         "name": "content",
         "type": "CcbPlatformContent"
       },
       {
-        "line": 10711,
+        "line": 10737,
         "name": "dialogue",
         "type": "CcbPlatformDialogueApi"
       },
       {
-        "line": 10707,
+        "line": 10733,
         "name": "platform_version",
         "type": "1"
       },
       {
-        "line": 10714,
+        "line": 10740,
         "name": "presentation",
         "type": "CcbPlatformPresentation"
       },
       {
-        "line": 10710,
+        "line": 10736,
         "name": "runtime",
         "type": "CcbPlatformRuntime"
       },
       {
-        "line": 10715,
+        "line": 10741,
         "name": "services",
         "type": "CcbPlatformServices"
       },
       {
-        "line": 10712,
+        "line": 10738,
         "name": "state",
         "type": "CcbPlatformState"
       },
       {
-        "line": 10713,
+        "line": 10739,
         "name": "tasks",
         "type": "CcbPlatformTasks"
       }

--- a/data/lua/reference/ccb_platform_api_v1.json
+++ b/data/lua/reference/ccb_platform_api_v1.json
@@ -7,7 +7,7 @@
     "root_class": "CcbPlatformV1"
   },
   "lua_luals": {
-    "class_count": 700,
+    "class_count": 702,
     "classes": [
       {
         "fields": [
@@ -1230,27 +1230,27 @@
       {
         "fields": [
           {
-            "line": 10603,
+            "line": 10620,
             "name": "items",
             "type": "table"
           },
           {
-            "line": 10606,
+            "line": 10623,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 10605,
+            "line": 10622,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 10604,
+            "line": 10621,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 10607,
+            "line": 10624,
             "name": "truncated",
             "type": "boolean"
           }
@@ -2450,67 +2450,67 @@
       {
         "fields": [
           {
-            "line": 10590,
+            "line": 10607,
             "name": "focus",
             "type": "integer"
           },
           {
-            "line": 10592,
+            "line": 10609,
             "name": "hunger",
             "type": "integer"
           },
           {
-            "line": 10586,
+            "line": 10603,
             "name": "moves",
             "type": "integer"
           },
           {
-            "line": 10582,
+            "line": 10599,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 10589,
+            "line": 10606,
             "name": "pain",
             "type": "integer"
           },
           {
-            "line": 10594,
+            "line": 10611,
             "name": "sleepiness",
             "type": "integer"
           },
           {
-            "line": 10591,
+            "line": 10608,
             "name": "speed",
             "type": "integer"
           },
           {
-            "line": 10587,
+            "line": 10604,
             "name": "stamina",
             "type": "integer"
           },
           {
-            "line": 10588,
+            "line": 10605,
             "name": "stamina_max",
             "type": "integer"
           },
           {
-            "line": 10593,
+            "line": 10610,
             "name": "thirst",
             "type": "integer"
           },
           {
-            "line": 10583,
+            "line": 10600,
             "name": "x",
             "type": "integer"
           },
           {
-            "line": 10584,
+            "line": 10601,
             "name": "y",
             "type": "integer"
           },
           {
-            "line": 10585,
+            "line": 10602,
             "name": "z",
             "type": "integer"
           }
@@ -2544,52 +2544,52 @@
       {
         "fields": [
           {
-            "line": 10616,
+            "line": 10633,
             "name": "attitude",
             "type": "string"
           },
           {
-            "line": 10617,
+            "line": 10634,
             "name": "dead",
             "type": "boolean"
           },
           {
-            "line": 10612,
+            "line": 10629,
             "name": "display_name",
             "type": "string"
           },
           {
-            "line": 10615,
+            "line": 10632,
             "name": "distance",
             "type": "integer"
           },
           {
-            "line": 10618,
+            "line": 10635,
             "name": "hp",
             "type": "integer"
           },
           {
-            "line": 10619,
+            "line": 10636,
             "name": "hp_max",
             "type": "integer"
           },
           {
-            "line": 10610,
+            "line": 10627,
             "name": "kind",
             "type": "'avatar'|'npc'|'monster'|'creature'"
           },
           {
-            "line": 10611,
+            "line": 10628,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 10613,
+            "line": 10630,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 10614,
+            "line": 10631,
             "name": "visible",
             "type": "boolean"
           }
@@ -2648,22 +2648,22 @@
       {
         "fields": [
           {
-            "line": 10063,
+            "line": 10080,
             "name": "items",
             "type": "GameId[]"
           },
           {
-            "line": 10065,
+            "line": 10082,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 10064,
+            "line": 10081,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 10066,
+            "line": 10083,
             "name": "truncated",
             "type": "boolean"
           }
@@ -2673,12 +2673,12 @@
       {
         "fields": [
           {
-            "line": 10070,
+            "line": 10087,
             "name": "effects",
             "type": "CcbEffectRelatedIdPage"
           },
           {
-            "line": 10069,
+            "line": 10086,
             "name": "mutations",
             "type": "CcbEffectRelatedIdPage"
           }
@@ -2688,112 +2688,112 @@
       {
         "fields": [
           {
-            "line": 10094,
+            "line": 10111,
             "name": "blocks_effects",
             "type": "CcbEffectRelatedIdPage"
           },
           {
-            "line": 10092,
+            "line": 10109,
             "name": "body_part",
             "type": "GameId"
           },
           {
-            "line": 10075,
+            "line": 10092,
             "name": "description",
             "type": "string"
           },
           {
-            "line": 10079,
+            "line": 10096,
             "name": "duration",
             "type": "TimeDuration"
           },
           {
-            "line": 10089,
+            "line": 10106,
             "name": "duration_add_percent",
             "type": "integer"
           },
           {
-            "line": 10085,
+            "line": 10102,
             "name": "effective_intensity",
             "type": "integer"
           },
           {
-            "line": 10088,
+            "line": 10105,
             "name": "harmful_cough",
             "type": "boolean"
           },
           {
-            "line": 10073,
+            "line": 10090,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 10087,
+            "line": 10104,
             "name": "impairs_movement",
             "type": "boolean"
           },
           {
-            "line": 10082,
+            "line": 10099,
             "name": "intensity",
             "type": "integer"
           },
           {
-            "line": 10090,
+            "line": 10107,
             "name": "intensity_add",
             "type": "integer"
           },
           {
-            "line": 10091,
+            "line": 10108,
             "name": "intensity_duration",
             "type": "TimeDuration"
           },
           {
-            "line": 10080,
+            "line": 10097,
             "name": "maximum_duration",
             "type": "TimeDuration"
           },
           {
-            "line": 10084,
+            "line": 10101,
             "name": "maximum_effective_intensity",
             "type": "integer"
           },
           {
-            "line": 10083,
+            "line": 10100,
             "name": "maximum_intensity",
             "type": "integer"
           },
           {
-            "line": 10077,
+            "line": 10094,
             "name": "mod_source",
             "type": "string"
           },
           {
-            "line": 10074,
+            "line": 10091,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 10086,
+            "line": 10103,
             "name": "permanent",
             "type": "boolean"
           },
           {
-            "line": 10093,
+            "line": 10110,
             "name": "resisted_by",
             "type": "CcbEffectResistanceIds"
           },
           {
-            "line": 10076,
+            "line": 10093,
             "name": "short_description",
             "type": "string"
           },
           {
-            "line": 10081,
+            "line": 10098,
             "name": "start_time",
             "type": "TimePoint"
           },
           {
-            "line": 10078,
+            "line": 10095,
             "name": "uses_body_part_description",
             "type": "boolean"
           }
@@ -2803,7 +2803,7 @@
       {
         "fields": [
           {
-            "line": 10097,
+            "line": 10114,
             "name": "value",
             "type": "CcbEffectSnapshot"
           }
@@ -5211,22 +5211,22 @@
       {
         "fields": [
           {
-            "line": 10598,
+            "line": 10615,
             "name": "count",
             "type": "integer"
           },
           {
-            "line": 10599,
+            "line": 10616,
             "name": "current_id",
             "type": "string"
           },
           {
-            "line": 10600,
+            "line": 10617,
             "name": "desired_id",
             "type": "string"
           },
           {
-            "line": 10597,
+            "line": 10614,
             "name": "items",
             "type": "table"
           }
@@ -6182,22 +6182,22 @@
       {
         "fields": [
           {
-            "line": 10217,
+            "line": 10234,
             "name": "has_capacity",
             "type": "boolean"
           },
           {
-            "line": 10214,
+            "line": 10231,
             "name": "installed_count",
             "type": "integer"
           },
           {
-            "line": 10216,
+            "line": 10233,
             "name": "maximum_power",
             "type": "UnitValue"
           },
           {
-            "line": 10215,
+            "line": 10232,
             "name": "power",
             "type": "UnitValue"
           }
@@ -6493,27 +6493,27 @@
       {
         "fields": [
           {
-            "line": 10557,
+            "line": 10574,
             "name": "environment",
             "type": "CcbPlatformEnvironmentQueries"
           },
           {
-            "line": 10556,
+            "line": 10573,
             "name": "math",
             "type": "CcbPlatformMathApi"
           },
           {
-            "line": 10555,
+            "line": 10572,
             "name": "mods",
             "type": "CcbPlatformModQueries"
           },
           {
-            "line": 10558,
+            "line": 10575,
             "name": "options",
             "type": "CcbPlatformGameplayOptionsApi"
           },
           {
-            "line": 10554,
+            "line": 10571,
             "name": "strings",
             "type": "CcbPlatformStringPredicates"
           }
@@ -6654,17 +6654,17 @@
       {
         "fields": [
           {
-            "line": 10421,
+            "line": 10438,
             "name": "capped",
             "type": "boolean"
           },
           {
-            "line": 10420,
+            "line": 10437,
             "name": "decay_start",
             "type": "TimeDuration"
           },
           {
-            "line": 10419,
+            "line": 10436,
             "name": "duration",
             "type": "TimeDuration"
           }
@@ -6746,32 +6746,32 @@
       {
         "fields": [
           {
-            "line": 10337,
+            "line": 10354,
             "name": "category",
             "type": "GameId"
           },
           {
-            "line": 10333,
+            "line": 10350,
             "name": "changed",
             "type": "boolean"
           },
           {
-            "line": 10334,
+            "line": 10351,
             "name": "forgotten_count",
             "type": "integer"
           },
           {
-            "line": 10336,
+            "line": 10353,
             "name": "known_after",
             "type": "integer"
           },
           {
-            "line": 10335,
+            "line": 10352,
             "name": "known_before",
             "type": "integer"
           },
           {
-            "line": 10338,
+            "line": 10355,
             "name": "subcategory",
             "type": "string"
           }
@@ -7377,47 +7377,47 @@
       {
         "fields": [
           {
-            "line": 10747,
+            "line": 10764,
             "name": "ModDefinition",
             "type": "fun(options:"
           },
           {
-            "line": 10748,
+            "line": 10765,
             "name": "content",
             "type": "CcbPlatformContent"
           },
           {
-            "line": 10750,
+            "line": 10767,
             "name": "dialogue",
             "type": "CcbPlatformDialogueApi"
           },
           {
-            "line": 10746,
+            "line": 10763,
             "name": "platform_version",
             "type": "1"
           },
           {
-            "line": 10753,
+            "line": 10770,
             "name": "presentation",
             "type": "CcbPlatformPresentation"
           },
           {
-            "line": 10749,
+            "line": 10766,
             "name": "runtime",
             "type": "CcbPlatformRuntime"
           },
           {
-            "line": 10754,
+            "line": 10771,
             "name": "services",
             "type": "CcbPlatformServices"
           },
           {
-            "line": 10751,
+            "line": 10768,
             "name": "state",
             "type": "CcbPlatformState"
           },
           {
-            "line": 10752,
+            "line": 10769,
             "name": "tasks",
             "type": "CcbPlatformTasks"
           }
@@ -7486,37 +7486,37 @@
       {
         "fields": [
           {
-            "line": 10254,
+            "line": 10271,
             "name": "batch",
             "type": "integer"
           },
           {
-            "line": 10253,
+            "line": 10270,
             "name": "has_more",
             "type": "boolean"
           },
           {
-            "line": 10248,
+            "line": 10265,
             "name": "items",
             "type": "table"
           },
           {
-            "line": 10251,
+            "line": 10268,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 10250,
+            "line": 10267,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 10252,
+            "line": 10269,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 10249,
+            "line": 10266,
             "name": "total",
             "type": "integer"
           }
@@ -7526,47 +7526,47 @@
       {
         "fields": [
           {
-            "line": 10239,
+            "line": 10256,
             "name": "batch",
             "type": "integer"
           },
           {
-            "line": 10242,
+            "line": 10259,
             "name": "craftable",
             "type": "boolean"
           },
           {
-            "line": 10245,
+            "line": 10262,
             "name": "flag",
             "type": "string"
           },
           {
-            "line": 10240,
+            "line": 10257,
             "name": "include_obsolete",
             "type": "boolean"
           },
           {
-            "line": 10241,
+            "line": 10258,
             "name": "known",
             "type": "boolean"
           },
           {
-            "line": 10238,
+            "line": 10255,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 10237,
+            "line": 10254,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 10244,
+            "line": 10261,
             "name": "result",
             "type": "GameId"
           },
           {
-            "line": 10243,
+            "line": 10260,
             "name": "skill",
             "type": "GameId"
           }
@@ -7639,17 +7639,17 @@
       {
         "fields": [
           {
-            "line": 10259,
+            "line": 10276,
             "name": "batch",
             "type": "integer"
           },
           {
-            "line": 10258,
+            "line": 10275,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 10257,
+            "line": 10274,
             "name": "offset",
             "type": "integer"
           }
@@ -7762,172 +7762,172 @@
       {
         "fields": [
           {
-            "line": 10392,
+            "line": 10409,
             "name": "area",
             "type": "string"
           },
           {
-            "line": 10394,
+            "line": 10411,
             "name": "attack_vectors",
             "type": "CcbTechniqueIdPage"
           },
           {
-            "line": 10367,
+            "line": 10384,
             "name": "avatar_message",
             "type": "string"
           },
           {
-            "line": 10377,
+            "line": 10394,
             "name": "block_counter",
             "type": "boolean"
           },
           {
-            "line": 10373,
+            "line": 10390,
             "name": "critical_compatible",
             "type": "boolean"
           },
           {
-            "line": 10372,
+            "line": 10389,
             "name": "critical_only",
             "type": "boolean"
           },
           {
-            "line": 10369,
+            "line": 10386,
             "name": "defensive",
             "type": "boolean"
           },
           {
-            "line": 10364,
+            "line": 10381,
             "name": "description",
             "type": "string"
           },
           {
-            "line": 10380,
+            "line": 10397,
             "name": "disarms",
             "type": "boolean"
           },
           {
-            "line": 10376,
+            "line": 10393,
             "name": "dodge_counter",
             "type": "boolean"
           },
           {
-            "line": 10387,
+            "line": 10404,
             "name": "down_duration",
             "type": "integer"
           },
           {
-            "line": 10371,
+            "line": 10388,
             "name": "dummy",
             "type": "boolean"
           },
           {
-            "line": 10395,
+            "line": 10412,
             "name": "eocs",
             "type": "CcbTechniqueIdPage"
           },
           {
-            "line": 10393,
+            "line": 10410,
             "name": "flags",
             "type": "CcbTechniqueFlagPage"
           },
           {
-            "line": 10365,
+            "line": 10382,
             "name": "flavor_description",
             "type": "string"
           },
           {
-            "line": 10366,
+            "line": 10383,
             "name": "goal",
             "type": "string"
           },
           {
-            "line": 10379,
+            "line": 10396,
             "name": "grab_break",
             "type": "boolean"
           },
           {
-            "line": 10362,
+            "line": 10379,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 10389,
+            "line": 10406,
             "name": "knockback_distance",
             "type": "integer"
           },
           {
-            "line": 10391,
+            "line": 10408,
             "name": "knockback_follow",
             "type": "boolean"
           },
           {
-            "line": 10390,
+            "line": 10407,
             "name": "knockback_spread",
             "type": "number"
           },
           {
-            "line": 10378,
+            "line": 10395,
             "name": "miss_recovery",
             "type": "boolean"
           },
           {
-            "line": 10363,
+            "line": 10380,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 10382,
+            "line": 10399,
             "name": "needs_ammo",
             "type": "boolean"
           },
           {
-            "line": 10368,
+            "line": 10385,
             "name": "npc_message",
             "type": "string"
           },
           {
-            "line": 10375,
+            "line": 10392,
             "name": "reach_compatible",
             "type": "boolean"
           },
           {
-            "line": 10374,
+            "line": 10391,
             "name": "reach_only",
             "type": "boolean"
           },
           {
-            "line": 10386,
+            "line": 10403,
             "name": "repeat_max",
             "type": "integer"
           },
           {
-            "line": 10385,
+            "line": 10402,
             "name": "repeat_min",
             "type": "integer"
           },
           {
-            "line": 10370,
+            "line": 10387,
             "name": "side_switch",
             "type": "boolean"
           },
           {
-            "line": 10388,
+            "line": 10405,
             "name": "stun_duration",
             "type": "integer"
           },
           {
-            "line": 10381,
+            "line": 10398,
             "name": "take_weapon",
             "type": "boolean"
           },
           {
-            "line": 10383,
+            "line": 10400,
             "name": "wall_adjacent",
             "type": "boolean"
           },
           {
-            "line": 10384,
+            "line": 10401,
             "name": "weight",
             "type": "integer"
           }
@@ -7937,22 +7937,22 @@
       {
         "fields": [
           {
-            "line": 10356,
+            "line": 10373,
             "name": "items",
             "type": "string[]"
           },
           {
-            "line": 10358,
+            "line": 10375,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 10357,
+            "line": 10374,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 10359,
+            "line": 10376,
             "name": "truncated",
             "type": "boolean"
           }
@@ -7962,22 +7962,22 @@
       {
         "fields": [
           {
-            "line": 10350,
+            "line": 10367,
             "name": "items",
             "type": "GameId[]"
           },
           {
-            "line": 10352,
+            "line": 10369,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 10351,
+            "line": 10368,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 10353,
+            "line": 10370,
             "name": "truncated",
             "type": "boolean"
           }
@@ -7987,22 +7987,22 @@
       {
         "fields": [
           {
-            "line": 10641,
+            "line": 10658,
             "name": "season_id",
             "type": "string"
           },
           {
-            "line": 10642,
+            "line": 10659,
             "name": "season_name",
             "type": "string"
           },
           {
-            "line": 10639,
+            "line": 10656,
             "name": "turn",
             "type": "integer"
           },
           {
-            "line": 10640,
+            "line": 10657,
             "name": "year",
             "type": "integer"
           }
@@ -8506,6 +8506,31 @@
       {
         "fields": [],
         "name": "CcbTypesApi"
+      },
+      {
+        "fields": [
+          {
+            "line": 10018,
+            "name": "value",
+            "type": "CcbVariableCopyValue"
+          }
+        ],
+        "name": "CcbVariableCopyResult"
+      },
+      {
+        "fields": [
+          {
+            "line": 10015,
+            "name": "destination_existed",
+            "type": "boolean"
+          },
+          {
+            "line": 10014,
+            "name": "source_exists",
+            "type": "boolean"
+          }
+        ],
+        "name": "CcbVariableCopyValue"
       },
       {
         "fields": [
@@ -9407,22 +9432,22 @@
       {
         "fields": [
           {
-            "line": 10645,
+            "line": 10662,
             "name": "id",
             "type": "string"
           },
           {
-            "line": 10646,
+            "line": 10663,
             "name": "temperature_c",
             "type": "number"
           },
           {
-            "line": 10648,
+            "line": 10665,
             "name": "wind_direction",
             "type": "number"
           },
           {
-            "line": 10647,
+            "line": 10664,
             "name": "wind_speed",
             "type": "number"
           }
@@ -20078,7 +20103,7 @@
         "name": "ZoneTypeDefinitionOptions"
       }
     ],
-    "function_count": 1278,
+    "function_count": 1279,
     "functions": [
       {
         "line": "2713",
@@ -20621,43 +20646,43 @@
         "parameters": "character, body_part_limit"
       },
       {
-        "line": "10631",
+        "line": "10648",
         "name": "nearby",
         "owner": "CcbCreaturesApi",
         "parameters": "observer, options"
       },
       {
-        "line": "10626",
+        "line": "10643",
         "name": "snapshot",
         "owner": "CcbCreaturesApi",
         "parameters": "handle"
       },
       {
-        "line": "10636",
+        "line": "10653",
         "name": "visible_monsters",
         "owner": "CcbCreaturesApi",
         "parameters": "observer, direction"
       },
       {
-        "line": "10109",
+        "line": "10126",
         "name": "add",
         "owner": "CcbEffectsApi",
         "parameters": "character, effect, duration, options"
       },
       {
-        "line": "10124",
+        "line": "10141",
         "name": "get",
         "owner": "CcbEffectsApi",
         "parameters": "character, effect, body_part"
       },
       {
-        "line": "10117",
+        "line": "10134",
         "name": "has",
         "owner": "CcbEffectsApi",
         "parameters": "character, effect, body_part, intensity"
       },
       {
-        "line": "10131",
+        "line": "10148",
         "name": "remove",
         "owner": "CcbEffectsApi",
         "parameters": "character, effect, body_part"
@@ -21329,61 +21354,61 @@
         "parameters": "character, morale"
       },
       {
-        "line": "10170",
+        "line": "10187",
         "name": "grant",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation, variant"
       },
       {
-        "line": "10140",
+        "line": "10157",
         "name": "has",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation"
       },
       {
-        "line": "10154",
+        "line": "10171",
         "name": "is_purifiable",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation"
       },
       {
-        "line": "10147",
+        "line": "10164",
         "name": "is_visible_to",
         "owner": "CcbMutationsApi",
         "parameters": "observed, observer, mutation"
       },
       {
-        "line": "10199",
+        "line": "10216",
         "name": "mutate_category",
         "owner": "CcbMutationsApi",
         "parameters": "character, category, use_vitamins, true_random"
       },
       {
-        "line": "10177",
+        "line": "10194",
         "name": "remove",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation"
       },
       {
-        "line": "10191",
+        "line": "10208",
         "name": "remove_category",
         "owner": "CcbMutationsApi",
         "parameters": "character, category"
       },
       {
-        "line": "10208",
+        "line": "10225",
         "name": "remove_type",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation_type"
       },
       {
-        "line": "10185",
+        "line": "10202",
         "name": "set_active",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation, active"
       },
       {
-        "line": "10162",
+        "line": "10179",
         "name": "set_purifiable",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation, purifiable"
@@ -21935,19 +21960,19 @@
         "parameters": "character_handle, npc_handle, duration"
       },
       {
-        "line": "10228",
+        "line": "10245",
         "name": "grant",
         "owner": "CcbPlatformBionicsApi",
         "parameters": "character, id"
       },
       {
-        "line": "10234",
+        "line": "10251",
         "name": "remove_type",
         "owner": "CcbPlatformBionicsApi",
         "parameters": "character, id"
       },
       {
-        "line": "10222",
+        "line": "10239",
         "name": "summary",
         "owner": "CcbPlatformBionicsApi",
         "parameters": "character"
@@ -23687,67 +23712,67 @@
         "parameters": "dimension"
       },
       {
-        "line": "10498",
+        "line": "10515",
         "name": "dimension",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": ""
       },
       {
-        "line": "10536",
+        "line": "10553",
         "name": "field_exists",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position, field_id"
       },
       {
-        "line": "10519",
+        "line": "10536",
         "name": "furniture_has_flag",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position, flag"
       },
       {
-        "line": "10531",
+        "line": "10548",
         "name": "furniture_id",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position"
       },
       {
-        "line": "10546",
+        "line": "10563",
         "name": "is_indoor_tile",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position"
       },
       {
-        "line": "10502",
+        "line": "10519",
         "name": "is_night",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": ""
       },
       {
-        "line": "10506",
+        "line": "10523",
         "name": "is_outside",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position"
       },
       {
-        "line": "10513",
+        "line": "10530",
         "name": "line_of_sight",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "from, to, range, with_fields"
       },
       {
-        "line": "10551",
+        "line": "10568",
         "name": "safe_mode_dangerous",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "direction"
       },
       {
-        "line": "10541",
+        "line": "10558",
         "name": "terrain_has_flag",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position, flag"
       },
       {
-        "line": "10525",
+        "line": "10542",
         "name": "terrain_id",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position"
@@ -23825,31 +23850,31 @@
         "parameters": "id"
       },
       {
-        "line": "10416",
+        "line": "10433",
         "name": "forget",
         "owner": "CcbPlatformMartialArtsApi",
         "parameters": "character, id"
       },
       {
-        "line": "10410",
+        "line": "10427",
         "name": "learn",
         "owner": "CcbPlatformMartialArtsApi",
         "parameters": "character, id"
       },
       {
-        "line": "10403",
+        "line": "10420",
         "name": "technique_definition",
         "owner": "CcbPlatformMartialArtsApi",
         "parameters": "id"
       },
       {
-        "line": "10578",
+        "line": "10595",
         "name": "apply",
         "owner": "CcbPlatformMathApi",
         "parameters": "expression, actor, context"
       },
       {
-        "line": "10571",
+        "line": "10588",
         "name": "evaluate",
         "owner": "CcbPlatformMathApi",
         "parameters": "expression, actor, context"
@@ -23873,7 +23898,7 @@
         "parameters": "message, type"
       },
       {
-        "line": "10492",
+        "line": "10509",
         "name": "is_loaded",
         "owner": "CcbPlatformModQueries",
         "parameters": "mod_id"
@@ -23885,13 +23910,13 @@
         "parameters": "id"
       },
       {
-        "line": "10433",
+        "line": "10450",
         "name": "add",
         "owner": "CcbPlatformMoraleApi",
         "parameters": "character, id, bonus, max_bonus, options"
       },
       {
-        "line": "10439",
+        "line": "10456",
         "name": "remove",
         "owner": "CcbPlatformMoraleApi",
         "parameters": "character, id"
@@ -23957,97 +23982,97 @@
         "parameters": "file, volume"
       },
       {
-        "line": "10452",
+        "line": "10469",
         "name": "chance",
         "owner": "CcbPlatformRandomApi",
         "parameters": "numerator, denominator"
       },
       {
-        "line": "10474",
+        "line": "10491",
         "name": "contested",
         "owner": "CcbPlatformRandomApi",
         "parameters": "check, difficulty, die_size"
       },
       {
-        "line": "10447",
+        "line": "10464",
         "name": "int",
         "owner": "CcbPlatformRandomApi",
         "parameters": "minimum, maximum"
       },
       {
-        "line": "10456",
+        "line": "10473",
         "name": "one_in",
         "owner": "CcbPlatformRandomApi",
         "parameters": "denominator"
       },
       {
-        "line": "10461",
+        "line": "10478",
         "name": "probability",
         "owner": "CcbPlatformRandomApi",
         "parameters": "numerator, denominator"
       },
       {
-        "line": "10468",
+        "line": "10485",
         "name": "sample_integers",
         "owner": "CcbPlatformRandomApi",
         "parameters": "minimum, maximum, count, with_replacement"
       },
       {
-        "line": "10278",
+        "line": "10295",
         "name": "all",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, options"
       },
       {
-        "line": "10288",
+        "line": "10305",
         "name": "by_flag",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "flag, character, options"
       },
       {
-        "line": "10283",
+        "line": "10300",
         "name": "by_skill",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "skill, character, options"
       },
       {
-        "line": "10330",
+        "line": "10347",
         "name": "forget",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, id"
       },
       {
-        "line": "10347",
+        "line": "10364",
         "name": "forget_category",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, category, subcategory"
       },
       {
-        "line": "10293",
+        "line": "10310",
         "name": "get",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, id, batch"
       },
       {
-        "line": "10297",
+        "line": "10314",
         "name": "has_flag",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "id, flag"
       },
       {
-        "line": "10318",
+        "line": "10335",
         "name": "knows",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, id"
       },
       {
-        "line": "10324",
+        "line": "10341",
         "name": "learn",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, id"
       },
       {
-        "line": "10274",
+        "line": "10291",
         "name": "list",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, options"
@@ -24089,115 +24114,115 @@
         "parameters": "event_name, handler_id"
       },
       {
-        "line": "10737",
+        "line": "10754",
         "name": "activity_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10727",
+        "line": "10744",
         "name": "bionics_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10674",
+        "line": "10691",
         "name": "character_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character"
       },
       {
-        "line": "10717",
+        "line": "10734",
         "name": "current_tile_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, field_limit"
       },
       {
-        "line": "10695",
+        "line": "10712",
         "name": "effects_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10705",
+        "line": "10722",
         "name": "equipment_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10690",
+        "line": "10707",
         "name": "inventory_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10712",
+        "line": "10729",
         "name": "item_contents_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, item_handle, offset, limit"
       },
       {
-        "line": "10650",
+        "line": "10667",
         "name": "message",
         "owner": "CcbPlatformServices",
         "parameters": "text"
       },
       {
-        "line": "10732",
+        "line": "10749",
         "name": "missions_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10678",
+        "line": "10695",
         "name": "movement_modes_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character"
       },
       {
-        "line": "10722",
+        "line": "10739",
         "name": "mutations_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10743",
+        "line": "10760",
         "name": "nearby_creatures_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, radius, limit"
       },
       {
-        "line": "10700",
+        "line": "10717",
         "name": "skills_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10681",
+        "line": "10698",
         "name": "time_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": ""
       },
       {
-        "line": "10657",
+        "line": "10674",
         "name": "translate",
         "owner": "CcbPlatformServices",
         "parameters": "text, context"
       },
       {
-        "line": "10667",
+        "line": "10684",
         "name": "translate_plural",
         "owner": "CcbPlatformServices",
         "parameters": "singular, plural, count, context"
       },
       {
-        "line": "10670",
+        "line": "10687",
         "name": "turn",
         "owner": "CcbPlatformServices",
         "parameters": ""
       },
       {
-        "line": "10684",
+        "line": "10701",
         "name": "weather_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": ""
@@ -24269,13 +24294,13 @@
         "parameters": "key, value"
       },
       {
-        "line": "10485",
+        "line": "10502",
         "name": "all_equal",
         "owner": "CcbPlatformStringPredicates",
         "parameters": "values"
       },
       {
-        "line": "10481",
+        "line": "10498",
         "name": "any_equal",
         "owner": "CcbPlatformStringPredicates",
         "parameters": "values"
@@ -24365,19 +24390,19 @@
         "parameters": "avatar, target, options"
       },
       {
-        "line": "10312",
+        "line": "10329",
         "name": "for_recipe",
         "owner": "CcbRequirementsApi",
         "parameters": "character, id, batch"
       },
       {
-        "line": "10307",
+        "line": "10324",
         "name": "get",
         "owner": "CcbRequirementsApi",
         "parameters": "character, id, batch"
       },
       {
-        "line": "10302",
+        "line": "10319",
         "name": "list",
         "owner": "CcbRequirementsApi",
         "parameters": "character, options"
@@ -24437,49 +24462,55 @@
         "parameters": ""
       },
       {
-        "line": "10016",
+        "line": "10028",
+        "name": "copy",
+        "owner": "CcbVariablesApi",
+        "parameters": "source_owner, source_key, destination_owner, destination_key"
+      },
+      {
+        "line": "10033",
         "name": "get",
         "owner": "CcbVariablesApi",
         "parameters": "character, key"
       },
       {
-        "line": "10033",
+        "line": "10050",
         "name": "get_global",
         "owner": "CcbVariablesApi",
         "parameters": "key"
       },
       {
-        "line": "10029",
+        "line": "10046",
         "name": "remove",
         "owner": "CcbVariablesApi",
         "parameters": "character, key"
       },
       {
-        "line": "10042",
+        "line": "10059",
         "name": "remove_global",
         "owner": "CcbVariablesApi",
         "parameters": "key"
       },
       {
-        "line": "10051",
+        "line": "10068",
         "name": "resolve",
         "owner": "CcbVariablesApi",
         "parameters": "context, actor, scope, key"
       },
       {
-        "line": "10024",
+        "line": "10041",
         "name": "set",
         "owner": "CcbVariablesApi",
         "parameters": "character, key, value"
       },
       {
-        "line": "10038",
+        "line": "10055",
         "name": "set_global",
         "owner": "CcbVariablesApi",
         "parameters": "key, value"
       },
       {
-        "line": "10060",
+        "line": "10077",
         "name": "set_resolved",
         "owner": "CcbVariablesApi",
         "parameters": "context, actor, scope, key, value"
@@ -30385,47 +30416,47 @@
   "public_root": {
     "fields": [
       {
-        "line": 10747,
+        "line": 10764,
         "name": "ModDefinition",
         "type": "fun(options:"
       },
       {
-        "line": 10748,
+        "line": 10765,
         "name": "content",
         "type": "CcbPlatformContent"
       },
       {
-        "line": 10750,
+        "line": 10767,
         "name": "dialogue",
         "type": "CcbPlatformDialogueApi"
       },
       {
-        "line": 10746,
+        "line": 10763,
         "name": "platform_version",
         "type": "1"
       },
       {
-        "line": 10753,
+        "line": 10770,
         "name": "presentation",
         "type": "CcbPlatformPresentation"
       },
       {
-        "line": 10749,
+        "line": 10766,
         "name": "runtime",
         "type": "CcbPlatformRuntime"
       },
       {
-        "line": 10754,
+        "line": 10771,
         "name": "services",
         "type": "CcbPlatformServices"
       },
       {
-        "line": 10751,
+        "line": 10768,
         "name": "state",
         "type": "CcbPlatformState"
       },
       {
-        "line": 10752,
+        "line": 10769,
         "name": "tasks",
         "type": "CcbPlatformTasks"
       }

--- a/data/lua/reference/ccb_platform_api_v1.json
+++ b/data/lua/reference/ccb_platform_api_v1.json
@@ -7,7 +7,7 @@
     "root_class": "CcbPlatformV1"
   },
   "lua_luals": {
-    "class_count": 692,
+    "class_count": 695,
     "classes": [
       {
         "fields": [
@@ -1230,27 +1230,27 @@
       {
         "fields": [
           {
-            "line": 10510,
+            "line": 10564,
             "name": "items",
             "type": "table"
           },
           {
-            "line": 10513,
+            "line": 10567,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 10512,
+            "line": 10566,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 10511,
+            "line": 10565,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 10514,
+            "line": 10568,
             "name": "truncated",
             "type": "boolean"
           }
@@ -2450,67 +2450,67 @@
       {
         "fields": [
           {
-            "line": 10497,
+            "line": 10551,
             "name": "focus",
             "type": "integer"
           },
           {
-            "line": 10499,
+            "line": 10553,
             "name": "hunger",
             "type": "integer"
           },
           {
-            "line": 10493,
+            "line": 10547,
             "name": "moves",
             "type": "integer"
           },
           {
-            "line": 10489,
+            "line": 10543,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 10496,
+            "line": 10550,
             "name": "pain",
             "type": "integer"
           },
           {
-            "line": 10501,
+            "line": 10555,
             "name": "sleepiness",
             "type": "integer"
           },
           {
-            "line": 10498,
+            "line": 10552,
             "name": "speed",
             "type": "integer"
           },
           {
-            "line": 10494,
+            "line": 10548,
             "name": "stamina",
             "type": "integer"
           },
           {
-            "line": 10495,
+            "line": 10549,
             "name": "stamina_max",
             "type": "integer"
           },
           {
-            "line": 10500,
+            "line": 10554,
             "name": "thirst",
             "type": "integer"
           },
           {
-            "line": 10490,
+            "line": 10544,
             "name": "x",
             "type": "integer"
           },
           {
-            "line": 10491,
+            "line": 10545,
             "name": "y",
             "type": "integer"
           },
           {
-            "line": 10492,
+            "line": 10546,
             "name": "z",
             "type": "integer"
           }
@@ -2544,52 +2544,52 @@
       {
         "fields": [
           {
-            "line": 10523,
+            "line": 10577,
             "name": "attitude",
             "type": "string"
           },
           {
-            "line": 10524,
+            "line": 10578,
             "name": "dead",
             "type": "boolean"
           },
           {
-            "line": 10519,
+            "line": 10573,
             "name": "display_name",
             "type": "string"
           },
           {
-            "line": 10522,
+            "line": 10576,
             "name": "distance",
             "type": "integer"
           },
           {
-            "line": 10525,
+            "line": 10579,
             "name": "hp",
             "type": "integer"
           },
           {
-            "line": 10526,
+            "line": 10580,
             "name": "hp_max",
             "type": "integer"
           },
           {
-            "line": 10517,
+            "line": 10571,
             "name": "kind",
             "type": "'avatar'|'npc'|'monster'|'creature'"
           },
           {
-            "line": 10518,
+            "line": 10572,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 10520,
+            "line": 10574,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 10521,
+            "line": 10575,
             "name": "visible",
             "type": "boolean"
           }
@@ -5211,22 +5211,22 @@
       {
         "fields": [
           {
-            "line": 10505,
+            "line": 10559,
             "name": "count",
             "type": "integer"
           },
           {
-            "line": 10506,
+            "line": 10560,
             "name": "current_id",
             "type": "string"
           },
           {
-            "line": 10507,
+            "line": 10561,
             "name": "desired_id",
             "type": "string"
           },
           {
-            "line": 10504,
+            "line": 10558,
             "name": "items",
             "type": "table"
           }
@@ -6493,27 +6493,27 @@
       {
         "fields": [
           {
-            "line": 10464,
+            "line": 10518,
             "name": "environment",
             "type": "CcbPlatformEnvironmentQueries"
           },
           {
-            "line": 10463,
+            "line": 10517,
             "name": "math",
             "type": "CcbPlatformMathApi"
           },
           {
-            "line": 10462,
+            "line": 10516,
             "name": "mods",
             "type": "CcbPlatformModQueries"
           },
           {
-            "line": 10465,
+            "line": 10519,
             "name": "options",
             "type": "CcbPlatformGameplayOptionsApi"
           },
           {
-            "line": 10461,
+            "line": 10515,
             "name": "strings",
             "type": "CcbPlatformStringPredicates"
           }
@@ -6654,17 +6654,17 @@
       {
         "fields": [
           {
-            "line": 10328,
+            "line": 10382,
             "name": "capped",
             "type": "boolean"
           },
           {
-            "line": 10327,
+            "line": 10381,
             "name": "decay_start",
             "type": "TimeDuration"
           },
           {
-            "line": 10326,
+            "line": 10380,
             "name": "duration",
             "type": "TimeDuration"
           }
@@ -7377,47 +7377,47 @@
       {
         "fields": [
           {
-            "line": 10654,
+            "line": 10708,
             "name": "ModDefinition",
             "type": "fun(options:"
           },
           {
-            "line": 10655,
+            "line": 10709,
             "name": "content",
             "type": "CcbPlatformContent"
           },
           {
-            "line": 10657,
+            "line": 10711,
             "name": "dialogue",
             "type": "CcbPlatformDialogueApi"
           },
           {
-            "line": 10653,
+            "line": 10707,
             "name": "platform_version",
             "type": "1"
           },
           {
-            "line": 10660,
+            "line": 10714,
             "name": "presentation",
             "type": "CcbPlatformPresentation"
           },
           {
-            "line": 10656,
+            "line": 10710,
             "name": "runtime",
             "type": "CcbPlatformRuntime"
           },
           {
-            "line": 10661,
+            "line": 10715,
             "name": "services",
             "type": "CcbPlatformServices"
           },
           {
-            "line": 10658,
+            "line": 10712,
             "name": "state",
             "type": "CcbPlatformState"
           },
           {
-            "line": 10659,
+            "line": 10713,
             "name": "tasks",
             "type": "CcbPlatformTasks"
           }
@@ -7687,22 +7687,247 @@
       {
         "fields": [
           {
-            "line": 10548,
+            "line": 10353,
+            "name": "area",
+            "type": "string"
+          },
+          {
+            "line": 10355,
+            "name": "attack_vectors",
+            "type": "CcbTechniqueIdPage"
+          },
+          {
+            "line": 10328,
+            "name": "avatar_message",
+            "type": "string"
+          },
+          {
+            "line": 10338,
+            "name": "block_counter",
+            "type": "boolean"
+          },
+          {
+            "line": 10334,
+            "name": "critical_compatible",
+            "type": "boolean"
+          },
+          {
+            "line": 10333,
+            "name": "critical_only",
+            "type": "boolean"
+          },
+          {
+            "line": 10330,
+            "name": "defensive",
+            "type": "boolean"
+          },
+          {
+            "line": 10325,
+            "name": "description",
+            "type": "string"
+          },
+          {
+            "line": 10341,
+            "name": "disarms",
+            "type": "boolean"
+          },
+          {
+            "line": 10337,
+            "name": "dodge_counter",
+            "type": "boolean"
+          },
+          {
+            "line": 10348,
+            "name": "down_duration",
+            "type": "integer"
+          },
+          {
+            "line": 10332,
+            "name": "dummy",
+            "type": "boolean"
+          },
+          {
+            "line": 10356,
+            "name": "eocs",
+            "type": "CcbTechniqueIdPage"
+          },
+          {
+            "line": 10354,
+            "name": "flags",
+            "type": "CcbTechniqueFlagPage"
+          },
+          {
+            "line": 10326,
+            "name": "flavor_description",
+            "type": "string"
+          },
+          {
+            "line": 10327,
+            "name": "goal",
+            "type": "string"
+          },
+          {
+            "line": 10340,
+            "name": "grab_break",
+            "type": "boolean"
+          },
+          {
+            "line": 10323,
+            "name": "id",
+            "type": "GameId"
+          },
+          {
+            "line": 10350,
+            "name": "knockback_distance",
+            "type": "integer"
+          },
+          {
+            "line": 10352,
+            "name": "knockback_follow",
+            "type": "boolean"
+          },
+          {
+            "line": 10351,
+            "name": "knockback_spread",
+            "type": "number"
+          },
+          {
+            "line": 10339,
+            "name": "miss_recovery",
+            "type": "boolean"
+          },
+          {
+            "line": 10324,
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "line": 10343,
+            "name": "needs_ammo",
+            "type": "boolean"
+          },
+          {
+            "line": 10329,
+            "name": "npc_message",
+            "type": "string"
+          },
+          {
+            "line": 10336,
+            "name": "reach_compatible",
+            "type": "boolean"
+          },
+          {
+            "line": 10335,
+            "name": "reach_only",
+            "type": "boolean"
+          },
+          {
+            "line": 10347,
+            "name": "repeat_max",
+            "type": "integer"
+          },
+          {
+            "line": 10346,
+            "name": "repeat_min",
+            "type": "integer"
+          },
+          {
+            "line": 10331,
+            "name": "side_switch",
+            "type": "boolean"
+          },
+          {
+            "line": 10349,
+            "name": "stun_duration",
+            "type": "integer"
+          },
+          {
+            "line": 10342,
+            "name": "take_weapon",
+            "type": "boolean"
+          },
+          {
+            "line": 10344,
+            "name": "wall_adjacent",
+            "type": "boolean"
+          },
+          {
+            "line": 10345,
+            "name": "weight",
+            "type": "integer"
+          }
+        ],
+        "name": "CcbTechniqueDefinitionSnapshot"
+      },
+      {
+        "fields": [
+          {
+            "line": 10317,
+            "name": "items",
+            "type": "string[]"
+          },
+          {
+            "line": 10319,
+            "name": "returned",
+            "type": "integer"
+          },
+          {
+            "line": 10318,
+            "name": "total",
+            "type": "integer"
+          },
+          {
+            "line": 10320,
+            "name": "truncated",
+            "type": "boolean"
+          }
+        ],
+        "name": "CcbTechniqueFlagPage"
+      },
+      {
+        "fields": [
+          {
+            "line": 10311,
+            "name": "items",
+            "type": "GameId[]"
+          },
+          {
+            "line": 10313,
+            "name": "returned",
+            "type": "integer"
+          },
+          {
+            "line": 10312,
+            "name": "total",
+            "type": "integer"
+          },
+          {
+            "line": 10314,
+            "name": "truncated",
+            "type": "boolean"
+          }
+        ],
+        "name": "CcbTechniqueIdPage"
+      },
+      {
+        "fields": [
+          {
+            "line": 10602,
             "name": "season_id",
             "type": "string"
           },
           {
-            "line": 10549,
+            "line": 10603,
             "name": "season_name",
             "type": "string"
           },
           {
-            "line": 10546,
+            "line": 10600,
             "name": "turn",
             "type": "integer"
           },
           {
-            "line": 10547,
+            "line": 10601,
             "name": "year",
             "type": "integer"
           }
@@ -9107,22 +9332,22 @@
       {
         "fields": [
           {
-            "line": 10552,
+            "line": 10606,
             "name": "id",
             "type": "string"
           },
           {
-            "line": 10553,
+            "line": 10607,
             "name": "temperature_c",
             "type": "number"
           },
           {
-            "line": 10555,
+            "line": 10609,
             "name": "wind_direction",
             "type": "number"
           },
           {
-            "line": 10554,
+            "line": 10608,
             "name": "wind_speed",
             "type": "number"
           }
@@ -19733,7 +19958,7 @@
         "name": "ZoneTypeDefinitionOptions"
       }
     ],
-    "function_count": 1276,
+    "function_count": 1277,
     "functions": [
       {
         "line": "2713",
@@ -20270,19 +20495,19 @@
         "parameters": "character, body_part_limit"
       },
       {
-        "line": "10538",
+        "line": "10592",
         "name": "nearby",
         "owner": "CcbCreaturesApi",
         "parameters": "observer, options"
       },
       {
-        "line": "10533",
+        "line": "10587",
         "name": "snapshot",
         "owner": "CcbCreaturesApi",
         "parameters": "handle"
       },
       {
-        "line": "10543",
+        "line": "10597",
         "name": "visible_monsters",
         "owner": "CcbCreaturesApi",
         "parameters": "observer, direction"
@@ -23336,67 +23561,67 @@
         "parameters": "dimension"
       },
       {
-        "line": "10405",
+        "line": "10459",
         "name": "dimension",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": ""
       },
       {
-        "line": "10443",
+        "line": "10497",
         "name": "field_exists",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position, field_id"
       },
       {
-        "line": "10426",
+        "line": "10480",
         "name": "furniture_has_flag",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position, flag"
       },
       {
-        "line": "10438",
+        "line": "10492",
         "name": "furniture_id",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position"
       },
       {
-        "line": "10453",
+        "line": "10507",
         "name": "is_indoor_tile",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position"
       },
       {
-        "line": "10409",
+        "line": "10463",
         "name": "is_night",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": ""
       },
       {
-        "line": "10413",
+        "line": "10467",
         "name": "is_outside",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position"
       },
       {
-        "line": "10420",
+        "line": "10474",
         "name": "line_of_sight",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "from, to, range, with_fields"
       },
       {
-        "line": "10458",
+        "line": "10512",
         "name": "safe_mode_dangerous",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "direction"
       },
       {
-        "line": "10448",
+        "line": "10502",
         "name": "terrain_has_flag",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position, flag"
       },
       {
-        "line": "10432",
+        "line": "10486",
         "name": "terrain_id",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position"
@@ -23474,25 +23699,31 @@
         "parameters": "id"
       },
       {
-        "line": "10323",
+        "line": "10377",
         "name": "forget",
         "owner": "CcbPlatformMartialArtsApi",
         "parameters": "character, id"
       },
       {
-        "line": "10317",
+        "line": "10371",
         "name": "learn",
         "owner": "CcbPlatformMartialArtsApi",
         "parameters": "character, id"
       },
       {
-        "line": "10485",
+        "line": "10364",
+        "name": "technique_definition",
+        "owner": "CcbPlatformMartialArtsApi",
+        "parameters": "id"
+      },
+      {
+        "line": "10539",
         "name": "apply",
         "owner": "CcbPlatformMathApi",
         "parameters": "expression, actor, context"
       },
       {
-        "line": "10478",
+        "line": "10532",
         "name": "evaluate",
         "owner": "CcbPlatformMathApi",
         "parameters": "expression, actor, context"
@@ -23516,7 +23747,7 @@
         "parameters": "message, type"
       },
       {
-        "line": "10399",
+        "line": "10453",
         "name": "is_loaded",
         "owner": "CcbPlatformModQueries",
         "parameters": "mod_id"
@@ -23528,13 +23759,13 @@
         "parameters": "id"
       },
       {
-        "line": "10340",
+        "line": "10394",
         "name": "add",
         "owner": "CcbPlatformMoraleApi",
         "parameters": "character, id, bonus, max_bonus, options"
       },
       {
-        "line": "10346",
+        "line": "10400",
         "name": "remove",
         "owner": "CcbPlatformMoraleApi",
         "parameters": "character, id"
@@ -23600,37 +23831,37 @@
         "parameters": "file, volume"
       },
       {
-        "line": "10359",
+        "line": "10413",
         "name": "chance",
         "owner": "CcbPlatformRandomApi",
         "parameters": "numerator, denominator"
       },
       {
-        "line": "10381",
+        "line": "10435",
         "name": "contested",
         "owner": "CcbPlatformRandomApi",
         "parameters": "check, difficulty, die_size"
       },
       {
-        "line": "10354",
+        "line": "10408",
         "name": "int",
         "owner": "CcbPlatformRandomApi",
         "parameters": "minimum, maximum"
       },
       {
-        "line": "10363",
+        "line": "10417",
         "name": "one_in",
         "owner": "CcbPlatformRandomApi",
         "parameters": "denominator"
       },
       {
-        "line": "10368",
+        "line": "10422",
         "name": "probability",
         "owner": "CcbPlatformRandomApi",
         "parameters": "numerator, denominator"
       },
       {
-        "line": "10375",
+        "line": "10429",
         "name": "sample_integers",
         "owner": "CcbPlatformRandomApi",
         "parameters": "minimum, maximum, count, with_replacement"
@@ -23732,115 +23963,115 @@
         "parameters": "event_name, handler_id"
       },
       {
-        "line": "10644",
+        "line": "10698",
         "name": "activity_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10634",
+        "line": "10688",
         "name": "bionics_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10581",
+        "line": "10635",
         "name": "character_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character"
       },
       {
-        "line": "10624",
+        "line": "10678",
         "name": "current_tile_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, field_limit"
       },
       {
-        "line": "10602",
+        "line": "10656",
         "name": "effects_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10612",
+        "line": "10666",
         "name": "equipment_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10597",
+        "line": "10651",
         "name": "inventory_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10619",
+        "line": "10673",
         "name": "item_contents_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, item_handle, offset, limit"
       },
       {
-        "line": "10557",
+        "line": "10611",
         "name": "message",
         "owner": "CcbPlatformServices",
         "parameters": "text"
       },
       {
-        "line": "10639",
+        "line": "10693",
         "name": "missions_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10585",
+        "line": "10639",
         "name": "movement_modes_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character"
       },
       {
-        "line": "10629",
+        "line": "10683",
         "name": "mutations_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10650",
+        "line": "10704",
         "name": "nearby_creatures_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, radius, limit"
       },
       {
-        "line": "10607",
+        "line": "10661",
         "name": "skills_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10588",
+        "line": "10642",
         "name": "time_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": ""
       },
       {
-        "line": "10564",
+        "line": "10618",
         "name": "translate",
         "owner": "CcbPlatformServices",
         "parameters": "text, context"
       },
       {
-        "line": "10574",
+        "line": "10628",
         "name": "translate_plural",
         "owner": "CcbPlatformServices",
         "parameters": "singular, plural, count, context"
       },
       {
-        "line": "10577",
+        "line": "10631",
         "name": "turn",
         "owner": "CcbPlatformServices",
         "parameters": ""
       },
       {
-        "line": "10591",
+        "line": "10645",
         "name": "weather_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": ""
@@ -23912,13 +24143,13 @@
         "parameters": "key, value"
       },
       {
-        "line": "10392",
+        "line": "10446",
         "name": "all_equal",
         "owner": "CcbPlatformStringPredicates",
         "parameters": "values"
       },
       {
-        "line": "10388",
+        "line": "10442",
         "name": "any_equal",
         "owner": "CcbPlatformStringPredicates",
         "parameters": "values"
@@ -30028,47 +30259,47 @@
   "public_root": {
     "fields": [
       {
-        "line": 10654,
+        "line": 10708,
         "name": "ModDefinition",
         "type": "fun(options:"
       },
       {
-        "line": 10655,
+        "line": 10709,
         "name": "content",
         "type": "CcbPlatformContent"
       },
       {
-        "line": 10657,
+        "line": 10711,
         "name": "dialogue",
         "type": "CcbPlatformDialogueApi"
       },
       {
-        "line": 10653,
+        "line": 10707,
         "name": "platform_version",
         "type": "1"
       },
       {
-        "line": 10660,
+        "line": 10714,
         "name": "presentation",
         "type": "CcbPlatformPresentation"
       },
       {
-        "line": 10656,
+        "line": 10710,
         "name": "runtime",
         "type": "CcbPlatformRuntime"
       },
       {
-        "line": 10661,
+        "line": 10715,
         "name": "services",
         "type": "CcbPlatformServices"
       },
       {
-        "line": 10658,
+        "line": 10712,
         "name": "state",
         "type": "CcbPlatformState"
       },
       {
-        "line": 10659,
+        "line": 10713,
         "name": "tasks",
         "type": "CcbPlatformTasks"
       }

--- a/data/lua/reference/ccb_platform_api_v1.json
+++ b/data/lua/reference/ccb_platform_api_v1.json
@@ -1230,27 +1230,27 @@
       {
         "fields": [
           {
-            "line": 10601,
+            "line": 10603,
             "name": "items",
             "type": "table"
           },
           {
-            "line": 10604,
+            "line": 10606,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 10603,
+            "line": 10605,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 10602,
+            "line": 10604,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 10605,
+            "line": 10607,
             "name": "truncated",
             "type": "boolean"
           }
@@ -2450,67 +2450,67 @@
       {
         "fields": [
           {
-            "line": 10588,
+            "line": 10590,
             "name": "focus",
             "type": "integer"
           },
           {
-            "line": 10590,
+            "line": 10592,
             "name": "hunger",
             "type": "integer"
           },
           {
-            "line": 10584,
+            "line": 10586,
             "name": "moves",
             "type": "integer"
           },
           {
-            "line": 10580,
+            "line": 10582,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 10587,
+            "line": 10589,
             "name": "pain",
             "type": "integer"
           },
           {
-            "line": 10592,
+            "line": 10594,
             "name": "sleepiness",
             "type": "integer"
           },
           {
-            "line": 10589,
+            "line": 10591,
             "name": "speed",
             "type": "integer"
           },
           {
-            "line": 10585,
+            "line": 10587,
             "name": "stamina",
             "type": "integer"
           },
           {
-            "line": 10586,
+            "line": 10588,
             "name": "stamina_max",
             "type": "integer"
           },
           {
-            "line": 10591,
+            "line": 10593,
             "name": "thirst",
             "type": "integer"
           },
           {
-            "line": 10581,
+            "line": 10583,
             "name": "x",
             "type": "integer"
           },
           {
-            "line": 10582,
+            "line": 10584,
             "name": "y",
             "type": "integer"
           },
           {
-            "line": 10583,
+            "line": 10585,
             "name": "z",
             "type": "integer"
           }
@@ -2544,52 +2544,52 @@
       {
         "fields": [
           {
-            "line": 10614,
+            "line": 10616,
             "name": "attitude",
             "type": "string"
           },
           {
-            "line": 10615,
+            "line": 10617,
             "name": "dead",
             "type": "boolean"
           },
           {
-            "line": 10610,
+            "line": 10612,
             "name": "display_name",
             "type": "string"
           },
           {
-            "line": 10613,
+            "line": 10615,
             "name": "distance",
             "type": "integer"
           },
           {
-            "line": 10616,
+            "line": 10618,
             "name": "hp",
             "type": "integer"
           },
           {
-            "line": 10617,
+            "line": 10619,
             "name": "hp_max",
             "type": "integer"
           },
           {
-            "line": 10608,
+            "line": 10610,
             "name": "kind",
             "type": "'avatar'|'npc'|'monster'|'creature'"
           },
           {
-            "line": 10609,
+            "line": 10611,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 10611,
+            "line": 10613,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 10612,
+            "line": 10614,
             "name": "visible",
             "type": "boolean"
           }
@@ -2648,22 +2648,22 @@
       {
         "fields": [
           {
-            "line": 10061,
+            "line": 10063,
             "name": "items",
             "type": "GameId[]"
           },
           {
-            "line": 10063,
+            "line": 10065,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 10062,
+            "line": 10064,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 10064,
+            "line": 10066,
             "name": "truncated",
             "type": "boolean"
           }
@@ -2673,12 +2673,12 @@
       {
         "fields": [
           {
-            "line": 10068,
+            "line": 10070,
             "name": "effects",
             "type": "CcbEffectRelatedIdPage"
           },
           {
-            "line": 10067,
+            "line": 10069,
             "name": "mutations",
             "type": "CcbEffectRelatedIdPage"
           }
@@ -2688,112 +2688,112 @@
       {
         "fields": [
           {
-            "line": 10092,
+            "line": 10094,
             "name": "blocks_effects",
             "type": "CcbEffectRelatedIdPage"
           },
           {
-            "line": 10090,
+            "line": 10092,
             "name": "body_part",
             "type": "GameId"
           },
           {
-            "line": 10073,
+            "line": 10075,
             "name": "description",
             "type": "string"
           },
           {
-            "line": 10077,
+            "line": 10079,
             "name": "duration",
             "type": "TimeDuration"
           },
           {
-            "line": 10087,
+            "line": 10089,
             "name": "duration_add_percent",
             "type": "integer"
           },
           {
-            "line": 10083,
+            "line": 10085,
             "name": "effective_intensity",
             "type": "integer"
           },
           {
-            "line": 10086,
+            "line": 10088,
             "name": "harmful_cough",
             "type": "boolean"
           },
           {
-            "line": 10071,
+            "line": 10073,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 10085,
+            "line": 10087,
             "name": "impairs_movement",
             "type": "boolean"
           },
           {
-            "line": 10080,
+            "line": 10082,
             "name": "intensity",
             "type": "integer"
           },
           {
-            "line": 10088,
+            "line": 10090,
             "name": "intensity_add",
             "type": "integer"
           },
           {
-            "line": 10089,
+            "line": 10091,
             "name": "intensity_duration",
             "type": "TimeDuration"
           },
           {
-            "line": 10078,
+            "line": 10080,
             "name": "maximum_duration",
             "type": "TimeDuration"
           },
           {
-            "line": 10082,
+            "line": 10084,
             "name": "maximum_effective_intensity",
             "type": "integer"
           },
           {
-            "line": 10081,
+            "line": 10083,
             "name": "maximum_intensity",
             "type": "integer"
           },
           {
-            "line": 10075,
+            "line": 10077,
             "name": "mod_source",
             "type": "string"
           },
           {
-            "line": 10072,
+            "line": 10074,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 10084,
+            "line": 10086,
             "name": "permanent",
             "type": "boolean"
           },
           {
-            "line": 10091,
+            "line": 10093,
             "name": "resisted_by",
             "type": "CcbEffectResistanceIds"
           },
           {
-            "line": 10074,
+            "line": 10076,
             "name": "short_description",
             "type": "string"
           },
           {
-            "line": 10079,
+            "line": 10081,
             "name": "start_time",
             "type": "TimePoint"
           },
           {
-            "line": 10076,
+            "line": 10078,
             "name": "uses_body_part_description",
             "type": "boolean"
           }
@@ -2803,7 +2803,7 @@
       {
         "fields": [
           {
-            "line": 10095,
+            "line": 10097,
             "name": "value",
             "type": "CcbEffectSnapshot"
           }
@@ -5211,22 +5211,22 @@
       {
         "fields": [
           {
-            "line": 10596,
+            "line": 10598,
             "name": "count",
             "type": "integer"
           },
           {
-            "line": 10597,
+            "line": 10599,
             "name": "current_id",
             "type": "string"
           },
           {
-            "line": 10598,
+            "line": 10600,
             "name": "desired_id",
             "type": "string"
           },
           {
-            "line": 10595,
+            "line": 10597,
             "name": "items",
             "type": "table"
           }
@@ -6182,22 +6182,22 @@
       {
         "fields": [
           {
-            "line": 10215,
+            "line": 10217,
             "name": "has_capacity",
             "type": "boolean"
           },
           {
-            "line": 10212,
+            "line": 10214,
             "name": "installed_count",
             "type": "integer"
           },
           {
-            "line": 10214,
+            "line": 10216,
             "name": "maximum_power",
             "type": "UnitValue"
           },
           {
-            "line": 10213,
+            "line": 10215,
             "name": "power",
             "type": "UnitValue"
           }
@@ -6493,27 +6493,27 @@
       {
         "fields": [
           {
-            "line": 10555,
+            "line": 10557,
             "name": "environment",
             "type": "CcbPlatformEnvironmentQueries"
           },
           {
-            "line": 10554,
+            "line": 10556,
             "name": "math",
             "type": "CcbPlatformMathApi"
           },
           {
-            "line": 10553,
+            "line": 10555,
             "name": "mods",
             "type": "CcbPlatformModQueries"
           },
           {
-            "line": 10556,
+            "line": 10558,
             "name": "options",
             "type": "CcbPlatformGameplayOptionsApi"
           },
           {
-            "line": 10552,
+            "line": 10554,
             "name": "strings",
             "type": "CcbPlatformStringPredicates"
           }
@@ -6654,17 +6654,17 @@
       {
         "fields": [
           {
-            "line": 10419,
+            "line": 10421,
             "name": "capped",
             "type": "boolean"
           },
           {
-            "line": 10418,
+            "line": 10420,
             "name": "decay_start",
             "type": "TimeDuration"
           },
           {
-            "line": 10417,
+            "line": 10419,
             "name": "duration",
             "type": "TimeDuration"
           }
@@ -6746,32 +6746,32 @@
       {
         "fields": [
           {
-            "line": 10335,
+            "line": 10337,
             "name": "category",
             "type": "GameId"
           },
           {
-            "line": 10331,
+            "line": 10333,
             "name": "changed",
             "type": "boolean"
           },
           {
-            "line": 10332,
+            "line": 10334,
             "name": "forgotten_count",
             "type": "integer"
           },
           {
-            "line": 10334,
+            "line": 10336,
             "name": "known_after",
             "type": "integer"
           },
           {
-            "line": 10333,
+            "line": 10335,
             "name": "known_before",
             "type": "integer"
           },
           {
-            "line": 10336,
+            "line": 10338,
             "name": "subcategory",
             "type": "string"
           }
@@ -7377,47 +7377,47 @@
       {
         "fields": [
           {
-            "line": 10745,
+            "line": 10747,
             "name": "ModDefinition",
             "type": "fun(options:"
           },
           {
-            "line": 10746,
+            "line": 10748,
             "name": "content",
             "type": "CcbPlatformContent"
           },
           {
-            "line": 10748,
+            "line": 10750,
             "name": "dialogue",
             "type": "CcbPlatformDialogueApi"
           },
           {
-            "line": 10744,
+            "line": 10746,
             "name": "platform_version",
             "type": "1"
           },
           {
-            "line": 10751,
+            "line": 10753,
             "name": "presentation",
             "type": "CcbPlatformPresentation"
           },
           {
-            "line": 10747,
+            "line": 10749,
             "name": "runtime",
             "type": "CcbPlatformRuntime"
           },
           {
-            "line": 10752,
+            "line": 10754,
             "name": "services",
             "type": "CcbPlatformServices"
           },
           {
-            "line": 10749,
+            "line": 10751,
             "name": "state",
             "type": "CcbPlatformState"
           },
           {
-            "line": 10750,
+            "line": 10752,
             "name": "tasks",
             "type": "CcbPlatformTasks"
           }
@@ -7486,37 +7486,37 @@
       {
         "fields": [
           {
-            "line": 10252,
+            "line": 10254,
             "name": "batch",
             "type": "integer"
           },
           {
-            "line": 10251,
+            "line": 10253,
             "name": "has_more",
             "type": "boolean"
           },
           {
-            "line": 10246,
+            "line": 10248,
             "name": "items",
             "type": "table"
           },
           {
-            "line": 10249,
+            "line": 10251,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 10248,
+            "line": 10250,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 10250,
+            "line": 10252,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 10247,
+            "line": 10249,
             "name": "total",
             "type": "integer"
           }
@@ -7526,47 +7526,47 @@
       {
         "fields": [
           {
-            "line": 10237,
+            "line": 10239,
             "name": "batch",
             "type": "integer"
           },
           {
-            "line": 10240,
+            "line": 10242,
             "name": "craftable",
             "type": "boolean"
           },
           {
-            "line": 10243,
+            "line": 10245,
             "name": "flag",
             "type": "string"
           },
           {
-            "line": 10238,
+            "line": 10240,
             "name": "include_obsolete",
             "type": "boolean"
           },
           {
-            "line": 10239,
+            "line": 10241,
             "name": "known",
             "type": "boolean"
           },
           {
-            "line": 10236,
+            "line": 10238,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 10235,
+            "line": 10237,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 10242,
+            "line": 10244,
             "name": "result",
             "type": "GameId"
           },
           {
-            "line": 10241,
+            "line": 10243,
             "name": "skill",
             "type": "GameId"
           }
@@ -7639,17 +7639,17 @@
       {
         "fields": [
           {
-            "line": 10257,
+            "line": 10259,
             "name": "batch",
             "type": "integer"
           },
           {
-            "line": 10256,
+            "line": 10258,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 10255,
+            "line": 10257,
             "name": "offset",
             "type": "integer"
           }
@@ -7762,172 +7762,172 @@
       {
         "fields": [
           {
-            "line": 10390,
+            "line": 10392,
             "name": "area",
             "type": "string"
           },
           {
-            "line": 10392,
+            "line": 10394,
             "name": "attack_vectors",
             "type": "CcbTechniqueIdPage"
           },
           {
-            "line": 10365,
+            "line": 10367,
             "name": "avatar_message",
             "type": "string"
           },
           {
-            "line": 10375,
+            "line": 10377,
             "name": "block_counter",
             "type": "boolean"
           },
           {
-            "line": 10371,
+            "line": 10373,
             "name": "critical_compatible",
             "type": "boolean"
           },
           {
-            "line": 10370,
+            "line": 10372,
             "name": "critical_only",
             "type": "boolean"
           },
           {
-            "line": 10367,
+            "line": 10369,
             "name": "defensive",
             "type": "boolean"
           },
           {
-            "line": 10362,
+            "line": 10364,
             "name": "description",
             "type": "string"
           },
           {
-            "line": 10378,
+            "line": 10380,
             "name": "disarms",
             "type": "boolean"
           },
           {
-            "line": 10374,
+            "line": 10376,
             "name": "dodge_counter",
             "type": "boolean"
           },
           {
-            "line": 10385,
+            "line": 10387,
             "name": "down_duration",
             "type": "integer"
           },
           {
-            "line": 10369,
+            "line": 10371,
             "name": "dummy",
             "type": "boolean"
           },
           {
-            "line": 10393,
+            "line": 10395,
             "name": "eocs",
             "type": "CcbTechniqueIdPage"
           },
           {
-            "line": 10391,
+            "line": 10393,
             "name": "flags",
             "type": "CcbTechniqueFlagPage"
           },
           {
-            "line": 10363,
+            "line": 10365,
             "name": "flavor_description",
             "type": "string"
           },
           {
-            "line": 10364,
+            "line": 10366,
             "name": "goal",
             "type": "string"
           },
           {
-            "line": 10377,
+            "line": 10379,
             "name": "grab_break",
             "type": "boolean"
           },
           {
-            "line": 10360,
+            "line": 10362,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 10387,
+            "line": 10389,
             "name": "knockback_distance",
             "type": "integer"
           },
           {
-            "line": 10389,
+            "line": 10391,
             "name": "knockback_follow",
             "type": "boolean"
           },
           {
-            "line": 10388,
+            "line": 10390,
             "name": "knockback_spread",
             "type": "number"
           },
           {
-            "line": 10376,
+            "line": 10378,
             "name": "miss_recovery",
             "type": "boolean"
           },
           {
-            "line": 10361,
+            "line": 10363,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 10380,
+            "line": 10382,
             "name": "needs_ammo",
             "type": "boolean"
           },
           {
-            "line": 10366,
+            "line": 10368,
             "name": "npc_message",
             "type": "string"
           },
           {
-            "line": 10373,
+            "line": 10375,
             "name": "reach_compatible",
             "type": "boolean"
           },
           {
-            "line": 10372,
+            "line": 10374,
             "name": "reach_only",
             "type": "boolean"
           },
           {
-            "line": 10384,
+            "line": 10386,
             "name": "repeat_max",
             "type": "integer"
           },
           {
-            "line": 10383,
+            "line": 10385,
             "name": "repeat_min",
             "type": "integer"
           },
           {
-            "line": 10368,
+            "line": 10370,
             "name": "side_switch",
             "type": "boolean"
           },
           {
-            "line": 10386,
+            "line": 10388,
             "name": "stun_duration",
             "type": "integer"
           },
           {
-            "line": 10379,
+            "line": 10381,
             "name": "take_weapon",
             "type": "boolean"
           },
           {
-            "line": 10381,
+            "line": 10383,
             "name": "wall_adjacent",
             "type": "boolean"
           },
           {
-            "line": 10382,
+            "line": 10384,
             "name": "weight",
             "type": "integer"
           }
@@ -7937,22 +7937,22 @@
       {
         "fields": [
           {
-            "line": 10354,
+            "line": 10356,
             "name": "items",
             "type": "string[]"
           },
           {
-            "line": 10356,
+            "line": 10358,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 10355,
+            "line": 10357,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 10357,
+            "line": 10359,
             "name": "truncated",
             "type": "boolean"
           }
@@ -7962,22 +7962,22 @@
       {
         "fields": [
           {
-            "line": 10348,
+            "line": 10350,
             "name": "items",
             "type": "GameId[]"
           },
           {
-            "line": 10350,
+            "line": 10352,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 10349,
+            "line": 10351,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 10351,
+            "line": 10353,
             "name": "truncated",
             "type": "boolean"
           }
@@ -7987,22 +7987,22 @@
       {
         "fields": [
           {
-            "line": 10639,
+            "line": 10641,
             "name": "season_id",
             "type": "string"
           },
           {
-            "line": 10640,
+            "line": 10642,
             "name": "season_name",
             "type": "string"
           },
           {
-            "line": 10637,
+            "line": 10639,
             "name": "turn",
             "type": "integer"
           },
           {
-            "line": 10638,
+            "line": 10640,
             "name": "year",
             "type": "integer"
           }
@@ -9407,22 +9407,22 @@
       {
         "fields": [
           {
-            "line": 10643,
+            "line": 10645,
             "name": "id",
             "type": "string"
           },
           {
-            "line": 10644,
+            "line": 10646,
             "name": "temperature_c",
             "type": "number"
           },
           {
-            "line": 10646,
+            "line": 10648,
             "name": "wind_direction",
             "type": "number"
           },
           {
-            "line": 10645,
+            "line": 10647,
             "name": "wind_speed",
             "type": "number"
           }
@@ -20621,43 +20621,43 @@
         "parameters": "character, body_part_limit"
       },
       {
-        "line": "10629",
+        "line": "10631",
         "name": "nearby",
         "owner": "CcbCreaturesApi",
         "parameters": "observer, options"
       },
       {
-        "line": "10624",
+        "line": "10626",
         "name": "snapshot",
         "owner": "CcbCreaturesApi",
         "parameters": "handle"
       },
       {
-        "line": "10634",
+        "line": "10636",
         "name": "visible_monsters",
         "owner": "CcbCreaturesApi",
         "parameters": "observer, direction"
       },
       {
-        "line": "10107",
+        "line": "10109",
         "name": "add",
         "owner": "CcbEffectsApi",
         "parameters": "character, effect, duration, options"
       },
       {
-        "line": "10122",
+        "line": "10124",
         "name": "get",
         "owner": "CcbEffectsApi",
         "parameters": "character, effect, body_part"
       },
       {
-        "line": "10115",
+        "line": "10117",
         "name": "has",
         "owner": "CcbEffectsApi",
         "parameters": "character, effect, body_part, intensity"
       },
       {
-        "line": "10129",
+        "line": "10131",
         "name": "remove",
         "owner": "CcbEffectsApi",
         "parameters": "character, effect, body_part"
@@ -21329,61 +21329,61 @@
         "parameters": "character, morale"
       },
       {
-        "line": "10168",
+        "line": "10170",
         "name": "grant",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation, variant"
       },
       {
-        "line": "10138",
+        "line": "10140",
         "name": "has",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation"
       },
       {
-        "line": "10152",
+        "line": "10154",
         "name": "is_purifiable",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation"
       },
       {
-        "line": "10145",
+        "line": "10147",
         "name": "is_visible_to",
         "owner": "CcbMutationsApi",
         "parameters": "observed, observer, mutation"
       },
       {
-        "line": "10197",
+        "line": "10199",
         "name": "mutate_category",
         "owner": "CcbMutationsApi",
         "parameters": "character, category, use_vitamins, true_random"
       },
       {
-        "line": "10175",
+        "line": "10177",
         "name": "remove",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation"
       },
       {
-        "line": "10189",
+        "line": "10191",
         "name": "remove_category",
         "owner": "CcbMutationsApi",
         "parameters": "character, category"
       },
       {
-        "line": "10206",
+        "line": "10208",
         "name": "remove_type",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation_type"
       },
       {
-        "line": "10183",
+        "line": "10185",
         "name": "set_active",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation, active"
       },
       {
-        "line": "10160",
+        "line": "10162",
         "name": "set_purifiable",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation, purifiable"
@@ -21935,19 +21935,19 @@
         "parameters": "character_handle, npc_handle, duration"
       },
       {
-        "line": "10226",
+        "line": "10228",
         "name": "grant",
         "owner": "CcbPlatformBionicsApi",
         "parameters": "character, id"
       },
       {
-        "line": "10232",
+        "line": "10234",
         "name": "remove_type",
         "owner": "CcbPlatformBionicsApi",
         "parameters": "character, id"
       },
       {
-        "line": "10220",
+        "line": "10222",
         "name": "summary",
         "owner": "CcbPlatformBionicsApi",
         "parameters": "character"
@@ -23687,67 +23687,67 @@
         "parameters": "dimension"
       },
       {
-        "line": "10496",
+        "line": "10498",
         "name": "dimension",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": ""
       },
       {
-        "line": "10534",
+        "line": "10536",
         "name": "field_exists",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position, field_id"
       },
       {
-        "line": "10517",
+        "line": "10519",
         "name": "furniture_has_flag",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position, flag"
       },
       {
-        "line": "10529",
+        "line": "10531",
         "name": "furniture_id",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position"
       },
       {
-        "line": "10544",
+        "line": "10546",
         "name": "is_indoor_tile",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position"
       },
       {
-        "line": "10500",
+        "line": "10502",
         "name": "is_night",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": ""
       },
       {
-        "line": "10504",
+        "line": "10506",
         "name": "is_outside",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position"
       },
       {
-        "line": "10511",
+        "line": "10513",
         "name": "line_of_sight",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "from, to, range, with_fields"
       },
       {
-        "line": "10549",
+        "line": "10551",
         "name": "safe_mode_dangerous",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "direction"
       },
       {
-        "line": "10539",
+        "line": "10541",
         "name": "terrain_has_flag",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position, flag"
       },
       {
-        "line": "10523",
+        "line": "10525",
         "name": "terrain_id",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position"
@@ -23825,31 +23825,31 @@
         "parameters": "id"
       },
       {
-        "line": "10414",
+        "line": "10416",
         "name": "forget",
         "owner": "CcbPlatformMartialArtsApi",
         "parameters": "character, id"
       },
       {
-        "line": "10408",
+        "line": "10410",
         "name": "learn",
         "owner": "CcbPlatformMartialArtsApi",
         "parameters": "character, id"
       },
       {
-        "line": "10401",
+        "line": "10403",
         "name": "technique_definition",
         "owner": "CcbPlatformMartialArtsApi",
         "parameters": "id"
       },
       {
-        "line": "10576",
+        "line": "10578",
         "name": "apply",
         "owner": "CcbPlatformMathApi",
         "parameters": "expression, actor, context"
       },
       {
-        "line": "10569",
+        "line": "10571",
         "name": "evaluate",
         "owner": "CcbPlatformMathApi",
         "parameters": "expression, actor, context"
@@ -23873,7 +23873,7 @@
         "parameters": "message, type"
       },
       {
-        "line": "10490",
+        "line": "10492",
         "name": "is_loaded",
         "owner": "CcbPlatformModQueries",
         "parameters": "mod_id"
@@ -23885,13 +23885,13 @@
         "parameters": "id"
       },
       {
-        "line": "10431",
+        "line": "10433",
         "name": "add",
         "owner": "CcbPlatformMoraleApi",
         "parameters": "character, id, bonus, max_bonus, options"
       },
       {
-        "line": "10437",
+        "line": "10439",
         "name": "remove",
         "owner": "CcbPlatformMoraleApi",
         "parameters": "character, id"
@@ -23957,97 +23957,97 @@
         "parameters": "file, volume"
       },
       {
-        "line": "10450",
+        "line": "10452",
         "name": "chance",
         "owner": "CcbPlatformRandomApi",
         "parameters": "numerator, denominator"
       },
       {
-        "line": "10472",
+        "line": "10474",
         "name": "contested",
         "owner": "CcbPlatformRandomApi",
         "parameters": "check, difficulty, die_size"
       },
       {
-        "line": "10445",
+        "line": "10447",
         "name": "int",
         "owner": "CcbPlatformRandomApi",
         "parameters": "minimum, maximum"
       },
       {
-        "line": "10454",
+        "line": "10456",
         "name": "one_in",
         "owner": "CcbPlatformRandomApi",
         "parameters": "denominator"
       },
       {
-        "line": "10459",
+        "line": "10461",
         "name": "probability",
         "owner": "CcbPlatformRandomApi",
         "parameters": "numerator, denominator"
       },
       {
-        "line": "10466",
+        "line": "10468",
         "name": "sample_integers",
         "owner": "CcbPlatformRandomApi",
         "parameters": "minimum, maximum, count, with_replacement"
       },
       {
-        "line": "10276",
+        "line": "10278",
         "name": "all",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, options"
       },
       {
-        "line": "10286",
+        "line": "10288",
         "name": "by_flag",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "flag, character, options"
       },
       {
-        "line": "10281",
+        "line": "10283",
         "name": "by_skill",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "skill, character, options"
       },
       {
-        "line": "10328",
+        "line": "10330",
         "name": "forget",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, id"
       },
       {
-        "line": "10345",
+        "line": "10347",
         "name": "forget_category",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, category, subcategory"
       },
       {
-        "line": "10291",
+        "line": "10293",
         "name": "get",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, id, batch"
       },
       {
-        "line": "10295",
+        "line": "10297",
         "name": "has_flag",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "id, flag"
       },
       {
-        "line": "10316",
+        "line": "10318",
         "name": "knows",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, id"
       },
       {
-        "line": "10322",
+        "line": "10324",
         "name": "learn",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, id"
       },
       {
-        "line": "10272",
+        "line": "10274",
         "name": "list",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, options"
@@ -24089,115 +24089,115 @@
         "parameters": "event_name, handler_id"
       },
       {
-        "line": "10735",
+        "line": "10737",
         "name": "activity_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10725",
+        "line": "10727",
         "name": "bionics_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10672",
+        "line": "10674",
         "name": "character_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character"
       },
       {
-        "line": "10715",
+        "line": "10717",
         "name": "current_tile_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, field_limit"
       },
       {
-        "line": "10693",
+        "line": "10695",
         "name": "effects_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10703",
+        "line": "10705",
         "name": "equipment_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10688",
+        "line": "10690",
         "name": "inventory_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10710",
+        "line": "10712",
         "name": "item_contents_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, item_handle, offset, limit"
       },
       {
-        "line": "10648",
+        "line": "10650",
         "name": "message",
         "owner": "CcbPlatformServices",
         "parameters": "text"
       },
       {
-        "line": "10730",
+        "line": "10732",
         "name": "missions_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10676",
+        "line": "10678",
         "name": "movement_modes_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character"
       },
       {
-        "line": "10720",
+        "line": "10722",
         "name": "mutations_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10741",
+        "line": "10743",
         "name": "nearby_creatures_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, radius, limit"
       },
       {
-        "line": "10698",
+        "line": "10700",
         "name": "skills_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10679",
+        "line": "10681",
         "name": "time_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": ""
       },
       {
-        "line": "10655",
+        "line": "10657",
         "name": "translate",
         "owner": "CcbPlatformServices",
         "parameters": "text, context"
       },
       {
-        "line": "10665",
+        "line": "10667",
         "name": "translate_plural",
         "owner": "CcbPlatformServices",
         "parameters": "singular, plural, count, context"
       },
       {
-        "line": "10668",
+        "line": "10670",
         "name": "turn",
         "owner": "CcbPlatformServices",
         "parameters": ""
       },
       {
-        "line": "10682",
+        "line": "10684",
         "name": "weather_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": ""
@@ -24269,13 +24269,13 @@
         "parameters": "key, value"
       },
       {
-        "line": "10483",
+        "line": "10485",
         "name": "all_equal",
         "owner": "CcbPlatformStringPredicates",
         "parameters": "values"
       },
       {
-        "line": "10479",
+        "line": "10481",
         "name": "any_equal",
         "owner": "CcbPlatformStringPredicates",
         "parameters": "values"
@@ -24365,19 +24365,19 @@
         "parameters": "avatar, target, options"
       },
       {
-        "line": "10310",
+        "line": "10312",
         "name": "for_recipe",
         "owner": "CcbRequirementsApi",
         "parameters": "character, id, batch"
       },
       {
-        "line": "10305",
+        "line": "10307",
         "name": "get",
         "owner": "CcbRequirementsApi",
         "parameters": "character, id, batch"
       },
       {
-        "line": "10300",
+        "line": "10302",
         "name": "list",
         "owner": "CcbRequirementsApi",
         "parameters": "character, options"
@@ -24443,43 +24443,43 @@
         "parameters": "character, key"
       },
       {
-        "line": "10032",
+        "line": "10033",
         "name": "get_global",
         "owner": "CcbVariablesApi",
         "parameters": "key"
       },
       {
-        "line": "10028",
+        "line": "10029",
         "name": "remove",
         "owner": "CcbVariablesApi",
         "parameters": "character, key"
       },
       {
-        "line": "10041",
+        "line": "10042",
         "name": "remove_global",
         "owner": "CcbVariablesApi",
         "parameters": "key"
       },
       {
-        "line": "10050",
+        "line": "10051",
         "name": "resolve",
         "owner": "CcbVariablesApi",
         "parameters": "context, actor, scope, key"
       },
       {
-        "line": "10023",
+        "line": "10024",
         "name": "set",
         "owner": "CcbVariablesApi",
         "parameters": "character, key, value"
       },
       {
-        "line": "10037",
+        "line": "10038",
         "name": "set_global",
         "owner": "CcbVariablesApi",
         "parameters": "key, value"
       },
       {
-        "line": "10058",
+        "line": "10060",
         "name": "set_resolved",
         "owner": "CcbVariablesApi",
         "parameters": "context, actor, scope, key, value"
@@ -30385,47 +30385,47 @@
   "public_root": {
     "fields": [
       {
-        "line": 10745,
+        "line": 10747,
         "name": "ModDefinition",
         "type": "fun(options:"
       },
       {
-        "line": 10746,
+        "line": 10748,
         "name": "content",
         "type": "CcbPlatformContent"
       },
       {
-        "line": 10748,
+        "line": 10750,
         "name": "dialogue",
         "type": "CcbPlatformDialogueApi"
       },
       {
-        "line": 10744,
+        "line": 10746,
         "name": "platform_version",
         "type": "1"
       },
       {
-        "line": 10751,
+        "line": 10753,
         "name": "presentation",
         "type": "CcbPlatformPresentation"
       },
       {
-        "line": 10747,
+        "line": 10749,
         "name": "runtime",
         "type": "CcbPlatformRuntime"
       },
       {
-        "line": 10752,
+        "line": 10754,
         "name": "services",
         "type": "CcbPlatformServices"
       },
       {
-        "line": 10749,
+        "line": 10751,
         "name": "state",
         "type": "CcbPlatformState"
       },
       {
-        "line": 10750,
+        "line": 10752,
         "name": "tasks",
         "type": "CcbPlatformTasks"
       }

--- a/data/lua/reference/ccb_platform_api_v1.json
+++ b/data/lua/reference/ccb_platform_api_v1.json
@@ -7,7 +7,7 @@
     "root_class": "CcbPlatformV1"
   },
   "lua_luals": {
-    "class_count": 691,
+    "class_count": 692,
     "classes": [
       {
         "fields": [
@@ -1101,42 +1101,42 @@
       {
         "fields": [
           {
-            "line": 6962,
+            "line": 6974,
             "name": "camp_identity_generation",
             "type": "integer"
           },
           {
-            "line": 6961,
+            "line": 6973,
             "name": "camp_stable_id",
             "type": "integer"
           },
           {
-            "line": 6957,
+            "line": 6969,
             "name": "expansion_id",
             "type": "integer"
           },
           {
-            "line": 6958,
+            "line": 6970,
             "name": "identity_generation",
             "type": "integer"
           },
           {
-            "line": 6964,
+            "line": 6976,
             "name": "is_valid",
             "type": "fun(self:"
           },
           {
-            "line": 6963,
+            "line": 6975,
             "name": "owner_faction",
             "type": "string"
           },
           {
-            "line": 6959,
+            "line": 6971,
             "name": "runtime_generation",
             "type": "integer"
           },
           {
-            "line": 6960,
+            "line": 6972,
             "name": "world_generation",
             "type": "integer"
           }
@@ -1146,57 +1146,57 @@
       {
         "fields": [
           {
-            "line": 7097,
+            "line": 7109,
             "name": "camp_identity_generation",
             "type": "integer"
           },
           {
-            "line": 7096,
+            "line": 7108,
             "name": "camp_stable_id",
             "type": "integer"
           },
           {
-            "line": 7093,
+            "line": 7105,
             "name": "identity_generation",
             "type": "integer"
           },
           {
-            "line": 7102,
+            "line": 7114,
             "name": "is_valid",
             "type": "fun(self:"
           },
           {
-            "line": 7100,
+            "line": 7112,
             "name": "manager_identity_generation",
             "type": "integer"
           },
           {
-            "line": 7098,
+            "line": 7110,
             "name": "manager_stable_id",
             "type": "integer"
           },
           {
-            "line": 7094,
+            "line": 7106,
             "name": "runtime_generation",
             "type": "integer"
           },
           {
-            "line": 7092,
+            "line": 7104,
             "name": "task_id",
             "type": "integer"
           },
           {
-            "line": 7101,
+            "line": 7113,
             "name": "worker_identity_generation",
             "type": "integer"
           },
           {
-            "line": 7099,
+            "line": 7111,
             "name": "worker_stable_id",
             "type": "integer"
           },
           {
-            "line": 7095,
+            "line": 7107,
             "name": "world_generation",
             "type": "integer"
           }
@@ -1210,7 +1210,7 @@
       {
         "fields": [
           {
-            "line": 7394,
+            "line": 7406,
             "name": "value",
             "type": "GameId|nil"
           }
@@ -1220,7 +1220,7 @@
       {
         "fields": [
           {
-            "line": 7397,
+            "line": 7409,
             "name": "value",
             "type": "GameId[]|nil"
           }
@@ -1230,27 +1230,27 @@
       {
         "fields": [
           {
-            "line": 10498,
+            "line": 10510,
             "name": "items",
             "type": "table"
           },
           {
-            "line": 10501,
+            "line": 10513,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 10500,
+            "line": 10512,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 10499,
+            "line": 10511,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 10502,
+            "line": 10514,
             "name": "truncated",
             "type": "boolean"
           }
@@ -1260,7 +1260,7 @@
       {
         "fields": [
           {
-            "line": 7336,
+            "line": 7348,
             "name": "type",
             "type": "string"
           }
@@ -1270,12 +1270,12 @@
       {
         "fields": [
           {
-            "line": 7221,
+            "line": 7233,
             "name": "x",
             "type": "integer"
           },
           {
-            "line": 7222,
+            "line": 7234,
             "name": "y",
             "type": "integer"
           }
@@ -1285,42 +1285,42 @@
       {
         "fields": [
           {
-            "line": 7242,
+            "line": 7254,
             "name": "camp",
             "type": "GameHandle"
           },
           {
-            "line": 7248,
+            "line": 7260,
             "name": "complete",
             "type": "boolean"
           },
           {
-            "line": 7243,
+            "line": 7255,
             "name": "items",
             "type": "CcbCampExpansionSnapshot[]"
           },
           {
-            "line": 7246,
+            "line": 7258,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7245,
+            "line": 7257,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 7247,
+            "line": 7259,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 7244,
+            "line": 7256,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 7249,
+            "line": 7261,
             "name": "truncated",
             "type": "boolean"
           }
@@ -1330,12 +1330,12 @@
       {
         "fields": [
           {
-            "line": 7239,
+            "line": 7251,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7238,
+            "line": 7250,
             "name": "offset",
             "type": "integer"
           }
@@ -1345,57 +1345,57 @@
       {
         "fields": [
           {
-            "line": 7228,
+            "line": 7240,
             "name": "camp",
             "type": "GameHandle"
           },
           {
-            "line": 7229,
+            "line": 7241,
             "name": "camp_stable_id",
             "type": "integer"
           },
           {
-            "line": 7230,
+            "line": 7242,
             "name": "direction",
             "type": "CcbCampExpansionDirection"
           },
           {
-            "line": 7226,
+            "line": 7238,
             "name": "expansion_id",
             "type": "integer"
           },
           {
-            "line": 7227,
+            "line": 7239,
             "name": "identity_generation",
             "type": "integer"
           },
           {
-            "line": 7233,
+            "line": 7245,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 7234,
+            "line": 7246,
             "name": "owner",
             "type": "GameId"
           },
           {
-            "line": 7231,
+            "line": 7243,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 7225,
+            "line": 7237,
             "name": "token",
             "type": "CampExpansionToken"
           },
           {
-            "line": 7232,
+            "line": 7244,
             "name": "type",
             "type": "string"
           },
           {
-            "line": 7235,
+            "line": 7247,
             "name": "work_in_progress",
             "type": "boolean"
           }
@@ -1413,37 +1413,37 @@
       {
         "fields": [
           {
-            "line": 6937,
+            "line": 6949,
             "name": "added",
             "type": "boolean"
           },
           {
-            "line": 6935,
+            "line": 6947,
             "name": "after_kcal",
             "type": "integer"
           },
           {
-            "line": 6936,
+            "line": 6948,
             "name": "amount_kcal",
             "type": "integer"
           },
           {
-            "line": 6934,
+            "line": 6946,
             "name": "before_kcal",
             "type": "integer"
           },
           {
-            "line": 6933,
+            "line": 6945,
             "name": "camp",
             "type": "GameHandle"
           },
           {
-            "line": 6939,
+            "line": 6951,
             "name": "changed",
             "type": "boolean"
           },
           {
-            "line": 6938,
+            "line": 6950,
             "name": "consumed",
             "type": "boolean"
           }
@@ -1453,12 +1453,12 @@
       {
         "fields": [
           {
-            "line": 6890,
+            "line": 6902,
             "name": "consumes_food",
             "type": "boolean"
           },
           {
-            "line": 6889,
+            "line": 6901,
             "name": "kcal",
             "type": "integer"
           }
@@ -1472,12 +1472,12 @@
       {
         "fields": [
           {
-            "line": 7305,
+            "line": 7317,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7304,
+            "line": 7316,
             "name": "radius_omt",
             "type": "integer"
           }
@@ -1487,32 +1487,32 @@
       {
         "fields": [
           {
-            "line": 7321,
+            "line": 7333,
             "name": "center",
             "type": "TripointCoord"
           },
           {
-            "line": 7325,
+            "line": 7337,
             "name": "complete",
             "type": "boolean"
           },
           {
-            "line": 7320,
+            "line": 7332,
             "name": "items",
             "type": "CcbCampSnapshot[]"
           },
           {
-            "line": 7324,
+            "line": 7336,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7322,
+            "line": 7334,
             "name": "radius_omt",
             "type": "integer"
           },
           {
-            "line": 7323,
+            "line": 7335,
             "name": "returned",
             "type": "integer"
           }
@@ -1522,42 +1522,42 @@
       {
         "fields": [
           {
-            "line": 7070,
+            "line": 7082,
             "name": "charges",
             "type": "integer"
           },
           {
-            "line": 7074,
+            "line": 7086,
             "name": "error",
             "type": "string"
           },
           {
-            "line": 7069,
+            "line": 7081,
             "name": "identity_generation",
             "type": "integer"
           },
           {
-            "line": 7073,
+            "line": 7085,
             "name": "item",
             "type": "table<string,"
           },
           {
-            "line": 7075,
+            "line": 7087,
             "name": "source_holder",
             "type": "CcbCampRecipeHolderSnapshot"
           },
           {
-            "line": 7071,
+            "line": 7083,
             "name": "tool",
             "type": "boolean"
           },
           {
-            "line": 7068,
+            "line": 7080,
             "name": "uid",
             "type": "integer"
           },
           {
-            "line": 7072,
+            "line": 7084,
             "name": "valid",
             "type": "boolean"
           }
@@ -1567,32 +1567,32 @@
       {
         "fields": [
           {
-            "line": 7082,
+            "line": 7094,
             "name": "complete",
             "type": "boolean"
           },
           {
-            "line": 7078,
+            "line": 7090,
             "name": "items",
             "type": "CcbCampRecipeEscrowItemSnapshot[]"
           },
           {
-            "line": 7081,
+            "line": 7093,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7080,
+            "line": 7092,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 7079,
+            "line": 7091,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 7083,
+            "line": 7095,
             "name": "truncated",
             "type": "boolean"
           }
@@ -1602,17 +1602,17 @@
       {
         "fields": [
           {
-            "line": 6983,
+            "line": 6995,
             "name": "character",
             "type": "GameHandle"
           },
           {
-            "line": 6982,
+            "line": 6994,
             "name": "kind",
             "type": "'character'"
           },
           {
-            "line": 6984,
+            "line": 6996,
             "name": "slot",
             "type": "'inventory'|'worn'|'wielded'"
           }
@@ -1622,22 +1622,22 @@
       {
         "fields": [
           {
-            "line": 7063,
+            "line": 7075,
             "name": "character_id",
             "type": "integer"
           },
           {
-            "line": 7064,
+            "line": 7076,
             "name": "identity_generation",
             "type": "integer"
           },
           {
-            "line": 7062,
+            "line": 7074,
             "name": "kind",
             "type": "'character'"
           },
           {
-            "line": 7065,
+            "line": 7077,
             "name": "slot",
             "type": "'inventory'|'worn'|'wielded'"
           }
@@ -1647,22 +1647,22 @@
       {
         "fields": [
           {
-            "line": 7056,
+            "line": 7068,
             "name": "item",
             "type": "GameHandle"
           },
           {
-            "line": 7058,
+            "line": 7070,
             "name": "quantity",
             "type": "integer"
           },
           {
-            "line": 7057,
+            "line": 7069,
             "name": "source_holder",
             "type": "CcbCampRecipeHolder"
           },
           {
-            "line": 7059,
+            "line": 7071,
             "name": "tool",
             "type": "boolean"
           }
@@ -1672,27 +1672,27 @@
       {
         "fields": [
           {
-            "line": 6988,
+            "line": 7000,
             "name": "batch",
             "type": "integer"
           },
           {
-            "line": 6991,
+            "line": 7003,
             "name": "destination_holder",
             "type": "CcbCampRecipeHolder"
           },
           {
-            "line": 6989,
+            "line": 7001,
             "name": "duration_turns",
             "type": "integer"
           },
           {
-            "line": 6987,
+            "line": 6999,
             "name": "recipe_id",
             "type": "GameId"
           },
           {
-            "line": 6990,
+            "line": 7002,
             "name": "source_holders",
             "type": "CcbCampRecipeHolder[]"
           }
@@ -1702,27 +1702,27 @@
       {
         "fields": [
           {
-            "line": 7025,
+            "line": 7037,
             "name": "batch",
             "type": "integer"
           },
           {
-            "line": 7028,
+            "line": 7040,
             "name": "destination_holder",
             "type": "CcbCampRecipeHolderSnapshot"
           },
           {
-            "line": 7026,
+            "line": 7038,
             "name": "duration_turns",
             "type": "integer"
           },
           {
-            "line": 7024,
+            "line": 7036,
             "name": "recipe_id",
             "type": "GameId"
           },
           {
-            "line": 7027,
+            "line": 7039,
             "name": "source_holders",
             "type": "CcbCampRecipeHolderSnapshot[]"
           }
@@ -1732,12 +1732,12 @@
       {
         "fields": [
           {
-            "line": 6886,
+            "line": 6898,
             "name": "delta",
             "type": "integer"
           },
           {
-            "line": 6885,
+            "line": 6897,
             "name": "id",
             "type": "GameId"
           }
@@ -1747,22 +1747,22 @@
       {
         "fields": [
           {
-            "line": 6880,
+            "line": 6892,
             "name": "ammo_id",
             "type": "GameId"
           },
           {
-            "line": 6881,
+            "line": 6893,
             "name": "available",
             "type": "integer"
           },
           {
-            "line": 6882,
+            "line": 6894,
             "name": "consumed",
             "type": "integer"
           },
           {
-            "line": 6879,
+            "line": 6891,
             "name": "id",
             "type": "GameId"
           }
@@ -1772,47 +1772,47 @@
       {
         "fields": [
           {
-            "line": 6893,
+            "line": 6905,
             "name": "camp",
             "type": "GameHandle"
           },
           {
-            "line": 6900,
+            "line": 6912,
             "name": "complete",
             "type": "boolean"
           },
           {
-            "line": 6895,
+            "line": 6907,
             "name": "food",
             "type": "CcbCampFoodSnapshot"
           },
           {
-            "line": 6898,
+            "line": 6910,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 6897,
+            "line": 6909,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 6894,
+            "line": 6906,
             "name": "resources",
             "type": "CcbCampResourceEntry[]"
           },
           {
-            "line": 6899,
+            "line": 6911,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 6896,
+            "line": 6908,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 6901,
+            "line": 6913,
             "name": "truncated",
             "type": "boolean"
           }
@@ -1822,12 +1822,12 @@
       {
         "fields": [
           {
-            "line": 6972,
+            "line": 6984,
             "name": "amount",
             "type": "integer"
           },
           {
-            "line": 6971,
+            "line": 6983,
             "name": "id",
             "type": "GameId"
           }
@@ -1837,27 +1837,27 @@
       {
         "fields": [
           {
-            "line": 6979,
+            "line": 6991,
             "name": "duration_turns",
             "type": "integer"
           },
           {
-            "line": 6977,
+            "line": 6989,
             "name": "food_input_kcal",
             "type": "integer"
           },
           {
-            "line": 6978,
+            "line": 6990,
             "name": "food_output_kcal",
             "type": "integer"
           },
           {
-            "line": 6975,
+            "line": 6987,
             "name": "resource_inputs",
             "type": "CcbCampResourceWorkChange[]"
           },
           {
-            "line": 6976,
+            "line": 6988,
             "name": "resource_outputs",
             "type": "CcbCampResourceWorkChange[]"
           }
@@ -1871,52 +1871,52 @@
       {
         "fields": [
           {
-            "line": 7317,
+            "line": 7329,
             "name": "assigned_worker_count",
             "type": "integer"
           },
           {
-            "line": 7312,
+            "line": 7324,
             "name": "board_name",
             "type": "string"
           },
           {
-            "line": 7315,
+            "line": 7327,
             "name": "board_position",
             "type": "TripointCoord"
           },
           {
-            "line": 7308,
+            "line": 7320,
             "name": "handle",
             "type": "GameHandle"
           },
           {
-            "line": 7310,
+            "line": 7322,
             "name": "identity_generation",
             "type": "integer"
           },
           {
-            "line": 7311,
+            "line": 7323,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 7316,
+            "line": 7328,
             "name": "owner",
             "type": "GameId"
           },
           {
-            "line": 7314,
+            "line": 7326,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 7309,
+            "line": 7321,
             "name": "stable_id",
             "type": "integer"
           },
           {
-            "line": 7313,
+            "line": 7325,
             "name": "valid",
             "type": "boolean"
           }
@@ -1926,7 +1926,7 @@
       {
         "fields": [
           {
-            "line": 7281,
+            "line": 7293,
             "name": "holder",
             "type": "CcbItemHolder"
           }
@@ -1936,47 +1936,47 @@
       {
         "fields": [
           {
-            "line": 7284,
+            "line": 7296,
             "name": "camp",
             "type": "GameHandle"
           },
           {
-            "line": 7290,
+            "line": 7302,
             "name": "complete",
             "type": "boolean"
           },
           {
-            "line": 7285,
+            "line": 7297,
             "name": "items",
             "type": "CcbCampStorageTile[]"
           },
           {
-            "line": 7288,
+            "line": 7300,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7287,
+            "line": 7299,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 7292,
+            "line": 7304,
             "name": "page_api",
             "type": "string"
           },
           {
-            "line": 7289,
+            "line": 7301,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 7286,
+            "line": 7298,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 7291,
+            "line": 7303,
             "name": "truncated",
             "type": "boolean"
           }
@@ -1986,52 +1986,52 @@
       {
         "fields": [
           {
-            "line": 7130,
+            "line": 7142,
             "name": "camp",
             "type": "GameHandle"
           },
           {
-            "line": 7138,
+            "line": 7150,
             "name": "complete",
             "type": "boolean"
           },
           {
-            "line": 7136,
+            "line": 7148,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7131,
+            "line": 7143,
             "name": "manager",
             "type": "GameHandle"
           },
           {
-            "line": 7135,
+            "line": 7147,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 7137,
+            "line": 7149,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 7133,
+            "line": 7145,
             "name": "tasks",
             "type": "CcbCampTaskSnapshot[]"
           },
           {
-            "line": 7134,
+            "line": 7146,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 7139,
+            "line": 7151,
             "name": "truncated",
             "type": "boolean"
           },
           {
-            "line": 7132,
+            "line": 7144,
             "name": "worker",
             "type": "GameHandle"
           }
@@ -2041,22 +2041,22 @@
       {
         "fields": [
           {
-            "line": 7088,
+            "line": 7100,
             "name": "active",
             "type": "boolean"
           },
           {
-            "line": 7089,
+            "line": 7101,
             "name": "discarded",
             "type": "boolean"
           },
           {
-            "line": 7087,
+            "line": 7099,
             "name": "food_kcal",
             "type": "integer"
           },
           {
-            "line": 7086,
+            "line": 7098,
             "name": "resources",
             "type": "CcbCampResourceWorkChange[]"
           }
@@ -2066,117 +2066,117 @@
       {
         "fields": [
           {
-            "line": 7107,
+            "line": 7119,
             "name": "camp",
             "type": "GameHandle"
           },
           {
-            "line": 7124,
+            "line": 7136,
             "name": "due_at",
             "type": "TimePoint"
           },
           {
-            "line": 7125,
+            "line": 7137,
             "name": "finished_at",
             "type": "TimePoint"
           },
           {
-            "line": 7106,
+            "line": 7118,
             "name": "identity_generation",
             "type": "integer"
           },
           {
-            "line": 7111,
+            "line": 7123,
             "name": "kind",
             "type": "CcbCampTaskKind"
           },
           {
-            "line": 7109,
+            "line": 7121,
             "name": "manager",
             "type": "GameHandle"
           },
           {
-            "line": 7108,
+            "line": 7120,
             "name": "owner",
             "type": "GameId"
           },
           {
-            "line": 7112,
+            "line": 7124,
             "name": "parameter_schema",
             "type": "string"
           },
           {
-            "line": 7117,
+            "line": 7129,
             "name": "recipe_commit_marker",
             "type": "integer"
           },
           {
-            "line": 7116,
+            "line": 7128,
             "name": "recipe_escrow",
             "type": "CcbCampRecipeEscrowPage"
           },
           {
-            "line": 7120,
+            "line": 7132,
             "name": "recipe_recovery_required",
             "type": "boolean"
           },
           {
-            "line": 7114,
+            "line": 7126,
             "name": "recipe_work",
             "type": "CcbCampRecipeWorkSnapshot"
           },
           {
-            "line": 7121,
+            "line": 7133,
             "name": "reservation",
             "type": "CcbCampTaskReservation"
           },
           {
-            "line": 7126,
+            "line": 7138,
             "name": "reservation_active",
             "type": "boolean"
           },
           {
-            "line": 7113,
+            "line": 7125,
             "name": "resource_work",
             "type": "CcbCampResourceWorkDescriptor"
           },
           {
-            "line": 7123,
+            "line": 7135,
             "name": "started_at",
             "type": "TimePoint"
           },
           {
-            "line": 7122,
+            "line": 7134,
             "name": "state",
             "type": "CcbCampTaskState"
           },
           {
-            "line": 7105,
+            "line": 7117,
             "name": "task_id",
             "type": "integer"
           },
           {
-            "line": 7127,
+            "line": 7139,
             "name": "token",
             "type": "CampTaskToken"
           },
           {
-            "line": 7119,
+            "line": 7131,
             "name": "upgrade_applying_marker",
             "type": "integer"
           },
           {
-            "line": 7118,
+            "line": 7130,
             "name": "upgrade_commit_marker",
             "type": "integer"
           },
           {
-            "line": 7115,
+            "line": 7127,
             "name": "upgrade_work",
             "type": "CcbCampUpgradeWorkSnapshot"
           },
           {
-            "line": 7110,
+            "line": 7122,
             "name": "worker",
             "type": "GameHandle"
           }
@@ -2190,27 +2190,27 @@
       {
         "fields": [
           {
-            "line": 7001,
+            "line": 7013,
             "name": "generation",
             "type": "integer"
           },
           {
-            "line": 7000,
+            "line": 7012,
             "name": "kind",
             "type": "'camp_core'"
           },
           {
-            "line": 7004,
+            "line": 7016,
             "name": "mapgen_args",
             "type": "CcbCampUpgradeMapgenArguments"
           },
           {
-            "line": 7002,
+            "line": 7014,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 7003,
+            "line": 7015,
             "name": "terrain",
             "type": "string"
           }
@@ -2220,27 +2220,27 @@
       {
         "fields": [
           {
-            "line": 7032,
+            "line": 7044,
             "name": "generation",
             "type": "integer"
           },
           {
-            "line": 7031,
+            "line": 7043,
             "name": "kind",
             "type": "'camp_core'"
           },
           {
-            "line": 7035,
+            "line": 7047,
             "name": "mapgen_args",
             "type": "CcbCampUpgradeMapgenArguments"
           },
           {
-            "line": 7033,
+            "line": 7045,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 7034,
+            "line": 7046,
             "name": "terrain",
             "type": "string"
           }
@@ -2250,27 +2250,27 @@
       {
         "fields": [
           {
-            "line": 7008,
+            "line": 7020,
             "name": "expansion",
             "type": "CampExpansionToken"
           },
           {
-            "line": 7007,
+            "line": 7019,
             "name": "kind",
             "type": "'expansion'"
           },
           {
-            "line": 7011,
+            "line": 7023,
             "name": "mapgen_args",
             "type": "CcbCampUpgradeMapgenArguments"
           },
           {
-            "line": 7009,
+            "line": 7021,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 7010,
+            "line": 7022,
             "name": "terrain",
             "type": "string"
           }
@@ -2280,32 +2280,32 @@
       {
         "fields": [
           {
-            "line": 7040,
+            "line": 7052,
             "name": "expansion_generation",
             "type": "integer"
           },
           {
-            "line": 7039,
+            "line": 7051,
             "name": "expansion_id",
             "type": "integer"
           },
           {
-            "line": 7038,
+            "line": 7050,
             "name": "kind",
             "type": "'expansion'"
           },
           {
-            "line": 7043,
+            "line": 7055,
             "name": "mapgen_args",
             "type": "CcbCampUpgradeMapgenArguments"
           },
           {
-            "line": 7041,
+            "line": 7053,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 7042,
+            "line": 7054,
             "name": "terrain",
             "type": "string"
           }
@@ -2315,12 +2315,12 @@
       {
         "fields": [
           {
-            "line": 6994,
+            "line": 7006,
             "name": "type",
             "type": "'int'|'bool'|'string'"
           },
           {
-            "line": 6995,
+            "line": 7007,
             "name": "value",
             "type": "integer|boolean|string"
           }
@@ -2330,32 +2330,32 @@
       {
         "fields": [
           {
-            "line": 7017,
+            "line": 7029,
             "name": "blueprint_id",
             "type": "string"
           },
           {
-            "line": 7021,
+            "line": 7033,
             "name": "destination_holder",
             "type": "CcbCampRecipeHolder"
           },
           {
-            "line": 7019,
+            "line": 7031,
             "name": "duration_turns",
             "type": "integer"
           },
           {
-            "line": 7020,
+            "line": 7032,
             "name": "source_holders",
             "type": "CcbCampRecipeHolder[]"
           },
           {
-            "line": 7018,
+            "line": 7030,
             "name": "target",
             "type": "CcbCampUpgradeTarget"
           },
           {
-            "line": 7016,
+            "line": 7028,
             "name": "upgrade_id",
             "type": "GameId"
           }
@@ -2365,32 +2365,32 @@
       {
         "fields": [
           {
-            "line": 7049,
+            "line": 7061,
             "name": "blueprint_id",
             "type": "string"
           },
           {
-            "line": 7053,
+            "line": 7065,
             "name": "destination_holder",
             "type": "CcbCampRecipeHolderSnapshot"
           },
           {
-            "line": 7051,
+            "line": 7063,
             "name": "duration_turns",
             "type": "integer"
           },
           {
-            "line": 7052,
+            "line": 7064,
             "name": "source_holders",
             "type": "CcbCampRecipeHolderSnapshot[]"
           },
           {
-            "line": 7050,
+            "line": 7062,
             "name": "target",
             "type": "CcbCampUpgradeTargetSnapshot"
           },
           {
-            "line": 7048,
+            "line": 7060,
             "name": "upgrade_id",
             "type": "GameId"
           }
@@ -2400,27 +2400,27 @@
       {
         "fields": [
           {
-            "line": 7332,
+            "line": 7344,
             "name": "expansions",
             "type": "CcbCampExpansionsApi"
           },
           {
-            "line": 7329,
+            "line": 7341,
             "name": "food",
             "type": "CcbCampFoodApi"
           },
           {
-            "line": 7330,
+            "line": 7342,
             "name": "inventory",
             "type": "CcbCampInventoryApi"
           },
           {
-            "line": 7328,
+            "line": 7340,
             "name": "resources",
             "type": "CcbCampResourcesApi"
           },
           {
-            "line": 7331,
+            "line": 7343,
             "name": "tasks",
             "type": "CcbCampTasksApi"
           }
@@ -2450,67 +2450,67 @@
       {
         "fields": [
           {
-            "line": 10485,
+            "line": 10497,
             "name": "focus",
             "type": "integer"
           },
           {
-            "line": 10487,
+            "line": 10499,
             "name": "hunger",
             "type": "integer"
           },
           {
-            "line": 10481,
+            "line": 10493,
             "name": "moves",
             "type": "integer"
           },
           {
-            "line": 10477,
+            "line": 10489,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 10484,
+            "line": 10496,
             "name": "pain",
             "type": "integer"
           },
           {
-            "line": 10489,
+            "line": 10501,
             "name": "sleepiness",
             "type": "integer"
           },
           {
-            "line": 10486,
+            "line": 10498,
             "name": "speed",
             "type": "integer"
           },
           {
-            "line": 10482,
+            "line": 10494,
             "name": "stamina",
             "type": "integer"
           },
           {
-            "line": 10483,
+            "line": 10495,
             "name": "stamina_max",
             "type": "integer"
           },
           {
-            "line": 10488,
+            "line": 10500,
             "name": "thirst",
             "type": "integer"
           },
           {
-            "line": 10478,
+            "line": 10490,
             "name": "x",
             "type": "integer"
           },
           {
-            "line": 10479,
+            "line": 10491,
             "name": "y",
             "type": "integer"
           },
           {
-            "line": 10480,
+            "line": 10492,
             "name": "z",
             "type": "integer"
           }
@@ -2544,52 +2544,52 @@
       {
         "fields": [
           {
-            "line": 10511,
+            "line": 10523,
             "name": "attitude",
             "type": "string"
           },
           {
-            "line": 10512,
+            "line": 10524,
             "name": "dead",
             "type": "boolean"
           },
           {
-            "line": 10507,
+            "line": 10519,
             "name": "display_name",
             "type": "string"
           },
           {
-            "line": 10510,
+            "line": 10522,
             "name": "distance",
             "type": "integer"
           },
           {
-            "line": 10513,
+            "line": 10525,
             "name": "hp",
             "type": "integer"
           },
           {
-            "line": 10514,
+            "line": 10526,
             "name": "hp_max",
             "type": "integer"
           },
           {
-            "line": 10505,
+            "line": 10517,
             "name": "kind",
             "type": "'avatar'|'npc'|'monster'|'creature'"
           },
           {
-            "line": 10506,
+            "line": 10518,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 10508,
+            "line": 10520,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 10509,
+            "line": 10521,
             "name": "visible",
             "type": "boolean"
           }
@@ -2603,17 +2603,17 @@
       {
         "fields": [
           {
-            "line": 6014,
+            "line": 6026,
             "name": "kind",
             "type": "'computer'|'zone'|'topic'|'talker'|'item'"
           },
           {
-            "line": 6015,
+            "line": 6027,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 6016,
+            "line": 6028,
             "name": "position",
             "type": "TripointCoord"
           }
@@ -2623,22 +2623,22 @@
       {
         "fields": [
           {
-            "line": 9873,
+            "line": 9885,
             "name": "body_part",
             "type": "GameId"
           },
           {
-            "line": 9876,
+            "line": 9888,
             "name": "force",
             "type": "boolean"
           },
           {
-            "line": 9875,
+            "line": 9887,
             "name": "intensity",
             "type": "integer"
           },
           {
-            "line": 9874,
+            "line": 9886,
             "name": "permanent",
             "type": "boolean"
           }
@@ -2648,22 +2648,22 @@
       {
         "fields": [
           {
-            "line": 10012,
+            "line": 10024,
             "name": "items",
             "type": "GameId[]"
           },
           {
-            "line": 10014,
+            "line": 10026,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 10013,
+            "line": 10025,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 10015,
+            "line": 10027,
             "name": "truncated",
             "type": "boolean"
           }
@@ -2673,12 +2673,12 @@
       {
         "fields": [
           {
-            "line": 10019,
+            "line": 10031,
             "name": "effects",
             "type": "CcbEffectRelatedIdPage"
           },
           {
-            "line": 10018,
+            "line": 10030,
             "name": "mutations",
             "type": "CcbEffectRelatedIdPage"
           }
@@ -2688,112 +2688,112 @@
       {
         "fields": [
           {
-            "line": 10043,
+            "line": 10055,
             "name": "blocks_effects",
             "type": "CcbEffectRelatedIdPage"
           },
           {
-            "line": 10041,
+            "line": 10053,
             "name": "body_part",
             "type": "GameId"
           },
           {
-            "line": 10024,
+            "line": 10036,
             "name": "description",
             "type": "string"
           },
           {
-            "line": 10028,
+            "line": 10040,
             "name": "duration",
             "type": "TimeDuration"
           },
           {
-            "line": 10038,
+            "line": 10050,
             "name": "duration_add_percent",
             "type": "integer"
           },
           {
-            "line": 10034,
+            "line": 10046,
             "name": "effective_intensity",
             "type": "integer"
           },
           {
-            "line": 10037,
+            "line": 10049,
             "name": "harmful_cough",
             "type": "boolean"
           },
           {
-            "line": 10022,
+            "line": 10034,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 10036,
+            "line": 10048,
             "name": "impairs_movement",
             "type": "boolean"
           },
           {
-            "line": 10031,
+            "line": 10043,
             "name": "intensity",
             "type": "integer"
           },
           {
-            "line": 10039,
+            "line": 10051,
             "name": "intensity_add",
             "type": "integer"
           },
           {
-            "line": 10040,
+            "line": 10052,
             "name": "intensity_duration",
             "type": "TimeDuration"
           },
           {
-            "line": 10029,
+            "line": 10041,
             "name": "maximum_duration",
             "type": "TimeDuration"
           },
           {
-            "line": 10033,
+            "line": 10045,
             "name": "maximum_effective_intensity",
             "type": "integer"
           },
           {
-            "line": 10032,
+            "line": 10044,
             "name": "maximum_intensity",
             "type": "integer"
           },
           {
-            "line": 10026,
+            "line": 10038,
             "name": "mod_source",
             "type": "string"
           },
           {
-            "line": 10023,
+            "line": 10035,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 10035,
+            "line": 10047,
             "name": "permanent",
             "type": "boolean"
           },
           {
-            "line": 10042,
+            "line": 10054,
             "name": "resisted_by",
             "type": "CcbEffectResistanceIds"
           },
           {
-            "line": 10025,
+            "line": 10037,
             "name": "short_description",
             "type": "string"
           },
           {
-            "line": 10030,
+            "line": 10042,
             "name": "start_time",
             "type": "TimePoint"
           },
           {
-            "line": 10027,
+            "line": 10039,
             "name": "uses_body_part_description",
             "type": "boolean"
           }
@@ -2803,7 +2803,7 @@
       {
         "fields": [
           {
-            "line": 10046,
+            "line": 10058,
             "name": "value",
             "type": "CcbEffectSnapshot"
           }
@@ -2821,81 +2821,6 @@
       {
         "fields": [
           {
-            "line": 9136,
-            "name": "handle",
-            "type": "GameHandle"
-          },
-          {
-            "line": 9137,
-            "name": "item",
-            "type": "table<string,"
-          },
-          {
-            "line": 9135,
-            "name": "source_handle_stale",
-            "type": "boolean"
-          },
-          {
-            "line": 9134,
-            "name": "source_uid",
-            "type": "integer"
-          }
-        ],
-        "name": "CcbEquipmentDisplacedItem"
-      },
-      {
-        "fields": [
-          {
-            "line": 9131,
-            "name": "code",
-            "type": "CcbEquipmentErrorCode"
-          }
-        ],
-        "name": "CcbEquipmentError"
-      },
-      {
-        "fields": [
-          {
-            "line": 9155,
-            "name": "error",
-            "type": "CcbEquipmentError"
-          },
-          {
-            "line": 9154,
-            "name": "value",
-            "type": "CcbEquipmentValue"
-          }
-        ],
-        "name": "CcbEquipmentResult"
-      },
-      {
-        "fields": [
-          {
-            "line": 9140,
-            "name": "accepted",
-            "type": "true"
-          },
-          {
-            "line": 9141,
-            "name": "changed",
-            "type": "boolean"
-          },
-          {
-            "line": 9147,
-            "name": "destination_holder",
-            "type": "CcbItemHolder"
-          },
-          {
-            "line": 9150,
-            "name": "displaced",
-            "type": "CcbEquipmentDisplacedItem[]"
-          },
-          {
-            "line": 9151,
-            "name": "displaced_count",
-            "type": "integer"
-          },
-          {
             "line": 9148,
             "name": "handle",
             "type": "GameHandle"
@@ -2906,27 +2831,102 @@
             "type": "table<string,"
           },
           {
-            "line": 9145,
-            "name": "old_handle_stale",
-            "type": "boolean"
-          },
-          {
-            "line": 9142,
-            "name": "operation",
-            "type": "CcbEquipmentOperation"
-          },
-          {
-            "line": 9144,
+            "line": 9147,
             "name": "source_handle_stale",
             "type": "boolean"
           },
           {
             "line": 9146,
+            "name": "source_uid",
+            "type": "integer"
+          }
+        ],
+        "name": "CcbEquipmentDisplacedItem"
+      },
+      {
+        "fields": [
+          {
+            "line": 9143,
+            "name": "code",
+            "type": "CcbEquipmentErrorCode"
+          }
+        ],
+        "name": "CcbEquipmentError"
+      },
+      {
+        "fields": [
+          {
+            "line": 9167,
+            "name": "error",
+            "type": "CcbEquipmentError"
+          },
+          {
+            "line": 9166,
+            "name": "value",
+            "type": "CcbEquipmentValue"
+          }
+        ],
+        "name": "CcbEquipmentResult"
+      },
+      {
+        "fields": [
+          {
+            "line": 9152,
+            "name": "accepted",
+            "type": "true"
+          },
+          {
+            "line": 9153,
+            "name": "changed",
+            "type": "boolean"
+          },
+          {
+            "line": 9159,
+            "name": "destination_holder",
+            "type": "CcbItemHolder"
+          },
+          {
+            "line": 9162,
+            "name": "displaced",
+            "type": "CcbEquipmentDisplacedItem[]"
+          },
+          {
+            "line": 9163,
+            "name": "displaced_count",
+            "type": "integer"
+          },
+          {
+            "line": 9160,
+            "name": "handle",
+            "type": "GameHandle"
+          },
+          {
+            "line": 9161,
+            "name": "item",
+            "type": "table<string,"
+          },
+          {
+            "line": 9157,
+            "name": "old_handle_stale",
+            "type": "boolean"
+          },
+          {
+            "line": 9154,
+            "name": "operation",
+            "type": "CcbEquipmentOperation"
+          },
+          {
+            "line": 9156,
+            "name": "source_handle_stale",
+            "type": "boolean"
+          },
+          {
+            "line": 9158,
             "name": "source_holder",
             "type": "CcbItemHolder"
           },
           {
-            "line": 9143,
+            "line": 9155,
             "name": "source_uid",
             "type": "integer"
           }
@@ -2936,32 +2936,32 @@
       {
         "fields": [
           {
-            "line": 8699,
+            "line": 8711,
             "name": "has_more",
             "type": "boolean"
           },
           {
-            "line": 8694,
+            "line": 8706,
             "name": "items",
             "type": "CcbFactionSnapshot[]"
           },
           {
-            "line": 8696,
+            "line": 8708,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 8695,
+            "line": 8707,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 8698,
+            "line": 8710,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 8697,
+            "line": 8709,
             "name": "total",
             "type": "integer"
           }
@@ -2971,22 +2971,22 @@
       {
         "fields": [
           {
-            "line": 8674,
+            "line": 8686,
             "name": "consumes_food",
             "type": "boolean"
           },
           {
-            "line": 8676,
+            "line": 8688,
             "name": "limited_area_claim",
             "type": "boolean"
           },
           {
-            "line": 8675,
+            "line": 8687,
             "name": "lone_wolf",
             "type": "boolean"
           },
           {
-            "line": 8677,
+            "line": 8689,
             "name": "stealing",
             "type": "'ask'|'always'|'never'"
           }
@@ -3061,27 +3061,27 @@
       {
         "fields": [
           {
-            "line": 8659,
+            "line": 8671,
             "name": "likes",
             "type": "integer"
           },
           {
-            "line": 8662,
+            "line": 8674,
             "name": "ranking",
             "type": "string"
           },
           {
-            "line": 8663,
+            "line": 8675,
             "name": "respect",
             "type": "string"
           },
           {
-            "line": 8660,
+            "line": 8672,
             "name": "respects",
             "type": "integer"
           },
           {
-            "line": 8661,
+            "line": 8673,
             "name": "trusts",
             "type": "integer"
           }
@@ -3091,32 +3091,32 @@
       {
         "fields": [
           {
-            "line": 8671,
+            "line": 8683,
             "name": "combat_ability",
             "type": "string"
           },
           {
-            "line": 8669,
+            "line": 8681,
             "name": "food_kcal",
             "type": "integer"
           },
           {
-            "line": 8667,
+            "line": 8679,
             "name": "power",
             "type": "integer"
           },
           {
-            "line": 8666,
+            "line": 8678,
             "name": "size",
             "type": "integer"
           },
           {
-            "line": 8668,
+            "line": 8680,
             "name": "wealth",
             "type": "integer"
           },
           {
-            "line": 8670,
+            "line": 8682,
             "name": "wealth_description",
             "type": "string"
           }
@@ -3126,62 +3126,62 @@
       {
         "fields": [
           {
-            "line": 8688,
+            "line": 8700,
             "name": "currency",
             "type": "GameId"
           },
           {
-            "line": 8682,
+            "line": 8694,
             "name": "description",
             "type": "string"
           },
           {
-            "line": 8680,
+            "line": 8692,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 8684,
+            "line": 8696,
             "name": "known_by_player",
             "type": "boolean"
           },
           {
-            "line": 8690,
+            "line": 8702,
             "name": "members",
             "type": "integer"
           },
           {
-            "line": 8689,
+            "line": 8701,
             "name": "monster_faction",
             "type": "GameId"
           },
           {
-            "line": 8681,
+            "line": 8693,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 8687,
+            "line": 8699,
             "name": "policy",
             "type": "CcbFactionPolicy"
           },
           {
-            "line": 8691,
+            "line": 8703,
             "name": "relationship_targets",
             "type": "integer"
           },
           {
-            "line": 8685,
+            "line": 8697,
             "name": "reputation",
             "type": "CcbFactionReputation"
           },
           {
-            "line": 8686,
+            "line": 8698,
             "name": "resources",
             "type": "CcbFactionResources"
           },
           {
-            "line": 8683,
+            "line": 8695,
             "name": "summary",
             "type": "string"
           }
@@ -3193,23 +3193,78 @@
         "name": "CcbFactionsApi"
       },
       {
+        "fields": [
+          {
+            "line": 4914,
+            "name": "default_value",
+            "type": "string"
+          },
+          {
+            "line": 4916,
+            "name": "description",
+            "type": "string"
+          },
+          {
+            "line": 4913,
+            "name": "display_value",
+            "type": "string"
+          },
+          {
+            "line": 4918,
+            "name": "hidden",
+            "type": "boolean"
+          },
+          {
+            "line": 4910,
+            "name": "id",
+            "type": "string"
+          },
+          {
+            "line": 4915,
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "line": 4917,
+            "name": "page",
+            "type": "string"
+          },
+          {
+            "line": 4919,
+            "name": "prerequisite_satisfied",
+            "type": "boolean"
+          },
+          {
+            "line": 4911,
+            "name": "type",
+            "type": "string"
+          },
+          {
+            "line": 4912,
+            "name": "value",
+            "type": "string"
+          }
+        ],
+        "name": "CcbGameplayOptionSnapshot"
+      },
+      {
         "fields": [],
         "name": "CcbHandlesApi"
       },
       {
         "fields": [
           {
-            "line": 8038,
+            "line": 8050,
             "name": "after",
             "type": "CcbHordeEntitySnapshot"
           },
           {
-            "line": 8037,
+            "line": 8049,
             "name": "before",
             "type": "CcbHordeEntitySnapshot"
           },
           {
-            "line": 8036,
+            "line": 8048,
             "name": "status",
             "type": "\"committed\""
           }
@@ -3219,47 +3274,47 @@
       {
         "fields": [
           {
-            "line": 8104,
+            "line": 8116,
             "name": "default_monster",
             "type": "GameId|nil"
           },
           {
-            "line": 8111,
+            "line": 8123,
             "name": "entries",
             "type": "CcbHordeDefinitionEntryPage"
           },
           {
-            "line": 8110,
+            "line": 8122,
             "name": "frequency_total",
             "type": "integer"
           },
           {
-            "line": 8103,
+            "line": 8115,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 8105,
+            "line": 8117,
             "name": "is_animal",
             "type": "boolean"
           },
           {
-            "line": 8107,
+            "line": 8119,
             "name": "new_monster_group",
             "type": "GameId|nil"
           },
           {
-            "line": 8106,
+            "line": 8118,
             "name": "replace_monster_group",
             "type": "boolean"
           },
           {
-            "line": 8108,
+            "line": 8120,
             "name": "replacement_time",
             "type": "TimeDuration"
           },
           {
-            "line": 8109,
+            "line": 8121,
             "name": "safe",
             "type": "boolean"
           }
@@ -3269,57 +3324,57 @@
       {
         "fields": [
           {
-            "line": 8084,
+            "line": 8096,
             "name": "conditions",
             "type": "CcbHordeStringPage"
           },
           {
-            "line": 8077,
+            "line": 8089,
             "name": "cost_multiplier",
             "type": "number"
           },
           {
-            "line": 8081,
+            "line": 8093,
             "name": "ends",
             "type": "TimeDuration"
           },
           {
-            "line": 8083,
+            "line": 8095,
             "name": "event",
             "type": "string"
           },
           {
-            "line": 8076,
+            "line": 8088,
             "name": "frequency",
             "type": "integer"
           },
           {
-            "line": 8075,
+            "line": 8087,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 8074,
+            "line": 8086,
             "name": "kind",
             "type": "\"group\"|\"monster\""
           },
           {
-            "line": 8082,
+            "line": 8094,
             "name": "lasts_forever",
             "type": "boolean"
           },
           {
-            "line": 8079,
+            "line": 8091,
             "name": "pack_maximum",
             "type": "integer"
           },
           {
-            "line": 8078,
+            "line": 8090,
             "name": "pack_minimum",
             "type": "integer"
           },
           {
-            "line": 8080,
+            "line": 8092,
             "name": "starts",
             "type": "TimeDuration"
           }
@@ -3329,32 +3384,32 @@
       {
         "fields": [
           {
-            "line": 8092,
+            "line": 8104,
             "name": "has_more",
             "type": "boolean"
           },
           {
-            "line": 8087,
+            "line": 8099,
             "name": "items",
             "type": "CcbHordeDefinitionEntry[]"
           },
           {
-            "line": 8090,
+            "line": 8102,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 8089,
+            "line": 8101,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 8091,
+            "line": 8103,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 8088,
+            "line": 8100,
             "name": "total",
             "type": "integer"
           }
@@ -3364,32 +3419,32 @@
       {
         "fields": [
           {
-            "line": 8100,
+            "line": 8112,
             "name": "has_more",
             "type": "boolean"
           },
           {
-            "line": 8095,
+            "line": 8107,
             "name": "items",
             "type": "CcbHordeDefinitionSummary[]"
           },
           {
-            "line": 8097,
+            "line": 8109,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 8096,
+            "line": 8108,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 8099,
+            "line": 8111,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 8098,
+            "line": 8110,
             "name": "total",
             "type": "integer"
           }
@@ -3399,27 +3454,27 @@
       {
         "fields": [
           {
-            "line": 8061,
+            "line": 8073,
             "name": "default_monster",
             "type": "GameId|nil"
           },
           {
-            "line": 8062,
+            "line": 8074,
             "name": "entries",
             "type": "integer"
           },
           {
-            "line": 8060,
+            "line": 8072,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 8063,
+            "line": 8075,
             "name": "is_animal",
             "type": "boolean"
           },
           {
-            "line": 8064,
+            "line": 8076,
             "name": "safe",
             "type": "boolean"
           }
@@ -3429,7 +3484,7 @@
       {
         "fields": [
           {
-            "line": 8041,
+            "line": 8053,
             "name": "status",
             "type": "\"committed\""
           }
@@ -3439,57 +3494,57 @@
       {
         "fields": [
           {
-            "line": 7976,
+            "line": 7988,
             "name": "existing_only",
             "type": "boolean"
           },
           {
-            "line": 7975,
+            "line": 7987,
             "name": "existing_overmaps",
             "type": "integer"
           },
           {
-            "line": 7977,
+            "line": 7989,
             "name": "flavors",
             "type": "integer"
           },
           {
-            "line": 7972,
+            "line": 7984,
             "name": "has_more",
             "type": "boolean"
           },
           {
-            "line": 7967,
+            "line": 7979,
             "name": "items",
             "type": "CcbHordeEntitySnapshot[]"
           },
           {
-            "line": 7970,
+            "line": 7982,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7969,
+            "line": 7981,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 7973,
+            "line": 7985,
             "name": "radius",
             "type": "integer"
           },
           {
-            "line": 7974,
+            "line": 7986,
             "name": "radius_z",
             "type": "integer"
           },
           {
-            "line": 7971,
+            "line": 7983,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 7968,
+            "line": 7980,
             "name": "total",
             "type": "integer"
           }
@@ -3499,22 +3554,22 @@
       {
         "fields": [
           {
-            "line": 7924,
+            "line": 7936,
             "name": "flavors",
             "type": "string[]"
           },
           {
-            "line": 7925,
+            "line": 7937,
             "name": "monster",
             "type": "GameId"
           },
           {
-            "line": 7922,
+            "line": 7934,
             "name": "radius",
             "type": "integer"
           },
           {
-            "line": 7923,
+            "line": 7935,
             "name": "radius_z",
             "type": "integer"
           }
@@ -3524,12 +3579,12 @@
       {
         "fields": [
           {
-            "line": 8053,
+            "line": 8065,
             "name": "removed",
             "type": "boolean"
           },
           {
-            "line": 8052,
+            "line": 8064,
             "name": "status",
             "type": "\"committed\""
           }
@@ -3539,62 +3594,62 @@
       {
         "fields": [
           {
-            "line": 7959,
+            "line": 7971,
             "name": "active",
             "type": "boolean"
           },
           {
-            "line": 7961,
+            "line": 7973,
             "name": "destination",
             "type": "TripointCoord"
           },
           {
-            "line": 7958,
+            "line": 7970,
             "name": "flavor",
             "type": "\"active\"|\"idle\"|\"dormant\"|\"immobile\""
           },
           {
-            "line": 7960,
+            "line": 7972,
             "name": "heavy",
             "type": "boolean"
           },
           {
-            "line": 7964,
+            "line": 7976,
             "name": "last_processed",
             "type": "TimePoint"
           },
           {
-            "line": 7956,
+            "line": 7968,
             "name": "monster",
             "type": "GameId"
           },
           {
-            "line": 7963,
+            "line": 7975,
             "name": "moves",
             "type": "integer"
           },
           {
-            "line": 7957,
+            "line": 7969,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 7955,
+            "line": 7967,
             "name": "overmap_position",
             "type": "TripointCoord"
           },
           {
-            "line": 7954,
+            "line": 7966,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 7953,
+            "line": 7965,
             "name": "token",
             "type": "HordeEntityToken"
           },
           {
-            "line": 7962,
+            "line": 7974,
             "name": "tracking_intensity",
             "type": "integer"
           }
@@ -3604,7 +3659,7 @@
       {
         "fields": [
           {
-            "line": 8049,
+            "line": 8061,
             "name": "status",
             "type": "\"committed\""
           }
@@ -3614,47 +3669,47 @@
       {
         "fields": [
           {
-            "line": 7939,
+            "line": 7951,
             "name": "behavior",
             "type": "\"none\"|\"city\"|\"roam\"|\"nemesis\""
           },
           {
-            "line": 7937,
+            "line": 7949,
             "name": "dying",
             "type": "boolean"
           },
           {
-            "line": 7933,
+            "line": 7945,
             "name": "group",
             "type": "GameId"
           },
           {
-            "line": 7938,
+            "line": 7950,
             "name": "horde",
             "type": "boolean"
           },
           {
-            "line": 7936,
+            "line": 7948,
             "name": "interest",
             "type": "integer"
           },
           {
-            "line": 7941,
+            "line": 7953,
             "name": "nemesis_target",
             "type": "TripointCoord"
           },
           {
-            "line": 7935,
+            "line": 7947,
             "name": "population",
             "type": "integer"
           },
           {
-            "line": 7934,
+            "line": 7946,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 7940,
+            "line": 7952,
             "name": "target",
             "type": "TripointCoord"
           }
@@ -3664,57 +3719,57 @@
       {
         "fields": [
           {
-            "line": 8020,
+            "line": 8032,
             "name": "existing_only",
             "type": "boolean"
           },
           {
-            "line": 8019,
+            "line": 8031,
             "name": "existing_overmaps",
             "type": "integer"
           },
           {
-            "line": 8015,
+            "line": 8027,
             "name": "has_more",
             "type": "boolean"
           },
           {
-            "line": 8018,
+            "line": 8030,
             "name": "horde_only",
             "type": "boolean"
           },
           {
-            "line": 8010,
+            "line": 8022,
             "name": "items",
             "type": "CcbHordeLegacyGroupSnapshot[]"
           },
           {
-            "line": 8012,
+            "line": 8024,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 8011,
+            "line": 8023,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 8016,
+            "line": 8028,
             "name": "radius",
             "type": "integer"
           },
           {
-            "line": 8017,
+            "line": 8029,
             "name": "radius_z",
             "type": "integer"
           },
           {
-            "line": 8014,
+            "line": 8026,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 8013,
+            "line": 8025,
             "name": "total",
             "type": "integer"
           }
@@ -3724,12 +3779,12 @@
       {
         "fields": [
           {
-            "line": 8057,
+            "line": 8069,
             "name": "removed",
             "type": "boolean"
           },
           {
-            "line": 8056,
+            "line": 8068,
             "name": "status",
             "type": "\"committed\""
           }
@@ -3739,82 +3794,82 @@
       {
         "fields": [
           {
-            "line": 8006,
+            "line": 8018,
             "name": "average_speed",
             "type": "number"
           },
           {
-            "line": 8003,
+            "line": 8015,
             "name": "behavior",
             "type": "\"none\"|\"city\"|\"roam\"|\"nemesis\""
           },
           {
-            "line": 8001,
+            "line": 8013,
             "name": "dying",
             "type": "boolean"
           },
           {
-            "line": 8004,
+            "line": 8016,
             "name": "empty",
             "type": "boolean"
           },
           {
-            "line": 7993,
+            "line": 8005,
             "name": "group",
             "type": "GameId"
           },
           {
-            "line": 8002,
+            "line": 8014,
             "name": "horde",
             "type": "boolean"
           },
           {
-            "line": 8000,
+            "line": 8012,
             "name": "interest",
             "type": "integer"
           },
           {
-            "line": 8007,
+            "line": 8019,
             "name": "monsters",
             "type": "CcbHordeLegacyMonsterPage"
           },
           {
-            "line": 7997,
+            "line": 8009,
             "name": "nemesis_target",
             "type": "TripointCoord"
           },
           {
-            "line": 7995,
+            "line": 8007,
             "name": "overmap_position",
             "type": "TripointCoord"
           },
           {
-            "line": 7998,
+            "line": 8010,
             "name": "population",
             "type": "integer"
           },
           {
-            "line": 7994,
+            "line": 8006,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 8005,
+            "line": 8017,
             "name": "safe",
             "type": "boolean"
           },
           {
-            "line": 7996,
+            "line": 8008,
             "name": "target",
             "type": "TripointCoord"
           },
           {
-            "line": 7992,
+            "line": 8004,
             "name": "token",
             "type": "LegacyHordeToken"
           },
           {
-            "line": 7999,
+            "line": 8011,
             "name": "tracked_monsters",
             "type": "integer"
           }
@@ -3824,37 +3879,37 @@
       {
         "fields": [
           {
-            "line": 7948,
+            "line": 7960,
             "name": "behavior",
             "type": "\"none\"|\"city\"|\"roam\"|\"nemesis\""
           },
           {
-            "line": 7946,
+            "line": 7958,
             "name": "dying",
             "type": "boolean"
           },
           {
-            "line": 7947,
+            "line": 7959,
             "name": "horde",
             "type": "boolean"
           },
           {
-            "line": 7945,
+            "line": 7957,
             "name": "interest",
             "type": "integer"
           },
           {
-            "line": 7950,
+            "line": 7962,
             "name": "nemesis_target",
             "type": "TripointCoord"
           },
           {
-            "line": 7944,
+            "line": 7956,
             "name": "population",
             "type": "integer"
           },
           {
-            "line": 7949,
+            "line": 7961,
             "name": "target",
             "type": "TripointCoord"
           }
@@ -3864,17 +3919,17 @@
       {
         "fields": [
           {
-            "line": 8046,
+            "line": 8058,
             "name": "after",
             "type": "CcbHordeLegacyGroupSnapshot"
           },
           {
-            "line": 8045,
+            "line": 8057,
             "name": "before",
             "type": "CcbHordeLegacyGroupSnapshot"
           },
           {
-            "line": 8044,
+            "line": 8056,
             "name": "status",
             "type": "\"committed\""
           }
@@ -3884,27 +3939,27 @@
       {
         "fields": [
           {
-            "line": 7985,
+            "line": 7997,
             "name": "items",
             "type": "CcbHordeLegacyMonsterSnapshot[]"
           },
           {
-            "line": 7987,
+            "line": 7999,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7988,
+            "line": 8000,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 7986,
+            "line": 7998,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 7989,
+            "line": 8001,
             "name": "truncated",
             "type": "boolean"
           }
@@ -3914,17 +3969,17 @@
       {
         "fields": [
           {
-            "line": 7980,
+            "line": 7992,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 7981,
+            "line": 7993,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 7982,
+            "line": 7994,
             "name": "position",
             "type": "TripointCoord"
           }
@@ -3934,17 +3989,17 @@
       {
         "fields": [
           {
-            "line": 7930,
+            "line": 7942,
             "name": "horde_only",
             "type": "boolean"
           },
           {
-            "line": 7928,
+            "line": 7940,
             "name": "radius",
             "type": "integer"
           },
           {
-            "line": 7929,
+            "line": 7941,
             "name": "radius_z",
             "type": "integer"
           }
@@ -3954,42 +4009,42 @@
       {
         "fields": [
           {
-            "line": 7893,
+            "line": 7905,
             "name": "existing_only",
             "type": "boolean"
           },
           {
-            "line": 7892,
+            "line": 7904,
             "name": "flavors",
             "type": "string[]"
           },
           {
-            "line": 7891,
+            "line": 7903,
             "name": "maximum_legacy_population",
             "type": "integer"
           },
           {
-            "line": 7888,
+            "line": 7900,
             "name": "maximum_limit",
             "type": "integer"
           },
           {
-            "line": 7889,
+            "line": 7901,
             "name": "maximum_offset",
             "type": "integer"
           },
           {
-            "line": 7886,
+            "line": 7898,
             "name": "maximum_radius",
             "type": "integer"
           },
           {
-            "line": 7887,
+            "line": 7899,
             "name": "maximum_radius_z",
             "type": "integer"
           },
           {
-            "line": 7890,
+            "line": 7902,
             "name": "maximum_tracking_intensity",
             "type": "integer"
           }
@@ -3999,42 +4054,42 @@
       {
         "fields": [
           {
-            "line": 8115,
+            "line": 8127,
             "name": "group",
             "type": "GameId"
           },
           {
-            "line": 8121,
+            "line": 8133,
             "name": "has_more",
             "type": "boolean"
           },
           {
-            "line": 8114,
+            "line": 8126,
             "name": "items",
             "type": "GameId[]"
           },
           {
-            "line": 8118,
+            "line": 8130,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 8117,
+            "line": 8129,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 8116,
+            "line": 8128,
             "name": "recursive",
             "type": "boolean"
           },
           {
-            "line": 8120,
+            "line": 8132,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 8119,
+            "line": 8131,
             "name": "total",
             "type": "integer"
           }
@@ -4044,12 +4099,12 @@
       {
         "fields": [
           {
-            "line": 7919,
+            "line": 7931,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7918,
+            "line": 7930,
             "name": "offset",
             "type": "integer"
           }
@@ -4059,27 +4114,27 @@
       {
         "fields": [
           {
-            "line": 8067,
+            "line": 8079,
             "name": "items",
             "type": "string[]"
           },
           {
-            "line": 8069,
+            "line": 8081,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 8070,
+            "line": 8082,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 8068,
+            "line": 8080,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 8071,
+            "line": 8083,
             "name": "truncated",
             "type": "boolean"
           }
@@ -4089,57 +4144,57 @@
       {
         "fields": [
           {
-            "line": 8025,
+            "line": 8037,
             "name": "active",
             "type": "integer"
           },
           {
-            "line": 8027,
+            "line": 8039,
             "name": "dormant",
             "type": "integer"
           },
           {
-            "line": 8024,
+            "line": 8036,
             "name": "entities",
             "type": "integer"
           },
           {
-            "line": 8031,
+            "line": 8043,
             "name": "estimated_size",
             "type": "integer"
           },
           {
-            "line": 8033,
+            "line": 8045,
             "name": "existing_only",
             "type": "boolean"
           },
           {
-            "line": 8032,
+            "line": 8044,
             "name": "has_horde",
             "type": "boolean"
           },
           {
-            "line": 8026,
+            "line": 8038,
             "name": "idle",
             "type": "integer"
           },
           {
-            "line": 8028,
+            "line": 8040,
             "name": "immobile",
             "type": "integer"
           },
           {
-            "line": 8029,
+            "line": 8041,
             "name": "legacy_hordes",
             "type": "integer"
           },
           {
-            "line": 8030,
+            "line": 8042,
             "name": "legacy_population",
             "type": "integer"
           },
           {
-            "line": 8023,
+            "line": 8035,
             "name": "position",
             "type": "TripointCoord"
           }
@@ -4187,7 +4242,7 @@
       {
         "fields": [
           {
-            "line": 8823,
+            "line": 8835,
             "name": "target",
             "type": "TripointCoord"
           }
@@ -4197,32 +4252,32 @@
       {
         "fields": [
           {
-            "line": 8826,
+            "line": 8838,
             "name": "accepted",
             "type": "boolean"
           },
           {
-            "line": 8827,
+            "line": 8839,
             "name": "destroyed",
             "type": "boolean"
           },
           {
-            "line": 8831,
+            "line": 8843,
             "name": "handle",
             "type": "GameHandle"
           },
           {
-            "line": 8830,
+            "line": 8842,
             "name": "item",
             "type": "table<string,"
           },
           {
-            "line": 8829,
+            "line": 8841,
             "name": "method",
             "type": "string"
           },
           {
-            "line": 8828,
+            "line": 8840,
             "name": "stale",
             "type": "boolean"
           }
@@ -4232,22 +4287,22 @@
       {
         "fields": [
           {
-            "line": 8837,
+            "line": 8849,
             "name": "activity",
             "type": "table<string,"
           },
           {
-            "line": 8836,
+            "line": 8848,
             "name": "input_handle_retired",
             "type": "boolean"
           },
           {
-            "line": 8835,
+            "line": 8847,
             "name": "item_uid",
             "type": "integer"
           },
           {
-            "line": 8834,
+            "line": 8846,
             "name": "quantity",
             "type": "integer"
           }
@@ -4261,12 +4316,12 @@
       {
         "fields": [
           {
-            "line": 8869,
+            "line": 8881,
             "name": "count",
             "type": "integer"
           },
           {
-            "line": 8868,
+            "line": 8880,
             "name": "items",
             "type": "CcbItemCategorySpawnRateResult[]"
           }
@@ -4276,12 +4331,12 @@
       {
         "fields": [
           {
-            "line": 8858,
+            "line": 8870,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 8859,
+            "line": 8871,
             "name": "spawn_rate",
             "type": "number"
           }
@@ -4291,22 +4346,22 @@
       {
         "fields": [
           {
-            "line": 8864,
+            "line": 8876,
             "name": "after",
             "type": "number"
           },
           {
-            "line": 8863,
+            "line": 8875,
             "name": "before",
             "type": "number"
           },
           {
-            "line": 8865,
+            "line": 8877,
             "name": "changed",
             "type": "boolean"
           },
           {
-            "line": 8862,
+            "line": 8874,
             "name": "id",
             "type": "GameId"
           }
@@ -4316,17 +4371,17 @@
       {
         "fields": [
           {
-            "line": 8851,
+            "line": 8863,
             "name": "force",
             "type": "boolean"
           },
           {
-            "line": 8853,
+            "line": 8865,
             "name": "holder",
             "type": "GameHandle"
           },
           {
-            "line": 8852,
+            "line": 8864,
             "name": "message",
             "type": "boolean"
           }
@@ -4336,42 +4391,42 @@
       {
         "fields": [
           {
-            "line": 8770,
+            "line": 8782,
             "name": "character",
             "type": "GameHandle"
           },
           {
-            "line": 8773,
+            "line": 8785,
             "name": "container",
             "type": "GameHandle"
           },
           {
-            "line": 8769,
+            "line": 8781,
             "name": "kind",
             "type": "'character'|'map_tile'|'container_pocket'|'vehicle_cargo'"
           },
           {
-            "line": 8776,
+            "line": 8788,
             "name": "part",
             "type": "GameHandle"
           },
           {
-            "line": 8774,
+            "line": 8786,
             "name": "pocket_index",
             "type": "integer"
           },
           {
-            "line": 8771,
+            "line": 8783,
             "name": "slot",
             "type": "'inventory'|'worn'|'wielded'"
           },
           {
-            "line": 8772,
+            "line": 8784,
             "name": "tile",
             "type": "MapTileToken"
           },
           {
-            "line": 8775,
+            "line": 8787,
             "name": "vehicle",
             "type": "GameHandle"
           }
@@ -4381,37 +4436,37 @@
       {
         "fields": [
           {
-            "line": 8760,
+            "line": 8772,
             "name": "continuation_id",
             "type": "integer"
           },
           {
-            "line": 8761,
+            "line": 8773,
             "name": "holder",
             "type": "CcbItemHolder"
           },
           {
-            "line": 8763,
+            "line": 8775,
             "name": "max_depth",
             "type": "integer"
           },
           {
-            "line": 8762,
+            "line": 8774,
             "name": "page_size",
             "type": "integer"
           },
           {
-            "line": 8766,
+            "line": 8778,
             "name": "reason",
             "type": "'page'|'node_budget'"
           },
           {
-            "line": 8764,
+            "line": 8776,
             "name": "recursive",
             "type": "boolean"
           },
           {
-            "line": 8765,
+            "line": 8777,
             "name": "same_runtime_world_holder",
             "type": "boolean"
           }
@@ -4421,32 +4476,32 @@
       {
         "fields": [
           {
-            "line": 8782,
+            "line": 8794,
             "name": "depth",
             "type": "integer"
           },
           {
-            "line": 8779,
+            "line": 8791,
             "name": "handle",
             "type": "GameHandle"
           },
           {
-            "line": 8781,
+            "line": 8793,
             "name": "holder",
             "type": "CcbItemHolder"
           },
           {
-            "line": 8784,
+            "line": 8796,
             "name": "parent_uid",
             "type": "integer"
           },
           {
-            "line": 8780,
+            "line": 8792,
             "name": "snapshot",
             "type": "table<string,"
           },
           {
-            "line": 8783,
+            "line": 8795,
             "name": "uid",
             "type": "integer"
           }
@@ -4456,57 +4511,57 @@
       {
         "fields": [
           {
-            "line": 8791,
+            "line": 8803,
             "name": "complete",
             "type": "boolean"
           },
           {
-            "line": 8796,
+            "line": 8808,
             "name": "continuation",
             "type": "CcbItemPageContinuation"
           },
           {
-            "line": 8788,
+            "line": 8800,
             "name": "holder",
             "type": "CcbItemHolder"
           },
           {
-            "line": 8787,
+            "line": 8799,
             "name": "items",
             "type": "CcbItemPageEntry[]"
           },
           {
-            "line": 8794,
+            "line": 8806,
             "name": "max_depth",
             "type": "integer"
           },
           {
-            "line": 8797,
+            "line": 8809,
             "name": "next",
             "type": "CcbItemPageContinuation"
           },
           {
-            "line": 8789,
+            "line": 8801,
             "name": "page_size",
             "type": "integer"
           },
           {
-            "line": 8795,
+            "line": 8807,
             "name": "recursive",
             "type": "boolean"
           },
           {
-            "line": 8790,
+            "line": 8802,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 8793,
+            "line": 8805,
             "name": "stop_reason",
             "type": "'empty'|'complete'|'page'|'node_budget'|'max_depth'|'cycle'|'repeated_item'|'invalid_pocket'|'stale_cursor'"
           },
           {
-            "line": 8792,
+            "line": 8804,
             "name": "truncated",
             "type": "boolean"
           }
@@ -4516,47 +4571,47 @@
       {
         "fields": [
           {
-            "line": 8840,
+            "line": 8852,
             "name": "accepted",
             "type": "boolean"
           },
           {
-            "line": 8841,
+            "line": 8853,
             "name": "changed",
             "type": "boolean"
           },
           {
-            "line": 8845,
+            "line": 8857,
             "name": "handle",
             "type": "GameHandle"
           },
           {
-            "line": 8847,
+            "line": 8859,
             "name": "holder",
             "type": "CcbItemHolder"
           },
           {
-            "line": 8848,
+            "line": 8860,
             "name": "item",
             "type": "table<string,"
           },
           {
-            "line": 8844,
+            "line": 8856,
             "name": "old_handle_stale",
             "type": "boolean"
           },
           {
-            "line": 8842,
+            "line": 8854,
             "name": "quantity",
             "type": "integer"
           },
           {
-            "line": 8843,
+            "line": 8855,
             "name": "source_handle_stale",
             "type": "boolean"
           },
           {
-            "line": 8846,
+            "line": 8858,
             "name": "source_holder",
             "type": "CcbItemHolder"
           }
@@ -4566,17 +4621,17 @@
       {
         "fields": [
           {
-            "line": 8812,
+            "line": 8824,
             "name": "active",
             "type": "boolean"
           },
           {
-            "line": 8813,
+            "line": 8825,
             "name": "browsed",
             "type": "boolean"
           },
           {
-            "line": 8811,
+            "line": 8823,
             "name": "carrier",
             "type": "GameHandle"
           }
@@ -4586,27 +4641,27 @@
       {
         "fields": [
           {
-            "line": 8817,
+            "line": 8829,
             "name": "after",
             "type": "table<string,"
           },
           {
-            "line": 8816,
+            "line": 8828,
             "name": "before",
             "type": "table<string,"
           },
           {
-            "line": 8818,
+            "line": 8830,
             "name": "changed",
             "type": "boolean"
           },
           {
-            "line": 8820,
+            "line": 8832,
             "name": "handle",
             "type": "GameHandle"
           },
           {
-            "line": 8819,
+            "line": 8831,
             "name": "old_handle_stale",
             "type": "boolean"
           }
@@ -4616,47 +4671,47 @@
       {
         "fields": [
           {
-            "line": 8805,
+            "line": 8817,
             "name": "active",
             "type": "boolean"
           },
           {
-            "line": 8806,
+            "line": 8818,
             "name": "browsed",
             "type": "boolean"
           },
           {
-            "line": 8803,
+            "line": 8815,
             "name": "burnt",
             "type": "integer"
           },
           {
-            "line": 8800,
+            "line": 8812,
             "name": "charges",
             "type": "integer"
           },
           {
-            "line": 8801,
+            "line": 8813,
             "name": "damage",
             "type": "integer"
           },
           {
-            "line": 8802,
+            "line": 8814,
             "name": "degradation",
             "type": "integer"
           },
           {
-            "line": 8804,
+            "line": 8816,
             "name": "favorite",
             "type": "boolean"
           },
           {
-            "line": 8807,
+            "line": 8819,
             "name": "relative_rot",
             "type": "number"
           },
           {
-            "line": 8808,
+            "line": 8820,
             "name": "rot",
             "type": "TimeDuration"
           }
@@ -4843,7 +4898,7 @@
       {
         "fields": [
           {
-            "line": 6853,
+            "line": 6865,
             "name": "cancel_on_collision",
             "type": "true"
           }
@@ -4853,32 +4908,32 @@
       {
         "fields": [
           {
-            "line": 6840,
+            "line": 6852,
             "name": "code",
             "type": "string"
           },
           {
-            "line": 6842,
+            "line": 6854,
             "name": "footprint",
             "type": "MapgenTransactionFootprint"
           },
           {
-            "line": 6841,
+            "line": 6853,
             "name": "message",
             "type": "string"
           },
           {
-            "line": 6839,
+            "line": 6851,
             "name": "state",
             "type": "'rejected'|'rolled_back'|'rollback_failed'"
           },
           {
-            "line": 6843,
+            "line": 6855,
             "name": "target",
             "type": "OvermapTileToken"
           },
           {
-            "line": 6844,
+            "line": 6856,
             "name": "update",
             "type": "MapgenUpdateToken"
           }
@@ -4888,12 +4943,12 @@
       {
         "fields": [
           {
-            "line": 6848,
+            "line": 6860,
             "name": "error",
             "type": "CcbMapgenTransactionError"
           },
           {
-            "line": 6847,
+            "line": 6859,
             "name": "value",
             "type": "MapgenTransactionResult"
           }
@@ -4903,47 +4958,47 @@
       {
         "fields": [
           {
-            "line": 8576,
+            "line": 8588,
             "name": "abandoned",
             "type": "CcbMissionSnapshot"
           },
           {
-            "line": 8574,
+            "line": 8586,
             "name": "after",
             "type": "CcbMissionSnapshot"
           },
           {
-            "line": 8573,
+            "line": 8585,
             "name": "before",
             "type": "CcbMissionSnapshot"
           },
           {
-            "line": 8575,
+            "line": 8587,
             "name": "cancelled",
             "type": "CcbMissionSnapshot"
           },
           {
-            "line": 8579,
+            "line": 8591,
             "name": "changed",
             "type": "boolean"
           },
           {
-            "line": 8578,
+            "line": 8590,
             "name": "cleared",
             "type": "boolean"
           },
           {
-            "line": 8581,
+            "line": 8593,
             "name": "forced",
             "type": "boolean"
           },
           {
-            "line": 8577,
+            "line": 8589,
             "name": "removed",
             "type": "boolean"
           },
           {
-            "line": 8580,
+            "line": 8592,
             "name": "step",
             "type": "integer"
           }
@@ -4953,42 +5008,42 @@
       {
         "fields": [
           {
-            "line": 8568,
+            "line": 8580,
             "name": "has_more",
             "type": "boolean"
           },
           {
-            "line": 8563,
+            "line": 8575,
             "name": "items",
             "type": "CcbMissionSnapshot[]"
           },
           {
-            "line": 8566,
+            "line": 8578,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 8565,
+            "line": 8577,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 8569,
+            "line": 8581,
             "name": "owner",
             "type": "GameHandle"
           },
           {
-            "line": 8567,
+            "line": 8579,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 8570,
+            "line": 8582,
             "name": "status",
             "type": "'all'|'reserved'|'active'|'success'|'failure'"
           },
           {
-            "line": 8564,
+            "line": 8576,
             "name": "total",
             "type": "integer"
           }
@@ -5018,107 +5073,107 @@
       {
         "fields": [
           {
-            "line": 8546,
+            "line": 8558,
             "name": "assigned",
             "type": "boolean"
           },
           {
-            "line": 8558,
+            "line": 8570,
             "name": "assigned_player_id",
             "type": "integer"
           },
           {
-            "line": 8551,
+            "line": 8563,
             "name": "deadline",
             "type": "TimePoint"
           },
           {
-            "line": 8544,
+            "line": 8556,
             "name": "description",
             "type": "string"
           },
           {
-            "line": 8548,
+            "line": 8560,
             "name": "failed",
             "type": "boolean"
           },
           {
-            "line": 8554,
+            "line": 8566,
             "name": "follow_up",
             "type": "GameId"
           },
           {
-            "line": 8550,
+            "line": 8562,
             "name": "has_deadline",
             "type": "boolean"
           },
           {
-            "line": 8560,
+            "line": 8572,
             "name": "has_generic_rewards",
             "type": "boolean"
           },
           {
-            "line": 8552,
+            "line": 8564,
             "name": "has_target",
             "type": "boolean"
           },
           {
-            "line": 8542,
+            "line": 8554,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 8547,
+            "line": 8559,
             "name": "in_progress",
             "type": "boolean"
           },
           {
-            "line": 8556,
+            "line": 8568,
             "name": "item",
             "type": "GameId"
           },
           {
-            "line": 8559,
+            "line": 8571,
             "name": "likely_rewards",
             "type": "table"
           },
           {
-            "line": 8543,
+            "line": 8555,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 8557,
+            "line": 8569,
             "name": "npc_id",
             "type": "integer"
           },
           {
-            "line": 8549,
+            "line": 8561,
             "name": "selected",
             "type": "boolean"
           },
           {
-            "line": 8545,
+            "line": 8557,
             "name": "status",
             "type": "'reserved'|'active'|'success'|'failure'"
           },
           {
-            "line": 8553,
+            "line": 8565,
             "name": "target",
             "type": "TripointCoord"
           },
           {
-            "line": 8540,
+            "line": 8552,
             "name": "token",
             "type": "MissionToken"
           },
           {
-            "line": 8541,
+            "line": 8553,
             "name": "uid",
             "type": "integer"
           },
           {
-            "line": 8555,
+            "line": 8567,
             "name": "value",
             "type": "integer"
           }
@@ -5132,17 +5187,17 @@
       {
         "fields": [
           {
-            "line": 9881,
+            "line": 9893,
             "name": "capped",
             "type": "boolean"
           },
           {
-            "line": 9880,
+            "line": 9892,
             "name": "decay_start",
             "type": "TimeDuration"
           },
           {
-            "line": 9879,
+            "line": 9891,
             "name": "duration",
             "type": "TimeDuration"
           }
@@ -5156,22 +5211,22 @@
       {
         "fields": [
           {
-            "line": 10493,
+            "line": 10505,
             "name": "count",
             "type": "integer"
           },
           {
-            "line": 10494,
+            "line": 10506,
             "name": "current_id",
             "type": "string"
           },
           {
-            "line": 10495,
+            "line": 10507,
             "name": "desired_id",
             "type": "string"
           },
           {
-            "line": 10492,
+            "line": 10504,
             "name": "items",
             "type": "table"
           }
@@ -5181,17 +5236,17 @@
       {
         "fields": [
           {
-            "line": 9869,
+            "line": 9881,
             "name": "removed",
             "type": "GameId[]"
           },
           {
-            "line": 9870,
+            "line": 9882,
             "name": "removed_count",
             "type": "integer"
           },
           {
-            "line": 9868,
+            "line": 9880,
             "name": "type",
             "type": "string"
           }
@@ -5209,17 +5264,17 @@
       {
         "fields": [
           {
-            "line": 9381,
+            "line": 9393,
             "name": "completed",
             "type": "boolean"
           },
           {
-            "line": 9380,
+            "line": 9392,
             "name": "started",
             "type": "boolean"
           },
           {
-            "line": 9379,
+            "line": 9391,
             "name": "status",
             "type": "CcbNpcDialogueStatus"
           }
@@ -5237,42 +5292,42 @@
       {
         "fields": [
           {
-            "line": 9270,
+            "line": 9282,
             "name": "action",
             "type": "'assign'|'success'|'failure'|'clear'|'reward'"
           },
           {
-            "line": 9275,
+            "line": 9287,
             "name": "after",
             "type": "CcbNpcMissionsState"
           },
           {
-            "line": 9274,
+            "line": 9286,
             "name": "before",
             "type": "CcbNpcMissionsState"
           },
           {
-            "line": 9272,
+            "line": 9284,
             "name": "forced",
             "type": "boolean"
           },
           {
-            "line": 9273,
+            "line": 9285,
             "name": "owed_delta",
             "type": "integer"
           },
           {
-            "line": 9271,
+            "line": 9283,
             "name": "owner",
             "type": "GameHandle"
           },
           {
-            "line": 9277,
+            "line": 9289,
             "name": "provider_after",
             "type": "CcbNpcProviderState"
           },
           {
-            "line": 9276,
+            "line": 9288,
             "name": "provider_before",
             "type": "CcbNpcProviderState"
           }
@@ -5282,22 +5337,22 @@
       {
         "fields": [
           {
-            "line": 9267,
+            "line": 9279,
             "name": "after",
             "type": "CcbNpcMissionsState"
           },
           {
-            "line": 9266,
+            "line": 9278,
             "name": "before",
             "type": "CcbNpcMissionsState"
           },
           {
-            "line": 9264,
+            "line": 9276,
             "name": "mission",
             "type": "CcbNpcMissionSnapshot"
           },
           {
-            "line": 9265,
+            "line": 9277,
             "name": "owner",
             "type": "GameHandle"
           }
@@ -5307,17 +5362,17 @@
       {
         "fields": [
           {
-            "line": 9261,
+            "line": 9273,
             "name": "after",
             "type": "CcbNpcMissionsState"
           },
           {
-            "line": 9260,
+            "line": 9272,
             "name": "before",
             "type": "CcbNpcMissionsState"
           },
           {
-            "line": 9259,
+            "line": 9271,
             "name": "mission",
             "type": "CcbNpcMissionSnapshot"
           }
@@ -5327,22 +5382,22 @@
       {
         "fields": [
           {
-            "line": 9222,
+            "line": 9234,
             "name": "items",
             "type": "CcbNpcMissionSnapshot[]"
           },
           {
-            "line": 9224,
+            "line": 9236,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 9223,
+            "line": 9235,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 9225,
+            "line": 9237,
             "name": "truncated",
             "type": "boolean"
           }
@@ -5352,57 +5407,57 @@
       {
         "fields": [
           {
-            "line": 9214,
+            "line": 9226,
             "name": "assigned",
             "type": "boolean"
           },
           {
-            "line": 9216,
+            "line": 9228,
             "name": "failed",
             "type": "boolean"
           },
           {
-            "line": 9219,
+            "line": 9231,
             "name": "follow_up",
             "type": "GameId"
           },
           {
-            "line": 9218,
+            "line": 9230,
             "name": "generic_reward_claimed",
             "type": "boolean"
           },
           {
-            "line": 9217,
+            "line": 9229,
             "name": "has_generic_rewards",
             "type": "boolean"
           },
           {
-            "line": 9211,
+            "line": 9223,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 9215,
+            "line": 9227,
             "name": "in_progress",
             "type": "boolean"
           },
           {
-            "line": 9212,
+            "line": 9224,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 9213,
+            "line": 9225,
             "name": "status",
             "type": "CcbNpcMissionStatus"
           },
           {
-            "line": 9209,
+            "line": 9221,
             "name": "token",
             "type": "MissionToken"
           },
           {
-            "line": 9210,
+            "line": 9222,
             "name": "uid",
             "type": "integer"
           }
@@ -5416,32 +5471,32 @@
       {
         "fields": [
           {
-            "line": 9230,
+            "line": 9242,
             "name": "assigned",
             "type": "CcbNpcMissionPage"
           },
           {
-            "line": 9229,
+            "line": 9241,
             "name": "available",
             "type": "CcbNpcMissionPage"
           },
           {
-            "line": 9228,
+            "line": 9240,
             "name": "provider_id",
             "type": "integer"
           },
           {
-            "line": 9231,
+            "line": 9243,
             "name": "selected",
             "type": "CcbNpcMissionSnapshot"
           },
           {
-            "line": 9233,
+            "line": 9245,
             "name": "selected_invalid",
             "type": "boolean"
           },
           {
-            "line": 9232,
+            "line": 9244,
             "name": "selected_stale",
             "type": "boolean"
           }
@@ -5451,12 +5506,12 @@
       {
         "fields": [
           {
-            "line": 9256,
+            "line": 9268,
             "name": "after",
             "type": "CcbNpcMissionsState"
           },
           {
-            "line": 9255,
+            "line": 9267,
             "name": "before",
             "type": "CcbNpcMissionsState"
           }
@@ -5466,32 +5521,32 @@
       {
         "fields": [
           {
-            "line": 9184,
+            "line": 9196,
             "name": "anger",
             "type": "integer"
           },
           {
-            "line": 9182,
+            "line": 9194,
             "name": "fear",
             "type": "integer"
           },
           {
-            "line": 9185,
+            "line": 9197,
             "name": "owed",
             "type": "integer"
           },
           {
-            "line": 9186,
+            "line": 9198,
             "name": "sold",
             "type": "integer"
           },
           {
-            "line": 9181,
+            "line": 9193,
             "name": "trust",
             "type": "integer"
           },
           {
-            "line": 9183,
+            "line": 9195,
             "name": "value",
             "type": "integer"
           }
@@ -5501,87 +5556,87 @@
       {
         "fields": [
           {
-            "line": 9248,
+            "line": 9260,
             "name": "activity",
             "type": "GameId"
           },
           {
-            "line": 9250,
+            "line": 9262,
             "name": "attitude",
             "type": "integer"
           },
           {
-            "line": 9238,
+            "line": 9250,
             "name": "avatar",
             "type": "boolean"
           },
           {
-            "line": 9241,
+            "line": 9253,
             "name": "bionics",
             "type": "integer"
           },
           {
-            "line": 9245,
+            "line": 9257,
             "name": "bitten",
             "type": "boolean"
           },
           {
-            "line": 9244,
+            "line": 9256,
             "name": "bleeding",
             "type": "boolean"
           },
           {
-            "line": 9251,
+            "line": 9263,
             "name": "busy_turns",
             "type": "integer"
           },
           {
-            "line": 9252,
+            "line": 9264,
             "name": "current_activity",
             "type": "string"
           },
           {
-            "line": 9239,
+            "line": 9251,
             "name": "hp",
             "type": "integer"
           },
           {
-            "line": 9236,
+            "line": 9248,
             "name": "id",
             "type": "integer"
           },
           {
-            "line": 9246,
+            "line": 9258,
             "name": "infected",
             "type": "boolean"
           },
           {
-            "line": 9247,
+            "line": 9259,
             "name": "inventory_stacks",
             "type": "integer"
           },
           {
-            "line": 9240,
+            "line": 9252,
             "name": "maximum_hp",
             "type": "integer"
           },
           {
-            "line": 9243,
+            "line": 9255,
             "name": "mounted",
             "type": "boolean"
           },
           {
-            "line": 9242,
+            "line": 9254,
             "name": "mutations",
             "type": "integer"
           },
           {
-            "line": 9237,
+            "line": 9249,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 9249,
+            "line": 9261,
             "name": "owed",
             "type": "integer"
           }
@@ -5611,82 +5666,82 @@
       {
         "fields": [
           {
-            "line": 9204,
+            "line": 9216,
             "name": "ai_rules",
             "type": "table<string,"
           },
           {
-            "line": 9198,
+            "line": 9210,
             "name": "attitude",
             "type": "GameId"
           },
           {
-            "line": 9199,
+            "line": 9211,
             "name": "attitude_name",
             "type": "string"
           },
           {
-            "line": 9195,
+            "line": 9207,
             "name": "class",
             "type": "GameId"
           },
           {
-            "line": 9200,
+            "line": 9212,
             "name": "dead",
             "type": "boolean"
           },
           {
-            "line": 9193,
+            "line": 9205,
             "name": "display_name",
             "type": "string"
           },
           {
-            "line": 9197,
+            "line": 9209,
             "name": "faction",
             "type": "GameId|nil"
           },
           {
-            "line": 9202,
+            "line": 9214,
             "name": "first_topic",
             "type": "string"
           },
           {
-            "line": 9189,
+            "line": 9201,
             "name": "handle",
             "type": "GameHandle"
           },
           {
-            "line": 9190,
+            "line": 9202,
             "name": "id",
             "type": "integer"
           },
           {
-            "line": 9192,
+            "line": 9204,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 9203,
+            "line": 9215,
             "name": "opinion",
             "type": "CcbNpcOpinion"
           },
           {
-            "line": 9201,
+            "line": 9213,
             "name": "player_ally",
             "type": "boolean"
           },
           {
-            "line": 9194,
+            "line": 9206,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 9196,
+            "line": 9208,
             "name": "template",
             "type": "GameId|nil"
           },
           {
-            "line": 9191,
+            "line": 9203,
             "name": "unique_id",
             "type": "string"
           }
@@ -5700,27 +5755,27 @@
       {
         "fields": [
           {
-            "line": 9533,
+            "line": 9545,
             "name": "dialogue",
             "type": "CcbNpcDialogueActionsApi"
           },
           {
-            "line": 9530,
+            "line": 9542,
             "name": "grooming",
             "type": "CcbNpcGroomingApi"
           },
           {
-            "line": 9529,
+            "line": 9541,
             "name": "medical",
             "type": "CcbNpcMedicalApi"
           },
           {
-            "line": 9532,
+            "line": 9544,
             "name": "missions",
             "type": "CcbNpcMissionsApi"
           },
           {
-            "line": 9531,
+            "line": 9543,
             "name": "training",
             "type": "CcbNpcTrainingApi"
           }
@@ -5730,22 +5785,22 @@
       {
         "fields": [
           {
-            "line": 9884,
+            "line": 9896,
             "name": "items",
             "type": "GameId[]"
           },
           {
-            "line": 9886,
+            "line": 9898,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 9885,
+            "line": 9897,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 9887,
+            "line": 9899,
             "name": "truncated",
             "type": "boolean"
           }
@@ -6022,12 +6077,12 @@
       {
         "fields": [
           {
-            "line": 9797,
+            "line": 9809,
             "name": "activity",
             "type": "CcbPlatformActivitySnapshot"
           },
           {
-            "line": 9796,
+            "line": 9808,
             "name": "changed",
             "type": "boolean"
           }
@@ -6037,57 +6092,57 @@
       {
         "fields": [
           {
-            "line": 9783,
+            "line": 9795,
             "name": "active",
             "type": "boolean"
           },
           {
-            "line": 9790,
+            "line": 9802,
             "name": "auto_resume",
             "type": "boolean"
           },
           {
-            "line": 9784,
+            "line": 9796,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 9788,
+            "line": 9800,
             "name": "interruptible",
             "type": "boolean"
           },
           {
-            "line": 9789,
+            "line": 9801,
             "name": "interruptible_with_keyboard",
             "type": "boolean"
           },
           {
-            "line": 9787,
+            "line": 9799,
             "name": "moves_left",
             "type": "integer"
           },
           {
-            "line": 9786,
+            "line": 9798,
             "name": "moves_total",
             "type": "integer"
           },
           {
-            "line": 9793,
+            "line": 9805,
             "name": "progress",
             "type": "number"
           },
           {
-            "line": 9792,
+            "line": 9804,
             "name": "resumable",
             "type": "boolean"
           },
           {
-            "line": 9791,
+            "line": 9803,
             "name": "rooted",
             "type": "boolean"
           },
           {
-            "line": 9785,
+            "line": 9797,
             "name": "verb",
             "type": "string"
           }
@@ -6097,27 +6152,27 @@
       {
         "fields": [
           {
-            "line": 6046,
+            "line": 6058,
             "name": "cancellable",
             "type": "true"
           },
           {
-            "line": 6044,
+            "line": 6056,
             "name": "character",
             "type": "GameHandle"
           },
           {
-            "line": 6043,
+            "line": 6055,
             "name": "hook",
             "type": "'on_avatar_fatal'"
           },
           {
-            "line": 6045,
+            "line": 6057,
             "name": "killer",
             "type": "GameHandle"
           },
           {
-            "line": 6047,
+            "line": 6059,
             "name": "results",
             "type": "table"
           }
@@ -6127,22 +6182,22 @@
       {
         "fields": [
           {
-            "line": 10166,
+            "line": 10178,
             "name": "has_capacity",
             "type": "boolean"
           },
           {
-            "line": 10163,
+            "line": 10175,
             "name": "installed_count",
             "type": "integer"
           },
           {
-            "line": 10165,
+            "line": 10177,
             "name": "maximum_power",
             "type": "UnitValue"
           },
           {
-            "line": 10164,
+            "line": 10176,
             "name": "power",
             "type": "UnitValue"
           }
@@ -6189,27 +6244,27 @@
       {
         "fields": [
           {
-            "line": 6039,
+            "line": 6051,
             "name": "by_radio",
             "type": "boolean"
           },
           {
-            "line": 6037,
+            "line": 6049,
             "name": "interlocutor",
             "type": "CcbDialogueParticipant"
           },
           {
-            "line": 6038,
+            "line": 6050,
             "name": "last_topic",
             "type": "string"
           },
           {
-            "line": 6040,
+            "line": 6052,
             "name": "reason",
             "type": "string"
           },
           {
-            "line": 6036,
+            "line": 6048,
             "name": "speaker",
             "type": "CcbDialogueParticipant"
           }
@@ -6219,17 +6274,17 @@
       {
         "fields": [
           {
-            "line": 6174,
+            "line": 6186,
             "name": "id",
             "type": "string"
           },
           {
-            "line": 6175,
+            "line": 6187,
             "name": "insert_before_standard_exits",
             "type": "boolean"
           },
           {
-            "line": 6176,
+            "line": 6188,
             "name": "responses",
             "type": "CcbPlatformDialogueResponses"
           }
@@ -6239,27 +6294,27 @@
       {
         "fields": [
           {
-            "line": 6180,
+            "line": 6192,
             "name": "extensions",
             "type": "integer"
           },
           {
-            "line": 6182,
+            "line": 6194,
             "name": "id_bytes",
             "type": "integer"
           },
           {
-            "line": 6181,
+            "line": 6193,
             "name": "responses_per_topic",
             "type": "integer"
           },
           {
-            "line": 6183,
+            "line": 6195,
             "name": "text_bytes",
             "type": "integer"
           },
           {
-            "line": 6179,
+            "line": 6191,
             "name": "topics",
             "type": "integer"
           }
@@ -6269,32 +6324,32 @@
       {
         "fields": [
           {
-            "line": 6032,
+            "line": 6044,
             "name": "by_radio",
             "type": "boolean"
           },
           {
-            "line": 6030,
+            "line": 6042,
             "name": "current_topic",
             "type": "string"
           },
           {
-            "line": 6029,
+            "line": 6041,
             "name": "interlocutor",
             "type": "CcbDialogueParticipant"
           },
           {
-            "line": 6033,
+            "line": 6045,
             "name": "reason",
             "type": "string"
           },
           {
-            "line": 6031,
+            "line": 6043,
             "name": "selected_topic",
             "type": "string"
           },
           {
-            "line": 6028,
+            "line": 6040,
             "name": "speaker",
             "type": "CcbDialogueParticipant"
           }
@@ -6304,42 +6359,42 @@
       {
         "fields": [
           {
-            "line": 6204,
+            "line": 6216,
             "name": "by_radio",
             "type": "boolean"
           },
           {
-            "line": 6203,
+            "line": 6215,
             "name": "has_interlocutor",
             "type": "boolean"
           },
           {
-            "line": 6202,
+            "line": 6214,
             "name": "has_speaker",
             "type": "boolean"
           },
           {
-            "line": 6201,
+            "line": 6213,
             "name": "interlocutor",
             "type": "CcbDialogueParticipant"
           },
           {
-            "line": 6207,
+            "line": 6219,
             "name": "phase",
             "type": "'line'|'responses'"
           },
           {
-            "line": 6205,
+            "line": 6217,
             "name": "reason",
             "type": "string"
           },
           {
-            "line": 6200,
+            "line": 6212,
             "name": "speaker",
             "type": "CcbDialogueParticipant"
           },
           {
-            "line": 6206,
+            "line": 6218,
             "name": "topic",
             "type": "string"
           }
@@ -6349,12 +6404,12 @@
       {
         "fields": [
           {
-            "line": 6094,
+            "line": 6106,
             "name": "text",
             "type": "string"
           },
           {
-            "line": 6095,
+            "line": 6107,
             "name": "topic",
             "type": "string"
           }
@@ -6364,17 +6419,17 @@
       {
         "fields": [
           {
-            "line": 6164,
+            "line": 6176,
             "name": "on_select",
             "type": "fun(context:"
           },
           {
-            "line": 6162,
+            "line": 6174,
             "name": "text",
             "type": "string"
           },
           {
-            "line": 6163,
+            "line": 6175,
             "name": "topic",
             "type": "string"
           }
@@ -6384,27 +6439,27 @@
       {
         "fields": [
           {
-            "line": 6024,
+            "line": 6036,
             "name": "by_radio",
             "type": "boolean"
           },
           {
-            "line": 6023,
+            "line": 6035,
             "name": "initial_topic",
             "type": "string"
           },
           {
-            "line": 6022,
+            "line": 6034,
             "name": "interlocutor",
             "type": "CcbDialogueParticipant"
           },
           {
-            "line": 6025,
+            "line": 6037,
             "name": "reason",
             "type": "string"
           },
           {
-            "line": 6021,
+            "line": 6033,
             "name": "speaker",
             "type": "CcbDialogueParticipant"
           }
@@ -6414,17 +6469,17 @@
       {
         "fields": [
           {
-            "line": 6170,
+            "line": 6182,
             "name": "dynamic_line",
             "type": "string|fun(context:"
           },
           {
-            "line": 6169,
+            "line": 6181,
             "name": "id",
             "type": "string"
           },
           {
-            "line": 6171,
+            "line": 6183,
             "name": "responses",
             "type": "CcbPlatformDialogueResponses"
           }
@@ -6438,27 +6493,27 @@
       {
         "fields": [
           {
-            "line": 10452,
+            "line": 10464,
             "name": "environment",
             "type": "CcbPlatformEnvironmentQueries"
           },
           {
-            "line": 10451,
+            "line": 10463,
             "name": "math",
             "type": "CcbPlatformMathApi"
           },
           {
-            "line": 10450,
+            "line": 10462,
             "name": "mods",
             "type": "CcbPlatformModQueries"
           },
           {
-            "line": 10453,
+            "line": 10465,
             "name": "options",
             "type": "CcbPlatformGameplayOptionsApi"
           },
           {
-            "line": 10449,
+            "line": 10461,
             "name": "strings",
             "type": "CcbPlatformStringPredicates"
           }
@@ -6476,27 +6531,27 @@
       {
         "fields": [
           {
-            "line": 6443,
+            "line": 6455,
             "name": "description",
             "type": "string"
           },
           {
-            "line": 6444,
+            "line": 6456,
             "name": "enabled",
             "type": "boolean"
           },
           {
-            "line": 6445,
+            "line": 6457,
             "name": "hotkey",
             "type": "string"
           },
           {
-            "line": 6441,
+            "line": 6453,
             "name": "id",
             "type": "string"
           },
           {
-            "line": 6442,
+            "line": 6454,
             "name": "label",
             "type": "string"
           }
@@ -6506,17 +6561,17 @@
       {
         "fields": [
           {
-            "line": 6449,
+            "line": 6461,
             "name": "allow_cancel",
             "type": "boolean"
           },
           {
-            "line": 6450,
+            "line": 6462,
             "name": "highlight_disabled",
             "type": "boolean"
           },
           {
-            "line": 6448,
+            "line": 6460,
             "name": "title",
             "type": "string"
           }
@@ -6526,22 +6581,22 @@
       {
         "fields": [
           {
-            "line": 6453,
+            "line": 6465,
             "name": "accepted",
             "type": "boolean"
           },
           {
-            "line": 6454,
+            "line": 6466,
             "name": "cancelled",
             "type": "boolean"
           },
           {
-            "line": 6456,
+            "line": 6468,
             "name": "id",
             "type": "string"
           },
           {
-            "line": 6455,
+            "line": 6467,
             "name": "index",
             "type": "integer"
           }
@@ -6559,17 +6614,17 @@
       {
         "fields": [
           {
-            "line": 6810,
+            "line": 6822,
             "name": "terrain_ids",
             "type": "string[]"
           },
           {
-            "line": 6812,
+            "line": 6824,
             "name": "z_max",
             "type": "integer"
           },
           {
-            "line": 6811,
+            "line": 6823,
             "name": "z_min",
             "type": "integer"
           }
@@ -6599,17 +6654,17 @@
       {
         "fields": [
           {
-            "line": 10316,
+            "line": 10328,
             "name": "capped",
             "type": "boolean"
           },
           {
-            "line": 10315,
+            "line": 10327,
             "name": "decay_start",
             "type": "TimeDuration"
           },
           {
-            "line": 10314,
+            "line": 10326,
             "name": "duration",
             "type": "TimeDuration"
           }
@@ -6619,27 +6674,27 @@
       {
         "fields": [
           {
-            "line": 6011,
+            "line": 6023,
             "name": "actors",
             "type": "table<string,"
           },
           {
-            "line": 6002,
+            "line": 6014,
             "name": "data",
             "type": "table<string,"
           },
           {
-            "line": 6003,
+            "line": 6015,
             "name": "data_types",
             "type": "table<string,"
           },
           {
-            "line": 6001,
+            "line": 6013,
             "name": "turn",
             "type": "integer"
           },
           {
-            "line": 6000,
+            "line": 6012,
             "name": "type",
             "type": "string"
           }
@@ -6653,27 +6708,27 @@
       {
         "fields": [
           {
-            "line": 6053,
+            "line": 6065,
             "name": "cancellable",
             "type": "true"
           },
           {
-            "line": 6051,
+            "line": 6063,
             "name": "character",
             "type": "GameHandle"
           },
           {
-            "line": 6050,
+            "line": 6062,
             "name": "hook",
             "type": "'on_npc_fatal'"
           },
           {
-            "line": 6052,
+            "line": 6064,
             "name": "killer",
             "type": "GameHandle"
           },
           {
-            "line": 6054,
+            "line": 6066,
             "name": "results",
             "type": "table"
           }
@@ -6691,32 +6746,32 @@
       {
         "fields": [
           {
-            "line": 10286,
+            "line": 10298,
             "name": "category",
             "type": "GameId"
           },
           {
-            "line": 10282,
+            "line": 10294,
             "name": "changed",
             "type": "boolean"
           },
           {
-            "line": 10283,
+            "line": 10295,
             "name": "forgotten_count",
             "type": "integer"
           },
           {
-            "line": 10285,
+            "line": 10297,
             "name": "known_after",
             "type": "integer"
           },
           {
-            "line": 10284,
+            "line": 10296,
             "name": "known_before",
             "type": "integer"
           },
           {
-            "line": 10287,
+            "line": 10299,
             "name": "subcategory",
             "type": "string"
           }
@@ -6749,307 +6804,307 @@
       {
         "fields": [
           {
-            "line": 8203,
+            "line": 8215,
             "name": "achievements",
             "type": "CcbPlatformAchievementsApi"
           },
           {
-            "line": 8204,
+            "line": 8216,
             "name": "activities",
             "type": "CcbPlatformActivitiesApi"
           },
           {
-            "line": 8205,
+            "line": 8217,
             "name": "addictions",
             "type": "CcbAddictionsApi"
           },
           {
-            "line": 8206,
+            "line": 8218,
             "name": "bionics",
             "type": "CcbPlatformBionicsApi"
           },
           {
-            "line": 8207,
+            "line": 8219,
             "name": "camps",
             "type": "CcbCampsApi"
           },
           {
-            "line": 8208,
+            "line": 8220,
             "name": "characters",
             "type": "CcbCharactersApi"
           },
           {
-            "line": 8209,
+            "line": 8221,
             "name": "constants",
             "type": "CcbConstantsApi"
           },
           {
-            "line": 8210,
+            "line": 8222,
             "name": "coords",
             "type": "CcbCoordsApi"
           },
           {
-            "line": 8211,
+            "line": 8223,
             "name": "crafting",
             "type": "CcbCraftingApi"
           },
           {
-            "line": 8212,
+            "line": 8224,
             "name": "creatures",
             "type": "CcbCreaturesApi"
           },
           {
-            "line": 8213,
+            "line": 8225,
             "name": "effects",
             "type": "CcbEffectsApi"
           },
           {
-            "line": 8214,
+            "line": 8226,
             "name": "enums",
             "type": "CcbEnumsApi"
           },
           {
-            "line": 8258,
+            "line": 8270,
             "name": "equipment",
             "type": "CcbEquipmentApi"
           },
           {
-            "line": 8215,
+            "line": 8227,
             "name": "factions",
             "type": "CcbFactionsApi"
           },
           {
-            "line": 8216,
+            "line": 8228,
             "name": "followers",
             "type": "CcbFollowersApi"
           },
           {
-            "line": 8257,
+            "line": 8269,
             "name": "gameplay",
             "type": "CcbPlatformGameplayApi"
           },
           {
-            "line": 8217,
+            "line": 8229,
             "name": "handles",
             "type": "CcbHandlesApi"
           },
           {
-            "line": 8219,
+            "line": 8231,
             "name": "hordes",
             "type": "CcbHordesApi"
           },
           {
-            "line": 8218,
+            "line": 8230,
             "name": "interaction",
             "type": "CcbPlatformInteractionApi"
           },
           {
-            "line": 8220,
+            "line": 8232,
             "name": "inventory",
             "type": "CcbPlatformInventoryApi"
           },
           {
-            "line": 8222,
+            "line": 8234,
             "name": "item_categories",
             "type": "CcbItemCategoriesApi"
           },
           {
-            "line": 8221,
+            "line": 8233,
             "name": "items",
             "type": "CcbItemsApi"
           },
           {
-            "line": 8198,
+            "line": 8210,
             "name": "lore",
             "type": "CcbPlatformLoreApi"
           },
           {
-            "line": 8228,
+            "line": 8240,
             "name": "map",
             "type": "CcbMapApi"
           },
           {
-            "line": 8227,
+            "line": 8239,
             "name": "mapgen",
             "type": "CcbMapgenApi"
           },
           {
-            "line": 8223,
+            "line": 8235,
             "name": "martial_arts",
             "type": "CcbPlatformMartialArtsApi"
           },
           {
-            "line": 8224,
+            "line": 8236,
             "name": "messages",
             "type": "CcbPlatformMessagesApi"
           },
           {
-            "line": 8225,
+            "line": 8237,
             "name": "missions",
             "type": "CcbMissionsApi"
           },
           {
-            "line": 8226,
+            "line": 8238,
             "name": "morale",
             "type": "CcbPlatformMoraleApi"
           },
           {
-            "line": 8229,
+            "line": 8241,
             "name": "mutations",
             "type": "CcbMutationsApi"
           },
           {
-            "line": 8199,
+            "line": 8211,
             "name": "native_events",
             "type": "CcbPlatformNativeEventsApi"
           },
           {
-            "line": 8230,
+            "line": 8242,
             "name": "needs",
             "type": "CcbNeedsApi"
           },
           {
-            "line": 8231,
+            "line": 8243,
             "name": "npcs",
             "type": "CcbNpcsApi"
           },
           {
-            "line": 8232,
+            "line": 8244,
             "name": "overmap",
             "type": "CcbOvermapApi"
           },
           {
-            "line": 8233,
+            "line": 8245,
             "name": "proficiencies",
             "type": "CcbProficienciesApi"
           },
           {
-            "line": 8234,
+            "line": 8246,
             "name": "random",
             "type": "CcbPlatformRandomApi"
           },
           {
-            "line": 8235,
+            "line": 8247,
             "name": "recipes",
             "type": "CcbPlatformRecipesApi"
           },
           {
-            "line": 8238,
+            "line": 8250,
             "name": "registry",
             "type": "CcbRegistryApi"
           },
           {
-            "line": 8236,
+            "line": 8248,
             "name": "relocation",
             "type": "CcbRelocationApi"
           },
           {
-            "line": 8237,
+            "line": 8249,
             "name": "requirements",
             "type": "CcbRequirementsApi"
           },
           {
-            "line": 8239,
+            "line": 8251,
             "name": "serde",
             "type": "CcbSerdeApi"
           },
           {
-            "line": 8240,
+            "line": 8252,
             "name": "skills",
             "type": "CcbSkillsApi"
           },
           {
-            "line": 8200,
+            "line": 8212,
             "name": "snippets",
             "type": "CcbPlatformSnippetsApi"
           },
           {
-            "line": 8241,
+            "line": 8253,
             "name": "sound",
             "type": "CcbPlatformSoundApi"
           },
           {
-            "line": 8242,
+            "line": 8254,
             "name": "spawns",
             "type": "CcbSpawnsApi"
           },
           {
-            "line": 8243,
+            "line": 8255,
             "name": "spells",
             "type": "CcbSpellsApi"
           },
           {
-            "line": 8244,
+            "line": 8256,
             "name": "statistics",
             "type": "CcbStatisticsApi"
           },
           {
-            "line": 8245,
+            "line": 8257,
             "name": "targeting",
             "type": "CcbTargetingApi"
           },
           {
-            "line": 8201,
+            "line": 8213,
             "name": "text",
             "type": "CcbPlatformTextApi"
           },
           {
-            "line": 8202,
+            "line": 8214,
             "name": "tileset",
             "type": "CcbPlatformTilesetApi"
           },
           {
-            "line": 8246,
+            "line": 8258,
             "name": "time",
             "type": "CcbTimeApi"
           },
           {
-            "line": 8247,
+            "line": 8259,
             "name": "trade",
             "type": "CcbTradeApi"
           },
           {
-            "line": 8248,
+            "line": 8260,
             "name": "types",
             "type": "CcbTypesApi"
           },
           {
-            "line": 8249,
+            "line": 8261,
             "name": "units",
             "type": "CcbUnitsApi"
           },
           {
-            "line": 8250,
+            "line": 8262,
             "name": "variables",
             "type": "CcbVariablesApi"
           },
           {
-            "line": 8251,
+            "line": 8263,
             "name": "vehicles",
             "type": "CcbVehiclesApi"
           },
           {
-            "line": 8252,
+            "line": 8264,
             "name": "vitamins",
             "type": "CcbVitaminsApi"
           },
           {
-            "line": 8253,
+            "line": 8265,
             "name": "weather",
             "type": "CcbWeatherApi"
           },
           {
-            "line": 8255,
+            "line": 8267,
             "name": "world",
             "type": "CcbWorldApi"
           },
           {
-            "line": 8254,
+            "line": 8266,
             "name": "wounds",
             "type": "CcbPlatformWoundsApi"
           },
           {
-            "line": 8256,
+            "line": 8268,
             "name": "zones",
             "type": "CcbZonesApi"
           }
@@ -7067,12 +7122,12 @@
       {
         "fields": [
           {
-            "line": 6255,
+            "line": 6267,
             "name": "character",
             "type": "CcbPlatformStateScope"
           },
           {
-            "line": 6256,
+            "line": 6268,
             "name": "world",
             "type": "CcbPlatformStateScope"
           }
@@ -7082,37 +7137,37 @@
       {
         "fields": [
           {
-            "line": 6227,
+            "line": 6239,
             "name": "items",
             "type": "string[]"
           },
           {
-            "line": 6231,
+            "line": 6243,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 6229,
+            "line": 6241,
             "name": "matched",
             "type": "integer"
           },
           {
-            "line": 6233,
+            "line": 6245,
             "name": "next_after",
             "type": "string"
           },
           {
-            "line": 6230,
+            "line": 6242,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 6228,
+            "line": 6240,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 6232,
+            "line": 6244,
             "name": "truncated",
             "type": "boolean"
           }
@@ -7130,27 +7185,27 @@
       {
         "fields": [
           {
-            "line": 6311,
+            "line": 6323,
             "name": "items",
             "type": "CcbPlatformTaskSnapshot[]"
           },
           {
-            "line": 6314,
+            "line": 6326,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 6313,
+            "line": 6325,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 6312,
+            "line": 6324,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 6315,
+            "line": 6327,
             "name": "truncated",
             "type": "boolean"
           }
@@ -7160,32 +7215,32 @@
       {
         "fields": [
           {
-            "line": 6279,
+            "line": 6291,
             "name": "character_id",
             "type": "integer"
           },
           {
-            "line": 6280,
+            "line": 6292,
             "name": "item_uid",
             "type": "integer"
           },
           {
-            "line": 6278,
+            "line": 6290,
             "name": "kind",
             "type": "'character'|'item'|'monster'|'vehicle'"
           },
           {
-            "line": 6281,
+            "line": 6293,
             "name": "monster_uid",
             "type": "integer"
           },
           {
-            "line": 6283,
+            "line": 6295,
             "name": "pending",
             "type": "boolean"
           },
           {
-            "line": 6282,
+            "line": 6294,
             "name": "vehicle_uid",
             "type": "integer"
           }
@@ -7195,112 +7250,112 @@
       {
         "fields": [
           {
-            "line": 6297,
+            "line": 6309,
             "name": "actor_character_id",
             "type": "integer"
           },
           {
-            "line": 6299,
+            "line": 6311,
             "name": "actor_item_pending",
             "type": "boolean"
           },
           {
-            "line": 6298,
+            "line": 6310,
             "name": "actor_item_uid",
             "type": "integer"
           },
           {
-            "line": 6296,
+            "line": 6308,
             "name": "actor_kind",
             "type": "'character'|'item'|'monster'|'vehicle'"
           },
           {
-            "line": 6301,
+            "line": 6313,
             "name": "actor_monster_pending",
             "type": "boolean"
           },
           {
-            "line": 6300,
+            "line": 6312,
             "name": "actor_monster_uid",
             "type": "integer"
           },
           {
-            "line": 6303,
+            "line": 6315,
             "name": "actor_vehicle_pending",
             "type": "boolean"
           },
           {
-            "line": 6302,
+            "line": 6314,
             "name": "actor_vehicle_uid",
             "type": "integer"
           },
           {
-            "line": 6289,
+            "line": 6301,
             "name": "due_turn",
             "type": "integer"
           },
           {
-            "line": 6288,
+            "line": 6300,
             "name": "handler",
             "type": "string"
           },
           {
-            "line": 6306,
+            "line": 6318,
             "name": "handler_available",
             "type": "boolean"
           },
           {
-            "line": 6287,
+            "line": 6299,
             "name": "id",
             "type": "integer"
           },
           {
-            "line": 6293,
+            "line": 6305,
             "name": "interval_turns",
             "type": "integer"
           },
           {
-            "line": 6291,
+            "line": 6303,
             "name": "overdue_turns",
             "type": "integer"
           },
           {
-            "line": 6294,
+            "line": 6306,
             "name": "owner",
             "type": "'character'|'world'"
           },
           {
-            "line": 6295,
+            "line": 6307,
             "name": "owner_mod_id",
             "type": "string"
           },
           {
-            "line": 6304,
+            "line": 6316,
             "name": "participants",
             "type": "table<string,"
           },
           {
-            "line": 6308,
+            "line": 6320,
             "name": "payload",
             "type": "table<string,"
           },
           {
-            "line": 6307,
+            "line": 6319,
             "name": "payload_current",
             "type": "boolean"
           },
           {
-            "line": 6305,
+            "line": 6317,
             "name": "payload_version",
             "type": "integer"
           },
           {
-            "line": 6292,
+            "line": 6304,
             "name": "recurring",
             "type": "boolean"
           },
           {
-            "line": 6290,
+            "line": 6302,
             "name": "remaining_turns",
             "type": "integer"
           }
@@ -7322,47 +7377,47 @@
       {
         "fields": [
           {
-            "line": 10642,
+            "line": 10654,
             "name": "ModDefinition",
             "type": "fun(options:"
           },
           {
-            "line": 10643,
+            "line": 10655,
             "name": "content",
             "type": "CcbPlatformContent"
           },
           {
-            "line": 10645,
+            "line": 10657,
             "name": "dialogue",
             "type": "CcbPlatformDialogueApi"
           },
           {
-            "line": 10641,
+            "line": 10653,
             "name": "platform_version",
             "type": "1"
           },
           {
-            "line": 10648,
+            "line": 10660,
             "name": "presentation",
             "type": "CcbPlatformPresentation"
           },
           {
-            "line": 10644,
+            "line": 10656,
             "name": "runtime",
             "type": "CcbPlatformRuntime"
           },
           {
-            "line": 10649,
+            "line": 10661,
             "name": "services",
             "type": "CcbPlatformServices"
           },
           {
-            "line": 10646,
+            "line": 10658,
             "name": "state",
             "type": "CcbPlatformState"
           },
           {
-            "line": 10647,
+            "line": 10659,
             "name": "tasks",
             "type": "CcbPlatformTasks"
           }
@@ -7372,17 +7427,17 @@
       {
         "fields": [
           {
-            "line": 9832,
+            "line": 9844,
             "name": "after",
             "type": "CcbPlatformWoundSnapshot[]"
           },
           {
-            "line": 9831,
+            "line": 9843,
             "name": "before",
             "type": "CcbPlatformWoundSnapshot[]"
           },
           {
-            "line": 9830,
+            "line": 9842,
             "name": "changed",
             "type": "boolean"
           }
@@ -7392,32 +7447,32 @@
       {
         "fields": [
           {
-            "line": 9823,
+            "line": 9835,
             "name": "base_pain",
             "type": "integer"
           },
           {
-            "line": 9824,
+            "line": 9836,
             "name": "current_pain",
             "type": "integer"
           },
           {
-            "line": 9827,
+            "line": 9839,
             "name": "healing_fraction",
             "type": "number"
           },
           {
-            "line": 9826,
+            "line": 9838,
             "name": "healing_progress",
             "type": "TimeDuration"
           },
           {
-            "line": 9825,
+            "line": 9837,
             "name": "healing_time",
             "type": "TimeDuration"
           },
           {
-            "line": 9822,
+            "line": 9834,
             "name": "id",
             "type": "GameId"
           }
@@ -7431,37 +7486,37 @@
       {
         "fields": [
           {
-            "line": 10203,
+            "line": 10215,
             "name": "batch",
             "type": "integer"
           },
           {
-            "line": 10202,
+            "line": 10214,
             "name": "has_more",
             "type": "boolean"
           },
           {
-            "line": 10197,
+            "line": 10209,
             "name": "items",
             "type": "table"
           },
           {
-            "line": 10200,
+            "line": 10212,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 10199,
+            "line": 10211,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 10201,
+            "line": 10213,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 10198,
+            "line": 10210,
             "name": "total",
             "type": "integer"
           }
@@ -7471,47 +7526,47 @@
       {
         "fields": [
           {
-            "line": 10188,
+            "line": 10200,
             "name": "batch",
             "type": "integer"
           },
           {
-            "line": 10191,
+            "line": 10203,
             "name": "craftable",
             "type": "boolean"
           },
           {
-            "line": 10194,
+            "line": 10206,
             "name": "flag",
             "type": "string"
           },
           {
-            "line": 10189,
+            "line": 10201,
             "name": "include_obsolete",
             "type": "boolean"
           },
           {
-            "line": 10190,
+            "line": 10202,
             "name": "known",
             "type": "boolean"
           },
           {
-            "line": 10187,
+            "line": 10199,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 10186,
+            "line": 10198,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 10193,
+            "line": 10205,
             "name": "result",
             "type": "GameId"
           },
           {
-            "line": 10192,
+            "line": 10204,
             "name": "skill",
             "type": "GameId"
           }
@@ -7529,7 +7584,7 @@
       {
         "fields": [
           {
-            "line": 7475,
+            "line": 7487,
             "name": "strict",
             "type": "true"
           }
@@ -7539,12 +7594,12 @@
       {
         "fields": [
           {
-            "line": 7486,
+            "line": 7498,
             "name": "error",
             "type": "CcbPlatformResultError"
           },
           {
-            "line": 7485,
+            "line": 7497,
             "name": "value",
             "type": "CcbRelocationMoveValue"
           }
@@ -7554,27 +7609,27 @@
       {
         "fields": [
           {
-            "line": 7478,
+            "line": 7490,
             "name": "changed",
             "type": "boolean"
           },
           {
-            "line": 7480,
+            "line": 7492,
             "name": "handle",
             "type": "GameHandle"
           },
           {
-            "line": 7482,
+            "line": 7494,
             "name": "overmap_terrain",
             "type": "TripointCoord"
           },
           {
-            "line": 7481,
+            "line": 7493,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 7479,
+            "line": 7491,
             "name": "scope",
             "type": "'monster'|'avatar'|'npc'|'vehicle'"
           }
@@ -7584,17 +7639,17 @@
       {
         "fields": [
           {
-            "line": 10208,
+            "line": 10220,
             "name": "batch",
             "type": "integer"
           },
           {
-            "line": 10207,
+            "line": 10219,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 10206,
+            "line": 10218,
             "name": "offset",
             "type": "integer"
           }
@@ -7632,22 +7687,22 @@
       {
         "fields": [
           {
-            "line": 10536,
+            "line": 10548,
             "name": "season_id",
             "type": "string"
           },
           {
-            "line": 10537,
+            "line": 10549,
             "name": "season_name",
             "type": "string"
           },
           {
-            "line": 10534,
+            "line": 10546,
             "name": "turn",
             "type": "integer"
           },
           {
-            "line": 10535,
+            "line": 10547,
             "name": "year",
             "type": "integer"
           }
@@ -7661,7 +7716,7 @@
       {
         "fields": [
           {
-            "line": 9682,
+            "line": 9694,
             "name": "code",
             "type": "CcbTradeCommitErrorCode"
           }
@@ -7671,27 +7726,27 @@
       {
         "fields": [
           {
-            "line": 9685,
+            "line": 9697,
             "name": "direction",
             "type": "'seller_to_buyer'|'buyer_to_seller'"
           },
           {
-            "line": 9686,
+            "line": 9698,
             "name": "item_uid",
             "type": "integer"
           },
           {
-            "line": 9688,
+            "line": 9700,
             "name": "quantity",
             "type": "integer"
           },
           {
-            "line": 9689,
+            "line": 9701,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 9687,
+            "line": 9699,
             "name": "transferred_item_uid",
             "type": "integer"
           }
@@ -7701,12 +7756,12 @@
       {
         "fields": [
           {
-            "line": 9711,
+            "line": 9723,
             "name": "error",
             "type": "CcbTradeCommitError"
           },
           {
-            "line": 9710,
+            "line": 9722,
             "name": "value",
             "type": "CcbTradeCommitValue"
           }
@@ -7716,82 +7771,82 @@
       {
         "fields": [
           {
-            "line": 9705,
+            "line": 9717,
             "name": "buyer_cash_after",
             "type": "integer"
           },
           {
-            "line": 9703,
+            "line": 9715,
             "name": "buyer_cash_before",
             "type": "integer"
           },
           {
-            "line": 9695,
+            "line": 9707,
             "name": "commit_generation",
             "type": "integer"
           },
           {
-            "line": 9692,
+            "line": 9704,
             "name": "committed",
             "type": "true"
           },
           {
-            "line": 9693,
+            "line": 9705,
             "name": "consumed",
             "type": "true"
           },
           {
-            "line": 9697,
+            "line": 9709,
             "name": "currency",
             "type": "'cash'"
           },
           {
-            "line": 9700,
+            "line": 9712,
             "name": "debt_after",
             "type": "integer"
           },
           {
-            "line": 9699,
+            "line": 9711,
             "name": "debt_before",
             "type": "integer"
           },
           {
-            "line": 9707,
+            "line": 9719,
             "name": "lines",
             "type": "CcbTradeCommitLineResult[]"
           },
           {
-            "line": 9694,
+            "line": 9706,
             "name": "quote_id",
             "type": "integer"
           },
           {
-            "line": 9706,
+            "line": 9718,
             "name": "seller_cash_after",
             "type": "integer"
           },
           {
-            "line": 9704,
+            "line": 9716,
             "name": "seller_cash_before",
             "type": "integer"
           },
           {
-            "line": 9698,
+            "line": 9710,
             "name": "settlement_amount",
             "type": "integer"
           },
           {
-            "line": 9696,
+            "line": 9708,
             "name": "settlement_strategy",
             "type": "CcbTradeCommitSettlementStrategy"
           },
           {
-            "line": 9702,
+            "line": 9714,
             "name": "sold_after",
             "type": "integer"
           },
           {
-            "line": 9701,
+            "line": 9713,
             "name": "sold_before",
             "type": "integer"
           }
@@ -7801,12 +7856,12 @@
       {
         "fields": [
           {
-            "line": 9563,
+            "line": 9575,
             "name": "currency",
             "type": "'cash'"
           },
           {
-            "line": 9562,
+            "line": 9574,
             "name": "strategy",
             "type": "'npc_debt'"
           }
@@ -7816,17 +7871,17 @@
       {
         "fields": [
           {
-            "line": 9571,
+            "line": 9583,
             "name": "character",
             "type": "GameHandle"
           },
           {
-            "line": 9570,
+            "line": 9582,
             "name": "kind",
             "type": "'character'"
           },
           {
-            "line": 9572,
+            "line": 9584,
             "name": "slot",
             "type": "'inventory'|'worn'|'wielded'"
           }
@@ -7836,12 +7891,12 @@
       {
         "fields": [
           {
-            "line": 9575,
+            "line": 9587,
             "name": "locator",
             "type": "table<string,"
           },
           {
-            "line": 9576,
+            "line": 9588,
             "name": "mutation_generation",
             "type": "integer"
           }
@@ -7851,27 +7906,27 @@
       {
         "fields": [
           {
-            "line": 9583,
+            "line": 9595,
             "name": "destination_holder",
             "type": "CcbTradeQuoteHolder"
           },
           {
-            "line": 9579,
+            "line": 9591,
             "name": "direction",
             "type": "'seller_to_buyer'|'buyer_to_seller'"
           },
           {
-            "line": 9580,
+            "line": 9592,
             "name": "item",
             "type": "GameHandle"
           },
           {
-            "line": 9581,
+            "line": 9593,
             "name": "quantity",
             "type": "integer"
           },
           {
-            "line": 9582,
+            "line": 9594,
             "name": "source_holder",
             "type": "CcbTradeQuoteHolder"
           }
@@ -7881,77 +7936,77 @@
       {
         "fields": [
           {
-            "line": 9603,
+            "line": 9615,
             "name": "accepted",
             "type": "boolean"
           },
           {
-            "line": 9595,
+            "line": 9607,
             "name": "charges_at_quote",
             "type": "integer"
           },
           {
-            "line": 9597,
+            "line": 9609,
             "name": "destination_holder",
             "type": "CcbTradeQuoteHolderSnapshot"
           },
           {
-            "line": 9599,
+            "line": 9611,
             "name": "destination_holder_mutation_generation",
             "type": "integer"
           },
           {
-            "line": 9590,
+            "line": 9602,
             "name": "direction",
             "type": "'seller_to_buyer'|'buyer_to_seller'"
           },
           {
-            "line": 9591,
+            "line": 9603,
             "name": "item",
             "type": "GameHandle"
           },
           {
-            "line": 9593,
+            "line": 9605,
             "name": "item_identity_generation",
             "type": "integer"
           },
           {
-            "line": 9592,
+            "line": 9604,
             "name": "item_uid",
             "type": "integer"
           },
           {
-            "line": 9594,
+            "line": 9606,
             "name": "quantity",
             "type": "integer"
           },
           {
-            "line": 9604,
+            "line": 9616,
             "name": "rejection_reason",
             "type": "string"
           },
           {
-            "line": 9596,
+            "line": 9608,
             "name": "source_holder",
             "type": "CcbTradeQuoteHolderSnapshot"
           },
           {
-            "line": 9598,
+            "line": 9610,
             "name": "source_holder_mutation_generation",
             "type": "integer"
           },
           {
-            "line": 9602,
+            "line": 9614,
             "name": "tax",
             "type": "integer"
           },
           {
-            "line": 9601,
+            "line": 9613,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 9600,
+            "line": 9612,
             "name": "unit_price",
             "type": "integer"
           }
@@ -7961,12 +8016,12 @@
       {
         "fields": [
           {
-            "line": 9587,
+            "line": 9599,
             "name": "expiry_turns",
             "type": "integer"
           },
           {
-            "line": 9586,
+            "line": 9598,
             "name": "settlement",
             "type": "CcbTradeQuoteSettlement"
           }
@@ -7976,12 +8031,12 @@
       {
         "fields": [
           {
-            "line": 9557,
+            "line": 9569,
             "name": "currency",
             "type": "'cash'"
           },
           {
-            "line": 9556,
+            "line": 9568,
             "name": "strategy",
             "type": "CcbTradeQuoteSettlementStrategy"
           }
@@ -7991,157 +8046,157 @@
       {
         "fields": [
           {
-            "line": 9635,
+            "line": 9647,
             "name": "available_settlement_modes",
             "type": "string[]"
           },
           {
-            "line": 9609,
+            "line": 9621,
             "name": "buyer",
             "type": "GameHandle"
           },
           {
-            "line": 9630,
+            "line": 9642,
             "name": "buyer_cash_before",
             "type": "integer"
           },
           {
-            "line": 9613,
+            "line": 9625,
             "name": "buyer_identity_generation",
             "type": "integer"
           },
           {
-            "line": 9611,
+            "line": 9623,
             "name": "buyer_stable_id",
             "type": "integer"
           },
           {
-            "line": 9622,
+            "line": 9634,
             "name": "buyer_to_seller_total",
             "type": "integer"
           },
           {
-            "line": 9620,
+            "line": 9632,
             "name": "currency",
             "type": "'cash'"
           },
           {
-            "line": 9627,
+            "line": 9639,
             "name": "debt_after",
             "type": "integer|nil"
           },
           {
-            "line": 9626,
+            "line": 9638,
             "name": "debt_before",
             "type": "integer|nil"
           },
           {
-            "line": 9617,
+            "line": 9629,
             "name": "debt_generation",
             "type": "integer"
           },
           {
-            "line": 9634,
+            "line": 9646,
             "name": "expires_turn",
             "type": "integer"
           },
           {
-            "line": 9616,
+            "line": 9628,
             "name": "faction_generation",
             "type": "integer"
           },
           {
-            "line": 9632,
+            "line": 9644,
             "name": "free_exchange",
             "type": "boolean"
           },
           {
-            "line": 9614,
+            "line": 9626,
             "name": "holder_mutation_generation",
             "type": "integer"
           },
           {
-            "line": 9633,
+            "line": 9645,
             "name": "issued_turn",
             "type": "integer"
           },
           {
-            "line": 9636,
+            "line": 9648,
             "name": "lines",
             "type": "CcbTradeQuoteLineSnapshot[]"
           },
           {
-            "line": 9623,
+            "line": 9635,
             "name": "net",
             "type": "integer"
           },
           {
-            "line": 9618,
+            "line": 9630,
             "name": "opinion_generation",
             "type": "integer"
           },
           {
-            "line": 9615,
+            "line": 9627,
             "name": "pricing_generation",
             "type": "integer"
           },
           {
-            "line": 9637,
+            "line": 9649,
             "name": "rejection_reasons",
             "type": "string[]"
           },
           {
-            "line": 9608,
+            "line": 9620,
             "name": "seller",
             "type": "GameHandle"
           },
           {
-            "line": 9631,
+            "line": 9643,
             "name": "seller_cash_before",
             "type": "integer"
           },
           {
-            "line": 9612,
+            "line": 9624,
             "name": "seller_identity_generation",
             "type": "integer"
           },
           {
-            "line": 9610,
+            "line": 9622,
             "name": "seller_stable_id",
             "type": "integer"
           },
           {
-            "line": 9621,
+            "line": 9633,
             "name": "seller_to_buyer_total",
             "type": "integer"
           },
           {
-            "line": 9625,
+            "line": 9637,
             "name": "settlement_amount",
             "type": "integer"
           },
           {
-            "line": 9619,
+            "line": 9631,
             "name": "settlement_strategy",
             "type": "CcbTradeQuoteSettlementStrategy"
           },
           {
-            "line": 9629,
+            "line": 9641,
             "name": "sold_after",
             "type": "integer|nil"
           },
           {
-            "line": 9628,
+            "line": 9640,
             "name": "sold_before",
             "type": "integer|nil"
           },
           {
-            "line": 9624,
+            "line": 9636,
             "name": "tax",
             "type": "integer"
           },
           {
-            "line": 9607,
+            "line": 9619,
             "name": "token",
             "type": "TradeQuoteToken"
           }
@@ -8155,7 +8210,7 @@
       {
         "fields": [
           {
-            "line": 9959,
+            "line": 9971,
             "name": "value",
             "type": "CcbVariableReadValue"
           }
@@ -8165,12 +8220,12 @@
       {
         "fields": [
           {
-            "line": 9955,
+            "line": 9967,
             "name": "exists",
             "type": "boolean"
           },
           {
-            "line": 9956,
+            "line": 9968,
             "name": "value",
             "type": "any"
           }
@@ -8204,37 +8259,37 @@
       {
         "fields": [
           {
-            "line": 8427,
+            "line": 8439,
             "name": "after",
             "type": "CcbVehiclePartSnapshot"
           },
           {
-            "line": 8426,
+            "line": 8438,
             "name": "before",
             "type": "CcbVehiclePartSnapshot"
           },
           {
-            "line": 8425,
+            "line": 8437,
             "name": "changed",
             "type": "boolean"
           },
           {
-            "line": 8429,
+            "line": 8441,
             "name": "part",
             "type": "GameHandle"
           },
           {
-            "line": 8431,
+            "line": 8443,
             "name": "part_error",
             "type": "string"
           },
           {
-            "line": 8430,
+            "line": 8442,
             "name": "part_stale",
             "type": "boolean"
           },
           {
-            "line": 8428,
+            "line": 8440,
             "name": "vehicle",
             "type": "GameHandle"
           }
@@ -8259,7 +8314,7 @@
       {
         "fields": [
           {
-            "line": 8434,
+            "line": 8446,
             "name": "status",
             "type": "\"cancelled\"|\"no_vehicle\"|\"no_value\"|\"no_output\"|\"payment_cancelled\"|\"invalidated\"|\"repairing\"|\"removing\"|\"installing\""
           }
@@ -8269,102 +8324,102 @@
       {
         "fields": [
           {
-            "line": 8390,
+            "line": 8402,
             "name": "ammo",
             "type": "table<string,"
           },
           {
-            "line": 8385,
+            "line": 8397,
             "name": "available",
             "type": "boolean"
           },
           {
-            "line": 8384,
+            "line": 8396,
             "name": "broken",
             "type": "boolean"
           },
           {
-            "line": 8383,
+            "line": 8395,
             "name": "damage_percent",
             "type": "number"
           },
           {
-            "line": 8382,
+            "line": 8394,
             "name": "durability",
             "type": "integer"
           },
           {
-            "line": 8386,
+            "line": 8398,
             "name": "enabled",
             "type": "boolean"
           },
           {
-            "line": 8388,
+            "line": 8400,
             "name": "fake",
             "type": "boolean"
           },
           {
-            "line": 8389,
+            "line": 8401,
             "name": "features",
             "type": "table<string,"
           },
           {
-            "line": 8371,
+            "line": 8383,
             "name": "handle",
             "type": "GameHandle"
           },
           {
-            "line": 8381,
+            "line": 8393,
             "name": "hp",
             "type": "integer"
           },
           {
-            "line": 8375,
+            "line": 8387,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 8374,
+            "line": 8386,
             "name": "index",
             "type": "integer"
           },
           {
-            "line": 8376,
+            "line": 8388,
             "name": "location",
             "type": "GameId"
           },
           {
-            "line": 8378,
+            "line": 8390,
             "name": "mount",
             "type": "table<string,"
           },
           {
-            "line": 8377,
+            "line": 8389,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 8373,
+            "line": 8385,
             "name": "part_uid",
             "type": "integer"
           },
           {
-            "line": 8379,
+            "line": 8391,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 8387,
+            "line": 8399,
             "name": "removed",
             "type": "boolean"
           },
           {
-            "line": 8380,
+            "line": 8392,
             "name": "variant",
             "type": "string"
           },
           {
-            "line": 8372,
+            "line": 8384,
             "name": "vehicle",
             "type": "GameHandle"
           }
@@ -8374,42 +8429,42 @@
       {
         "fields": [
           {
-            "line": 8398,
+            "line": 8410,
             "name": "has_more",
             "type": "boolean"
           },
           {
-            "line": 8399,
+            "line": 8411,
             "name": "include_fake",
             "type": "boolean"
           },
           {
-            "line": 8400,
+            "line": 8412,
             "name": "include_removed",
             "type": "boolean"
           },
           {
-            "line": 8393,
+            "line": 8405,
             "name": "items",
             "type": "CcbVehiclePartSnapshot[]"
           },
           {
-            "line": 8395,
+            "line": 8407,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 8394,
+            "line": 8406,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 8397,
+            "line": 8409,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 8396,
+            "line": 8408,
             "name": "total",
             "type": "integer"
           }
@@ -8419,47 +8474,47 @@
       {
         "fields": [
           {
-            "line": 8404,
+            "line": 8416,
             "name": "display_name",
             "type": "string"
           },
           {
-            "line": 8411,
+            "line": 8423,
             "name": "lift",
             "type": "table<string,"
           },
           {
-            "line": 8410,
+            "line": 8422,
             "name": "motion",
             "type": "table<string,"
           },
           {
-            "line": 8403,
+            "line": 8415,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 8407,
+            "line": 8419,
             "name": "parts",
             "type": "integer"
           },
           {
-            "line": 8406,
+            "line": 8418,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 8405,
+            "line": 8417,
             "name": "prototype",
             "type": "GameId"
           },
           {
-            "line": 8408,
+            "line": 8420,
             "name": "real_parts",
             "type": "integer"
           },
           {
-            "line": 8409,
+            "line": 8421,
             "name": "state",
             "type": "table<string,"
           }
@@ -8469,27 +8524,27 @@
       {
         "fields": [
           {
-            "line": 8415,
+            "line": 8427,
             "name": "fuel_percent",
             "type": "integer"
           },
           {
-            "line": 8417,
+            "line": 8429,
             "name": "merge_wrecks",
             "type": "boolean"
           },
           {
-            "line": 8418,
+            "line": 8430,
             "name": "owner",
             "type": "GameId"
           },
           {
-            "line": 8414,
+            "line": 8426,
             "name": "rotation_degrees",
             "type": "integer"
           },
           {
-            "line": 8416,
+            "line": 8428,
             "name": "status",
             "type": "integer"
           }
@@ -8499,12 +8554,12 @@
       {
         "fields": [
           {
-            "line": 8421,
+            "line": 8433,
             "name": "handle",
             "type": "GameHandle"
           },
           {
-            "line": 8422,
+            "line": 8434,
             "name": "vehicle",
             "type": "CcbVehicleSnapshot"
           }
@@ -8542,72 +8597,72 @@
       {
         "fields": [
           {
-            "line": 7585,
+            "line": 7597,
             "name": "changed",
             "type": "boolean"
           },
           {
-            "line": 7586,
+            "line": 7598,
             "name": "lightning_active",
             "type": "boolean"
           },
           {
-            "line": 7584,
+            "line": 7596,
             "name": "next_update",
             "type": "TimePoint"
           },
           {
-            "line": 7591,
+            "line": 7603,
             "name": "precise",
             "type": "CcbWeatherPointSnapshot"
           },
           {
-            "line": 7580,
+            "line": 7592,
             "name": "temperature",
             "type": "UnitValue"
           },
           {
-            "line": 7581,
+            "line": 7593,
             "name": "temperature_c",
             "type": "number"
           },
           {
-            "line": 7588,
+            "line": 7600,
             "name": "temperature_override",
             "type": "UnitValue"
           },
           {
-            "line": 7579,
+            "line": 7591,
             "name": "type",
             "type": "CcbWeatherTypeSnapshot"
           },
           {
-            "line": 7578,
+            "line": 7590,
             "name": "weather",
             "type": "GameId"
           },
           {
-            "line": 7587,
+            "line": 7599,
             "name": "weather_override",
             "type": "GameId"
           },
           {
-            "line": 7583,
+            "line": 7595,
             "name": "wind_direction_degrees",
             "type": "integer"
           },
           {
-            "line": 7590,
+            "line": 7602,
             "name": "wind_direction_override_degrees",
             "type": "integer"
           },
           {
-            "line": 7582,
+            "line": 7594,
             "name": "wind_speed_mph",
             "type": "integer"
           },
           {
-            "line": 7589,
+            "line": 7601,
             "name": "wind_speed_override_mph",
             "type": "integer"
           }
@@ -8617,27 +8672,27 @@
       {
         "fields": [
           {
-            "line": 7627,
+            "line": 7639,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7625,
+            "line": 7637,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 7628,
+            "line": 7640,
             "name": "respect_override",
             "type": "boolean"
           },
           {
-            "line": 7624,
+            "line": 7636,
             "name": "start",
             "type": "TimePoint"
           },
           {
-            "line": 7626,
+            "line": 7638,
             "name": "step",
             "type": "TimeDuration"
           }
@@ -8647,37 +8702,37 @@
       {
         "fields": [
           {
-            "line": 7631,
+            "line": 7643,
             "name": "items",
             "type": "CcbWeatherPointSnapshot[]"
           },
           {
-            "line": 7633,
+            "line": 7645,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7636,
+            "line": 7648,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 7637,
+            "line": 7649,
             "name": "respected_override",
             "type": "boolean"
           },
           {
-            "line": 7632,
+            "line": 7644,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 7634,
+            "line": 7646,
             "name": "start",
             "type": "TimePoint"
           },
           {
-            "line": 7635,
+            "line": 7647,
             "name": "step",
             "type": "TimeDuration"
           }
@@ -8687,62 +8742,62 @@
       {
         "fields": [
           {
-            "line": 7613,
+            "line": 7625,
             "name": "base_humidity",
             "type": "number"
           },
           {
-            "line": 7614,
+            "line": 7626,
             "name": "base_pressure",
             "type": "number"
           },
           {
-            "line": 7612,
+            "line": 7624,
             "name": "base_temperature_c",
             "type": "number"
           },
           {
-            "line": 7615,
+            "line": 7627,
             "name": "base_wind_mph",
             "type": "number"
           },
           {
-            "line": 7619,
+            "line": 7631,
             "name": "blacklist",
             "type": "CcbWeatherStringPage"
           },
           {
-            "line": 7610,
+            "line": 7622,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 7611,
+            "line": 7623,
             "name": "loaded",
             "type": "boolean"
           },
           {
-            "line": 7618,
+            "line": 7630,
             "name": "seasonal",
             "type": "CcbWeatherSeasonalSnapshot"
           },
           {
-            "line": 7621,
+            "line": 7633,
             "name": "sorted_weather",
             "type": "CcbWeatherTypeIdPage"
           },
           {
-            "line": 7620,
+            "line": 7632,
             "name": "whitelist",
             "type": "CcbWeatherStringPage"
           },
           {
-            "line": 7616,
+            "line": 7628,
             "name": "wind_distribution_peaks",
             "type": "integer"
           },
           {
-            "line": 7617,
+            "line": 7629,
             "name": "wind_season_variation",
             "type": "integer"
           }
@@ -8752,32 +8807,32 @@
       {
         "fields": [
           {
-            "line": 7690,
+            "line": 7702,
             "name": "accepted",
             "type": "boolean"
           },
           {
-            "line": 7687,
+            "line": 7699,
             "name": "duration",
             "type": "TimeDuration"
           },
           {
-            "line": 7688,
+            "line": 7700,
             "name": "expires_at",
             "type": "TimePoint"
           },
           {
-            "line": 7689,
+            "line": 7701,
             "name": "key",
             "type": "string"
           },
           {
-            "line": 7686,
+            "line": 7698,
             "name": "level",
             "type": "integer"
           },
           {
-            "line": 7691,
+            "line": 7703,
             "name": "replaced",
             "type": "boolean"
           }
@@ -8787,72 +8842,72 @@
       {
         "fields": [
           {
-            "line": 7640,
+            "line": 7652,
             "name": "catalog_limit",
             "type": "integer"
           },
           {
-            "line": 7643,
+            "line": 7655,
             "name": "forecast_limit",
             "type": "integer"
           },
           {
-            "line": 7646,
+            "line": 7658,
             "name": "forecast_maximum_horizon",
             "type": "TimeDuration"
           },
           {
-            "line": 7645,
+            "line": 7657,
             "name": "forecast_maximum_step",
             "type": "TimeDuration"
           },
           {
-            "line": 7644,
+            "line": 7656,
             "name": "forecast_minimum_step",
             "type": "TimeDuration"
           },
           {
-            "line": 7641,
+            "line": 7653,
             "name": "maximum_catalog_offset",
             "type": "integer"
           },
           {
-            "line": 7651,
+            "line": 7663,
             "name": "maximum_custom_light_duration",
             "type": "TimeDuration"
           },
           {
-            "line": 7652,
+            "line": 7664,
             "name": "maximum_custom_light_key_bytes",
             "type": "integer"
           },
           {
-            "line": 7650,
+            "line": 7662,
             "name": "maximum_custom_light_level",
             "type": "integer"
           },
           {
-            "line": 7642,
+            "line": 7654,
             "name": "maximum_nested_values",
             "type": "integer"
           },
           {
-            "line": 7653,
+            "line": 7665,
             "name": "maximum_pending_custom_light_events",
             "type": "integer"
           },
           {
-            "line": 7649,
+            "line": 7661,
             "name": "maximum_temperature_kelvin",
             "type": "number"
           },
           {
-            "line": 7648,
+            "line": 7660,
             "name": "maximum_wind_direction_degrees",
             "type": "integer"
           },
           {
-            "line": 7647,
+            "line": 7659,
             "name": "maximum_wind_speed_mph",
             "type": "integer"
           }
@@ -8862,27 +8917,27 @@
       {
         "fields": [
           {
-            "line": 7548,
+            "line": 7560,
             "name": "dangerous",
             "type": "boolean"
           },
           {
-            "line": 7546,
+            "line": 7558,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7545,
+            "line": 7557,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 7547,
+            "line": 7559,
             "name": "query",
             "type": "string"
           },
           {
-            "line": 7549,
+            "line": 7561,
             "name": "rains",
             "type": "boolean"
           }
@@ -8892,32 +8947,32 @@
       {
         "fields": [
           {
-            "line": 7552,
+            "line": 7564,
             "name": "items",
             "type": "CcbWeatherTypeSnapshot[]"
           },
           {
-            "line": 7556,
+            "line": 7568,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7555,
+            "line": 7567,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 7554,
+            "line": 7566,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 7553,
+            "line": 7565,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 7557,
+            "line": 7569,
             "name": "truncated",
             "type": "boolean"
           }
@@ -8927,82 +8982,82 @@
       {
         "fields": [
           {
-            "line": 7560,
+            "line": 7572,
             "name": "at",
             "type": "TimePoint"
           },
           {
-            "line": 7564,
+            "line": 7576,
             "name": "humidity",
             "type": "number"
           },
           {
-            "line": 7574,
+            "line": 7586,
             "name": "is_day",
             "type": "boolean"
           },
           {
-            "line": 7575,
+            "line": 7587,
             "name": "is_night",
             "type": "boolean"
           },
           {
-            "line": 7573,
+            "line": 7585,
             "name": "moonlight",
             "type": "number"
           },
           {
-            "line": 7569,
+            "line": 7581,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 7570,
+            "line": 7582,
             "name": "precipitation_mm_per_hour",
             "type": "number"
           },
           {
-            "line": 7565,
+            "line": 7577,
             "name": "pressure",
             "type": "number"
           },
           {
-            "line": 7572,
+            "line": 7584,
             "name": "sun_irradiance",
             "type": "number"
           },
           {
-            "line": 7571,
+            "line": 7583,
             "name": "sunlight",
             "type": "number"
           },
           {
-            "line": 7562,
+            "line": 7574,
             "name": "temperature",
             "type": "UnitValue"
           },
           {
-            "line": 7563,
+            "line": 7575,
             "name": "temperature_c",
             "type": "number"
           },
           {
-            "line": 7561,
+            "line": 7573,
             "name": "weather",
             "type": "GameId"
           },
           {
-            "line": 7568,
+            "line": 7580,
             "name": "wind_description",
             "type": "string"
           },
           {
-            "line": 7567,
+            "line": 7579,
             "name": "wind_direction_degrees",
             "type": "integer"
           },
           {
-            "line": 7566,
+            "line": 7578,
             "name": "wind_speed_mph",
             "type": "number"
           }
@@ -9012,12 +9067,12 @@
       {
         "fields": [
           {
-            "line": 7601,
+            "line": 7613,
             "name": "humidity_modifier",
             "type": "integer"
           },
           {
-            "line": 7600,
+            "line": 7612,
             "name": "temperature_modifier",
             "type": "integer"
           }
@@ -9027,22 +9082,22 @@
       {
         "fields": [
           {
-            "line": 7606,
+            "line": 7618,
             "name": "autumn",
             "type": "CcbWeatherSeasonModifiers"
           },
           {
-            "line": 7604,
+            "line": 7616,
             "name": "spring",
             "type": "CcbWeatherSeasonModifiers"
           },
           {
-            "line": 7605,
+            "line": 7617,
             "name": "summer",
             "type": "CcbWeatherSeasonModifiers"
           },
           {
-            "line": 7607,
+            "line": 7619,
             "name": "winter",
             "type": "CcbWeatherSeasonModifiers"
           }
@@ -9052,22 +9107,22 @@
       {
         "fields": [
           {
-            "line": 10540,
+            "line": 10552,
             "name": "id",
             "type": "string"
           },
           {
-            "line": 10541,
+            "line": 10553,
             "name": "temperature_c",
             "type": "number"
           },
           {
-            "line": 10543,
+            "line": 10555,
             "name": "wind_direction",
             "type": "number"
           },
           {
-            "line": 10542,
+            "line": 10554,
             "name": "wind_speed",
             "type": "number"
           }
@@ -9077,22 +9132,22 @@
       {
         "fields": [
           {
-            "line": 7514,
+            "line": 7526,
             "name": "items",
             "type": "CcbWeatherSourceSnapshot[]"
           },
           {
-            "line": 7516,
+            "line": 7528,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 7515,
+            "line": 7527,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 7517,
+            "line": 7529,
             "name": "truncated",
             "type": "boolean"
           }
@@ -9102,12 +9157,12 @@
       {
         "fields": [
           {
-            "line": 7511,
+            "line": 7523,
             "name": "mod",
             "type": "string"
           },
           {
-            "line": 7510,
+            "line": 7522,
             "name": "weather",
             "type": "GameId"
           }
@@ -9117,22 +9172,22 @@
       {
         "fields": [
           {
-            "line": 7594,
+            "line": 7606,
             "name": "items",
             "type": "string[]"
           },
           {
-            "line": 7596,
+            "line": 7608,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 7595,
+            "line": 7607,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 7597,
+            "line": 7609,
             "name": "truncated",
             "type": "boolean"
           }
@@ -9142,22 +9197,22 @@
       {
         "fields": [
           {
-            "line": 7504,
+            "line": 7516,
             "name": "items",
             "type": "GameId[]"
           },
           {
-            "line": 7506,
+            "line": 7518,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 7505,
+            "line": 7517,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 7507,
+            "line": 7519,
             "name": "truncated",
             "type": "boolean"
           }
@@ -9167,117 +9222,117 @@
       {
         "fields": [
           {
-            "line": 7531,
+            "line": 7543,
             "name": "dangerous",
             "type": "boolean"
           },
           {
-            "line": 7540,
+            "line": 7552,
             "name": "duration_max",
             "type": "TimeDuration"
           },
           {
-            "line": 7539,
+            "line": 7551,
             "name": "duration_min",
             "type": "TimeDuration"
           },
           {
-            "line": 7520,
+            "line": 7532,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 7527,
+            "line": 7539,
             "name": "light_modifier",
             "type": "integer"
           },
           {
-            "line": 7528,
+            "line": 7540,
             "name": "light_multiplier",
             "type": "number"
           },
           {
-            "line": 7522,
+            "line": 7534,
             "name": "loaded",
             "type": "boolean"
           },
           {
-            "line": 7521,
+            "line": 7533,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 7532,
+            "line": 7544,
             "name": "precipitation",
             "type": "'none'|'very_light'|'light'|'heavy'"
           },
           {
-            "line": 7533,
+            "line": 7545,
             "name": "precipitation_mm_per_hour",
             "type": "number"
           },
           {
-            "line": 7536,
+            "line": 7548,
             "name": "priority",
             "type": "integer"
           },
           {
-            "line": 7534,
+            "line": 7546,
             "name": "rains",
             "type": "boolean"
           },
           {
-            "line": 7525,
+            "line": 7537,
             "name": "ranged_penalty",
             "type": "integer"
           },
           {
-            "line": 7541,
+            "line": 7553,
             "name": "required_weathers",
             "type": "CcbWeatherTypeIdPage"
           },
           {
-            "line": 7526,
+            "line": 7538,
             "name": "sight_penalty",
             "type": "number"
           },
           {
-            "line": 7530,
+            "line": 7542,
             "name": "sound_attenuation",
             "type": "integer"
           },
           {
-            "line": 7538,
+            "line": 7550,
             "name": "sound_category",
             "type": "'silent'|'drizzle'|'rainy'|'rainstorm'|'thunder'|'flurries'|'snowstorm'|'snow'|'portal_storm'|'clear'|'sunny'|'cloudy'"
           },
           {
-            "line": 7542,
+            "line": 7554,
             "name": "sources",
             "type": "CcbWeatherSourcePage"
           },
           {
-            "line": 7529,
+            "line": 7541,
             "name": "sun_multiplier",
             "type": "number"
           },
           {
-            "line": 7524,
+            "line": 7536,
             "name": "sun_symbol",
             "type": "string"
           },
           {
-            "line": 7523,
+            "line": 7535,
             "name": "symbol",
             "type": "string"
           },
           {
-            "line": 7535,
+            "line": 7547,
             "name": "temperature_modifier_c",
             "type": "number"
           },
           {
-            "line": 7537,
+            "line": 7549,
             "name": "tiles_animation",
             "type": "string"
           }
@@ -9287,22 +9342,22 @@
       {
         "fields": [
           {
-            "line": 7683,
+            "line": 7695,
             "name": "clear_direction",
             "type": "boolean"
           },
           {
-            "line": 7682,
+            "line": 7694,
             "name": "clear_speed",
             "type": "boolean"
           },
           {
-            "line": 7681,
+            "line": 7693,
             "name": "direction_degrees",
             "type": "integer"
           },
           {
-            "line": 7680,
+            "line": 7692,
             "name": "speed_mph",
             "type": "integer"
           }
@@ -9312,42 +9367,42 @@
       {
         "fields": [
           {
-            "line": 7814,
+            "line": 7826,
             "name": "enabled",
             "type": "boolean"
           },
           {
-            "line": 7812,
+            "line": 7824,
             "name": "end",
             "type": "TripointCoord"
           },
           {
-            "line": 7810,
+            "line": 7822,
             "name": "faction",
             "type": "GameId"
           },
           {
-            "line": 7813,
+            "line": 7825,
             "name": "invert",
             "type": "boolean"
           },
           {
-            "line": 7815,
+            "line": 7827,
             "name": "kind",
             "type": "'global'|'personal'"
           },
           {
-            "line": 7808,
+            "line": 7820,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 7811,
+            "line": 7823,
             "name": "start",
             "type": "TripointCoord"
           },
           {
-            "line": 7809,
+            "line": 7821,
             "name": "type",
             "type": "GameId"
           }
@@ -9357,32 +9412,32 @@
       {
         "fields": [
           {
-            "line": 7760,
+            "line": 7772,
             "name": "faction",
             "type": "GameId"
           },
           {
-            "line": 7762,
+            "line": 7774,
             "name": "kind",
             "type": "'global'|'personal'|'vehicle'"
           },
           {
-            "line": 7758,
+            "line": 7770,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7757,
+            "line": 7769,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 7759,
+            "line": 7771,
             "name": "query",
             "type": "string"
           },
           {
-            "line": 7761,
+            "line": 7773,
             "name": "type",
             "type": "GameId"
           }
@@ -9392,42 +9447,42 @@
       {
         "fields": [
           {
-            "line": 7799,
+            "line": 7811,
             "name": "faction",
             "type": "GameId"
           },
           {
-            "line": 7805,
+            "line": 7817,
             "name": "has_more",
             "type": "boolean"
           },
           {
-            "line": 7798,
+            "line": 7810,
             "name": "items",
             "type": "CcbZoneSnapshot[]"
           },
           {
-            "line": 7802,
+            "line": 7814,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7801,
+            "line": 7813,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 7800,
+            "line": 7812,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 7804,
+            "line": 7816,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 7803,
+            "line": 7815,
             "name": "total",
             "type": "integer"
           }
@@ -9437,12 +9492,12 @@
       {
         "fields": [
           {
-            "line": 7818,
+            "line": 7830,
             "name": "changed",
             "type": "boolean"
           },
           {
-            "line": 7819,
+            "line": 7831,
             "name": "zone",
             "type": "CcbZoneSnapshot"
           }
@@ -9452,12 +9507,12 @@
       {
         "fields": [
           {
-            "line": 7765,
+            "line": 7777,
             "name": "label",
             "type": "string"
           },
           {
-            "line": 7766,
+            "line": 7778,
             "name": "value",
             "type": "string"
           }
@@ -9467,22 +9522,22 @@
       {
         "fields": [
           {
-            "line": 7769,
+            "line": 7781,
             "name": "items",
             "type": "CcbZoneOptionDescription[]"
           },
           {
-            "line": 7771,
+            "line": 7783,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 7770,
+            "line": 7782,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 7772,
+            "line": 7784,
             "name": "truncated",
             "type": "boolean"
           }
@@ -9492,12 +9547,12 @@
       {
         "fields": [
           {
-            "line": 7822,
+            "line": 7834,
             "name": "removed",
             "type": "boolean"
           },
           {
-            "line": 7823,
+            "line": 7835,
             "name": "zone",
             "type": "CcbZoneSnapshot"
           }
@@ -9507,92 +9562,92 @@
       {
         "fields": [
           {
-            "line": 7787,
+            "line": 7799,
             "name": "center",
             "type": "TripointCoord"
           },
           {
-            "line": 7790,
+            "line": 7802,
             "name": "displayed",
             "type": "boolean"
           },
           {
-            "line": 7793,
+            "line": 7805,
             "name": "enabled",
             "type": "boolean"
           },
           {
-            "line": 7784,
+            "line": 7796,
             "name": "end",
             "type": "TripointCoord"
           },
           {
-            "line": 7782,
+            "line": 7794,
             "name": "faction",
             "type": "GameId"
           },
           {
-            "line": 7794,
+            "line": 7806,
             "name": "has_options",
             "type": "boolean"
           },
           {
-            "line": 7788,
+            "line": 7800,
             "name": "invert",
             "type": "boolean"
           },
           {
-            "line": 7792,
+            "line": 7804,
             "name": "kind",
             "type": "'global'|'personal'|'vehicle'"
           },
           {
-            "line": 7779,
+            "line": 7791,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 7795,
+            "line": 7807,
             "name": "options",
             "type": "CcbZoneOptionPage"
           },
           {
-            "line": 7786,
+            "line": 7798,
             "name": "relative_end",
             "type": "TripointCoord"
           },
           {
-            "line": 7785,
+            "line": 7797,
             "name": "relative_start",
             "type": "TripointCoord"
           },
           {
-            "line": 7783,
+            "line": 7795,
             "name": "start",
             "type": "TripointCoord"
           },
           {
-            "line": 7789,
+            "line": 7801,
             "name": "temporarily_disabled",
             "type": "boolean"
           },
           {
-            "line": 7778,
+            "line": 7790,
             "name": "token",
             "type": "ZoneToken"
           },
           {
-            "line": 7780,
+            "line": 7792,
             "name": "type",
             "type": "GameId"
           },
           {
-            "line": 7781,
+            "line": 7793,
             "name": "type_name",
             "type": "string"
           },
           {
-            "line": 7791,
+            "line": 7803,
             "name": "vehicle",
             "type": "boolean"
           }
@@ -9602,17 +9657,17 @@
       {
         "fields": [
           {
-            "line": 7745,
+            "line": 7757,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7744,
+            "line": 7756,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 7746,
+            "line": 7758,
             "name": "query",
             "type": "string"
           }
@@ -9622,32 +9677,32 @@
       {
         "fields": [
           {
-            "line": 7754,
+            "line": 7766,
             "name": "has_more",
             "type": "boolean"
           },
           {
-            "line": 7749,
+            "line": 7761,
             "name": "items",
             "type": "CcbZoneTypeSnapshot[]"
           },
           {
-            "line": 7751,
+            "line": 7763,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 7750,
+            "line": 7762,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 7753,
+            "line": 7765,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 7752,
+            "line": 7764,
             "name": "total",
             "type": "integer"
           }
@@ -9657,12 +9712,12 @@
       {
         "fields": [
           {
-            "line": 7740,
+            "line": 7752,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 7741,
+            "line": 7753,
             "name": "name",
             "type": "string"
           }
@@ -12120,42 +12175,42 @@
       {
         "fields": [
           {
-            "line": 7903,
+            "line": 7915,
             "name": "__tostring",
             "type": "fun(self:"
           },
           {
-            "line": 7901,
+            "line": 7913,
             "name": "identity_generation",
             "type": "integer"
           },
           {
-            "line": 7902,
+            "line": 7914,
             "name": "is_valid",
             "type": "fun(self:"
           },
           {
-            "line": 7897,
+            "line": 7909,
             "name": "monster",
             "type": "GameId"
           },
           {
-            "line": 7900,
+            "line": 7912,
             "name": "owner_generation",
             "type": "integer"
           },
           {
-            "line": 7896,
+            "line": 7908,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 7898,
+            "line": 7910,
             "name": "runtime_generation",
             "type": "integer"
           },
           {
-            "line": 7899,
+            "line": 7911,
             "name": "world_generation",
             "type": "integer"
           }
@@ -12485,42 +12540,42 @@
       {
         "fields": [
           {
-            "line": 7914,
+            "line": 7926,
             "name": "__tostring",
             "type": "fun(self:"
           },
           {
-            "line": 7908,
+            "line": 7920,
             "name": "group",
             "type": "GameId"
           },
           {
-            "line": 7912,
+            "line": 7924,
             "name": "identity_generation",
             "type": "integer"
           },
           {
-            "line": 7913,
+            "line": 7925,
             "name": "is_valid",
             "type": "fun(self:"
           },
           {
-            "line": 7911,
+            "line": 7923,
             "name": "owner_generation",
             "type": "integer"
           },
           {
-            "line": 7907,
+            "line": 7919,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 7909,
+            "line": 7921,
             "name": "runtime_generation",
             "type": "integer"
           },
           {
-            "line": 7910,
+            "line": 7922,
             "name": "world_generation",
             "type": "integer"
           }
@@ -12724,37 +12779,37 @@
       {
         "fields": [
           {
-            "line": 6828,
+            "line": 6840,
             "name": "complete_omt_z_stack",
             "type": "boolean"
           },
           {
-            "line": 6823,
+            "line": 6835,
             "name": "max_submap_x",
             "type": "integer"
           },
           {
-            "line": 6825,
+            "line": 6837,
             "name": "max_submap_y",
             "type": "integer"
           },
           {
-            "line": 6827,
+            "line": 6839,
             "name": "max_z",
             "type": "integer"
           },
           {
-            "line": 6822,
+            "line": 6834,
             "name": "min_submap_x",
             "type": "integer"
           },
           {
-            "line": 6824,
+            "line": 6836,
             "name": "min_submap_y",
             "type": "integer"
           },
           {
-            "line": 6826,
+            "line": 6838,
             "name": "min_z",
             "type": "integer"
           }
@@ -12764,32 +12819,32 @@
       {
         "fields": [
           {
-            "line": 6832,
+            "line": 6844,
             "name": "code",
             "type": "'committed'"
           },
           {
-            "line": 6834,
+            "line": 6846,
             "name": "footprint",
             "type": "MapgenTransactionFootprint"
           },
           {
-            "line": 6833,
+            "line": 6845,
             "name": "message",
             "type": "''"
           },
           {
-            "line": 6831,
+            "line": 6843,
             "name": "state",
             "type": "'committed'"
           },
           {
-            "line": 6835,
+            "line": 6847,
             "name": "target",
             "type": "OvermapTileToken"
           },
           {
-            "line": 6836,
+            "line": 6848,
             "name": "update",
             "type": "MapgenUpdateToken"
           }
@@ -12799,27 +12854,27 @@
       {
         "fields": [
           {
-            "line": 6815,
+            "line": 6827,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 6819,
+            "line": 6831,
             "name": "is_valid",
             "type": "fun(self:"
           },
           {
-            "line": 6818,
+            "line": 6830,
             "name": "owner_is_current",
             "type": "fun(self:"
           },
           {
-            "line": 6816,
+            "line": 6828,
             "name": "runtime_generation",
             "type": "integer"
           },
           {
-            "line": 6817,
+            "line": 6829,
             "name": "world_generation",
             "type": "integer"
           }
@@ -13153,27 +13208,27 @@
       {
         "fields": [
           {
-            "line": 8534,
+            "line": 8546,
             "name": "identity_generation",
             "type": "integer"
           },
           {
-            "line": 8537,
+            "line": 8549,
             "name": "is_valid",
             "type": "fun(self:"
           },
           {
-            "line": 8535,
+            "line": 8547,
             "name": "runtime_generation",
             "type": "integer"
           },
           {
-            "line": 8533,
+            "line": 8545,
             "name": "uid",
             "type": "integer"
           },
           {
-            "line": 8536,
+            "line": 8548,
             "name": "world_generation",
             "type": "integer"
           }
@@ -14852,22 +14907,22 @@
       {
         "fields": [
           {
-            "line": 6359,
+            "line": 6371,
             "name": "delta_ms",
             "type": "integer"
           },
           {
-            "line": 6358,
+            "line": 6370,
             "name": "elapsed_ms",
             "type": "integer"
           },
           {
-            "line": 6357,
+            "line": 6369,
             "name": "height",
             "type": "integer"
           },
           {
-            "line": 6356,
+            "line": 6368,
             "name": "width",
             "type": "integer"
           }
@@ -14877,27 +14932,27 @@
       {
         "fields": [
           {
-            "line": 6352,
+            "line": 6364,
             "name": "allow_quit",
             "type": "boolean"
           },
           {
-            "line": 6351,
+            "line": 6363,
             "name": "height",
             "type": "integer"
           },
           {
-            "line": 6353,
+            "line": 6365,
             "name": "music",
             "type": "string"
           },
           {
-            "line": 6349,
+            "line": 6361,
             "name": "title",
             "type": "string"
           },
           {
-            "line": 6350,
+            "line": 6362,
             "name": "width",
             "type": "integer"
           }
@@ -14907,22 +14962,22 @@
       {
         "fields": [
           {
-            "line": 6073,
+            "line": 6085,
             "name": "character",
             "type": "GameHandle"
           },
           {
-            "line": 6075,
+            "line": 6087,
             "name": "due_turn",
             "type": "integer"
           },
           {
-            "line": 6074,
+            "line": 6086,
             "name": "first_schedule",
             "type": "boolean"
           },
           {
-            "line": 6076,
+            "line": 6088,
             "name": "overdue_turns",
             "type": "integer"
           }
@@ -14932,22 +14987,22 @@
       {
         "fields": [
           {
-            "line": 6338,
+            "line": 6350,
             "name": "description",
             "type": "string"
           },
           {
-            "line": 6339,
+            "line": 6351,
             "name": "enabled",
             "type": "boolean"
           },
           {
-            "line": 6336,
+            "line": 6348,
             "name": "id",
             "type": "string"
           },
           {
-            "line": 6337,
+            "line": 6349,
             "name": "label",
             "type": "string"
           }
@@ -15001,27 +15056,27 @@
       {
         "fields": [
           {
-            "line": 6213,
+            "line": 6225,
             "name": "from_version",
             "type": "integer"
           },
           {
-            "line": 6211,
+            "line": 6223,
             "name": "handler_id",
             "type": "string"
           },
           {
-            "line": 6212,
+            "line": 6224,
             "name": "owner",
             "type": "'character'|'world'"
           },
           {
-            "line": 6210,
+            "line": 6222,
             "name": "task_id",
             "type": "integer"
           },
           {
-            "line": 6214,
+            "line": 6226,
             "name": "to_version",
             "type": "integer"
           }
@@ -15031,87 +15086,87 @@
       {
         "fields": [
           {
-            "line": 6267,
+            "line": 6279,
             "name": "actor",
             "type": "GameHandle"
           },
           {
-            "line": 6269,
+            "line": 6281,
             "name": "actor_character_id",
             "type": "integer"
           },
           {
-            "line": 6270,
+            "line": 6282,
             "name": "actor_item_uid",
             "type": "integer"
           },
           {
-            "line": 6268,
+            "line": 6280,
             "name": "actor_kind",
             "type": "'character'|'item'|'monster'|'vehicle'"
           },
           {
-            "line": 6271,
+            "line": 6283,
             "name": "actor_monster_uid",
             "type": "integer"
           },
           {
-            "line": 6272,
+            "line": 6284,
             "name": "actor_vehicle_uid",
             "type": "integer"
           },
           {
-            "line": 6260,
+            "line": 6272,
             "name": "due_turn",
             "type": "integer"
           },
           {
-            "line": 6259,
+            "line": 6271,
             "name": "id",
             "type": "integer"
           },
           {
-            "line": 6263,
+            "line": 6275,
             "name": "interval_turns",
             "type": "integer"
           },
           {
-            "line": 6264,
+            "line": 6276,
             "name": "next_due_turn",
             "type": "integer"
           },
           {
-            "line": 6261,
+            "line": 6273,
             "name": "overdue_turns",
             "type": "integer"
           },
           {
-            "line": 6265,
+            "line": 6277,
             "name": "owner",
             "type": "'character'|'world'"
           },
           {
-            "line": 6266,
+            "line": 6278,
             "name": "owner_mod_id",
             "type": "string"
           },
           {
-            "line": 6273,
+            "line": 6285,
             "name": "participants",
             "type": "table<string,"
           },
           {
-            "line": 6275,
+            "line": 6287,
             "name": "payload",
             "type": "table<string,"
           },
           {
-            "line": 6274,
+            "line": 6286,
             "name": "payload_version",
             "type": "integer"
           },
           {
-            "line": 6262,
+            "line": 6274,
             "name": "recurring",
             "type": "boolean"
           }
@@ -15121,27 +15176,27 @@
       {
         "fields": [
           {
-            "line": 6343,
+            "line": 6355,
             "name": "description",
             "type": "string"
           },
           {
-            "line": 6342,
+            "line": 6354,
             "name": "initial",
             "type": "string"
           },
           {
-            "line": 6345,
+            "line": 6357,
             "name": "max_length",
             "type": "integer"
           },
           {
-            "line": 6346,
+            "line": 6358,
             "name": "only_digits",
             "type": "boolean"
           },
           {
-            "line": 6344,
+            "line": 6356,
             "name": "width",
             "type": "integer"
           }
@@ -17890,82 +17945,82 @@
       {
         "fields": [
           {
-            "line": 9542,
+            "line": 9554,
             "name": "buyer_identity_generation",
             "type": "integer"
           },
           {
-            "line": 9540,
+            "line": 9552,
             "name": "buyer_stable_id",
             "type": "integer"
           },
           {
-            "line": 9546,
+            "line": 9558,
             "name": "debt_generation",
             "type": "integer"
           },
           {
-            "line": 9549,
+            "line": 9561,
             "name": "expires_turn",
             "type": "integer"
           },
           {
-            "line": 9545,
+            "line": 9557,
             "name": "faction_generation",
             "type": "integer"
           },
           {
-            "line": 9543,
+            "line": 9555,
             "name": "holder_mutation_generation",
             "type": "integer"
           },
           {
-            "line": 9551,
+            "line": 9563,
             "name": "is_valid",
             "type": "fun(self:"
           },
           {
-            "line": 9548,
+            "line": 9560,
             "name": "issued_turn",
             "type": "integer"
           },
           {
-            "line": 9547,
+            "line": 9559,
             "name": "opinion_generation",
             "type": "integer"
           },
           {
-            "line": 9544,
+            "line": 9556,
             "name": "pricing_generation",
             "type": "integer"
           },
           {
-            "line": 9536,
+            "line": 9548,
             "name": "quote_id",
             "type": "integer"
           },
           {
-            "line": 9550,
+            "line": 9562,
             "name": "registered",
             "type": "boolean"
           },
           {
-            "line": 9537,
+            "line": 9549,
             "name": "runtime_generation",
             "type": "integer"
           },
           {
-            "line": 9541,
+            "line": 9553,
             "name": "seller_identity_generation",
             "type": "integer"
           },
           {
-            "line": 9539,
+            "line": 9551,
             "name": "seller_stable_id",
             "type": "integer"
           },
           {
-            "line": 9538,
+            "line": 9550,
             "name": "world_generation",
             "type": "integer"
           }
@@ -19575,57 +19630,57 @@
       {
         "fields": [
           {
-            "line": 7731,
+            "line": 7743,
             "name": "end",
             "type": "TripointCoord"
           },
           {
-            "line": 7727,
+            "line": 7739,
             "name": "faction",
             "type": "GameId"
           },
           {
-            "line": 7736,
+            "line": 7748,
             "name": "is_valid",
             "type": "fun(self:"
           },
           {
-            "line": 7735,
+            "line": 7747,
             "name": "kind",
             "type": "'global'|'personal'|'vehicle'"
           },
           {
-            "line": 7729,
+            "line": 7741,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 7733,
+            "line": 7745,
             "name": "relative_end",
             "type": "TripointCoord"
           },
           {
-            "line": 7732,
+            "line": 7744,
             "name": "relative_start",
             "type": "TripointCoord"
           },
           {
-            "line": 7730,
+            "line": 7742,
             "name": "start",
             "type": "TripointCoord"
           },
           {
-            "line": 7737,
+            "line": 7749,
             "name": "status",
             "type": "fun(self:"
           },
           {
-            "line": 7728,
+            "line": 7740,
             "name": "type",
             "type": "GameId"
           },
           {
-            "line": 7734,
+            "line": 7746,
             "name": "vehicle",
             "type": "boolean"
           }
@@ -19927,433 +19982,433 @@
         "parameters": "speed, size, butcher, requirement_id"
       },
       {
-        "line": "9934",
+        "line": "9946",
         "name": "grant",
         "owner": "CcbBionicsApi",
         "parameters": "character, bionic"
       },
       {
-        "line": "9928",
+        "line": "9940",
         "name": "has",
         "owner": "CcbBionicsApi",
         "parameters": "character, bionic"
       },
       {
-        "line": "9940",
+        "line": "9952",
         "name": "remove_type",
         "owner": "CcbBionicsApi",
         "parameters": "character, bionic"
       },
       {
-        "line": "9922",
+        "line": "9934",
         "name": "summary",
         "owner": "CcbBionicsApi",
         "parameters": "character"
       },
       {
-        "line": "7260",
+        "line": "7272",
         "name": "create",
         "owner": "CcbCampExpansionsApi",
         "parameters": "camp, manager, position, type, name"
       },
       {
-        "line": "7272",
+        "line": "7284",
         "name": "get",
         "owner": "CcbCampExpansionsApi",
         "parameters": "camp, manager, token"
       },
       {
-        "line": "7266",
+        "line": "7278",
         "name": "list",
         "owner": "CcbCampExpansionsApi",
         "parameters": "camp, manager, options"
       },
       {
-        "line": "7278",
+        "line": "7290",
         "name": "remove",
         "owner": "CcbCampExpansionsApi",
         "parameters": "camp, manager, token"
       },
       {
-        "line": "6948",
+        "line": "6960",
         "name": "add",
         "owner": "CcbCampFoodApi",
         "parameters": "camp, manager, kcal"
       },
       {
-        "line": "6954",
+        "line": "6966",
         "name": "consume",
         "owner": "CcbCampFoodApi",
         "parameters": "camp, manager, kcal"
       },
       {
-        "line": "7301",
+        "line": "7313",
         "name": "storage_tiles",
         "owner": "CcbCampInventoryApi",
         "parameters": "camp, manager, options"
       },
       {
-        "line": "6923",
+        "line": "6935",
         "name": "add",
         "owner": "CcbCampResourcesApi",
         "parameters": "camp, manager, resource_id, amount"
       },
       {
-        "line": "6916",
+        "line": "6928",
         "name": "adjust",
         "owner": "CcbCampResourcesApi",
         "parameters": "camp, manager, changes"
       },
       {
-        "line": "6930",
+        "line": "6942",
         "name": "consume",
         "owner": "CcbCampResourcesApi",
         "parameters": "camp, manager, resource_id, amount"
       },
       {
-        "line": "6910",
+        "line": "6922",
         "name": "snapshot",
         "owner": "CcbCampResourcesApi",
         "parameters": "camp, manager, options"
       },
       {
-        "line": "7204",
+        "line": "7216",
         "name": "cancel",
         "owner": "CcbCampTasksApi",
         "parameters": "camp, manager, worker, token"
       },
       {
-        "line": "7180",
+        "line": "7192",
         "name": "claim",
         "owner": "CcbCampTasksApi",
         "parameters": "camp, manager, worker, token, destination_holder"
       },
       {
-        "line": "7218",
+        "line": "7230",
         "name": "complete",
         "owner": "CcbCampTasksApi",
         "parameters": "camp, manager, worker, token"
       },
       {
-        "line": "7150",
+        "line": "7162",
         "name": "create",
         "owner": "CcbCampTasksApi",
         "parameters": "camp, manager, worker, kind, descriptor"
       },
       {
-        "line": "7164",
+        "line": "7176",
         "name": "get",
         "owner": "CcbCampTasksApi",
         "parameters": "camp, manager, worker, token"
       },
       {
-        "line": "7157",
+        "line": "7169",
         "name": "page",
         "owner": "CcbCampTasksApi",
         "parameters": "camp, manager, worker, options"
       },
       {
-        "line": "7211",
+        "line": "7223",
         "name": "recall",
         "owner": "CcbCampTasksApi",
         "parameters": "camp, manager, worker, token"
       },
       {
-        "line": "7172",
+        "line": "7184",
         "name": "resolve",
         "owner": "CcbCampTasksApi",
         "parameters": "camp, manager, worker, token, destination_holder"
       },
       {
-        "line": "7188",
+        "line": "7200",
         "name": "retry",
         "owner": "CcbCampTasksApi",
         "parameters": "camp, manager, worker, token, destination_holder"
       },
       {
-        "line": "7197",
+        "line": "7209",
         "name": "start",
         "owner": "CcbCampTasksApi",
         "parameters": "camp, manager, worker, token, requests_or_duration, duration_turns"
       },
       {
-        "line": "7383",
+        "line": "7395",
         "name": "assign_worker",
         "owner": "CcbCampsApi",
         "parameters": "camp, manager, worker"
       },
       {
-        "line": "7344",
+        "line": "7356",
         "name": "create",
         "owner": "CcbCampsApi",
         "parameters": "owner_faction, manager, omt_position, name, options"
       },
       {
-        "line": "7359",
+        "line": "7371",
         "name": "get",
         "owner": "CcbCampsApi",
         "parameters": "camp, manager"
       },
       {
-        "line": "7354",
+        "line": "7366",
         "name": "list",
         "owner": "CcbCampsApi",
         "parameters": "center, options"
       },
       {
-        "line": "7389",
+        "line": "7401",
         "name": "recall_worker",
         "owner": "CcbCampsApi",
         "parameters": "camp, manager, worker"
       },
       {
-        "line": "7349",
+        "line": "7361",
         "name": "remove",
         "owner": "CcbCampsApi",
         "parameters": "camp, manager"
       },
       {
-        "line": "7365",
+        "line": "7377",
         "name": "rename",
         "owner": "CcbCampsApi",
         "parameters": "camp, manager, name"
       },
       {
-        "line": "7377",
+        "line": "7389",
         "name": "set_board_position",
         "owner": "CcbCampsApi",
         "parameters": "camp, manager, position"
       },
       {
-        "line": "7371",
+        "line": "7383",
         "name": "set_owner",
         "owner": "CcbCampsApi",
         "parameters": "camp, manager, owner"
       },
       {
-        "line": "7432",
+        "line": "7444",
         "name": "attack",
         "owner": "CcbCharactersApi",
         "parameters": "attacker, target, technique, options"
       },
       {
-        "line": "7404",
+        "line": "7416",
         "name": "avatar",
         "owner": "CcbCharactersApi",
         "parameters": ""
       },
       {
-        "line": "7409",
+        "line": "7421",
         "name": "body_parts",
         "owner": "CcbCharactersApi",
         "parameters": "character"
       },
       {
-        "line": "7459",
+        "line": "7471",
         "name": "cast_spell",
         "owner": "CcbCharactersApi",
         "parameters": "character, spell, options"
       },
       {
-        "line": "7464",
+        "line": "7476",
         "name": "die",
         "owner": "CcbCharactersApi",
         "parameters": "character, options"
       },
       {
-        "line": "7453",
+        "line": "7465",
         "name": "emit",
         "owner": "CcbCharactersApi",
         "parameters": "character, emission, chance"
       },
       {
-        "line": "7447",
+        "line": "7459",
         "name": "explosion",
         "owner": "CcbCharactersApi",
         "parameters": "character, options"
       },
       {
-        "line": "7442",
+        "line": "7454",
         "name": "knockback",
         "owner": "CcbCharactersApi",
         "parameters": "character, options"
       },
       {
-        "line": "7425",
+        "line": "7437",
         "name": "nearby",
         "owner": "CcbCharactersApi",
         "parameters": "observer, options"
       },
       {
-        "line": "7468",
+        "line": "7480",
         "name": "prevent_death",
         "owner": "CcbCharactersApi",
         "parameters": "character"
       },
       {
-        "line": "7415",
+        "line": "7427",
         "name": "random_body_part",
         "owner": "CcbCharactersApi",
         "parameters": "character, main_parts_only"
       },
       {
-        "line": "7437",
+        "line": "7449",
         "name": "ranged_attack",
         "owner": "CcbCharactersApi",
         "parameters": "attacker, target"
       },
       {
-        "line": "7472",
+        "line": "7484",
         "name": "recalculate_enchantments",
         "owner": "CcbCharactersApi",
         "parameters": "character"
       },
       {
-        "line": "7420",
+        "line": "7432",
         "name": "snapshot",
         "owner": "CcbCharactersApi",
         "parameters": "character, body_part_limit"
       },
       {
-        "line": "10526",
+        "line": "10538",
         "name": "nearby",
         "owner": "CcbCreaturesApi",
         "parameters": "observer, options"
       },
       {
-        "line": "10521",
+        "line": "10533",
         "name": "snapshot",
         "owner": "CcbCreaturesApi",
         "parameters": "handle"
       },
       {
-        "line": "10531",
+        "line": "10543",
         "name": "visible_monsters",
         "owner": "CcbCreaturesApi",
         "parameters": "observer, direction"
       },
       {
-        "line": "10058",
+        "line": "10070",
         "name": "add",
         "owner": "CcbEffectsApi",
         "parameters": "character, effect, duration, options"
       },
       {
-        "line": "10073",
+        "line": "10085",
         "name": "get",
         "owner": "CcbEffectsApi",
         "parameters": "character, effect, body_part"
       },
       {
-        "line": "10066",
+        "line": "10078",
         "name": "has",
         "owner": "CcbEffectsApi",
         "parameters": "character, effect, body_part, intensity"
       },
       {
-        "line": "10080",
+        "line": "10092",
         "name": "remove",
         "owner": "CcbEffectsApi",
         "parameters": "character, effect, body_part"
       },
       {
-        "line": "9178",
+        "line": "9190",
         "name": "unequip",
         "owner": "CcbEquipmentApi",
         "parameters": "actor, item, destination_holder"
       },
       {
-        "line": "9172",
+        "line": "9184",
         "name": "wear",
         "owner": "CcbEquipmentApi",
         "parameters": "actor, item, source_holder, displaced_destination"
       },
       {
-        "line": "9165",
+        "line": "9177",
         "name": "wield",
         "owner": "CcbEquipmentApi",
         "parameters": "actor, item, source_holder, displaced_destination"
       },
       {
-        "line": "8728",
+        "line": "8740",
         "name": "food",
         "owner": "CcbFactionsApi",
         "parameters": "id, options"
       },
       {
-        "line": "8712",
+        "line": "8724",
         "name": "for_character",
         "owner": "CcbFactionsApi",
         "parameters": "character"
       },
       {
-        "line": "8709",
+        "line": "8721",
         "name": "get",
         "owner": "CcbFactionsApi",
         "parameters": "id"
       },
       {
-        "line": "8706",
+        "line": "8718",
         "name": "list",
         "owner": "CcbFactionsApi",
         "parameters": "options"
       },
       {
-        "line": "8716",
+        "line": "8728",
         "name": "members",
         "owner": "CcbFactionsApi",
         "parameters": "id, options"
       },
       {
-        "line": "8748",
+        "line": "8760",
         "name": "modify_food",
         "owner": "CcbFactionsApi",
         "parameters": "id, kcal"
       },
       {
-        "line": "8740",
+        "line": "8752",
         "name": "modify_reputation",
         "owner": "CcbFactionsApi",
         "parameters": "id, deltas"
       },
       {
-        "line": "8744",
+        "line": "8756",
         "name": "modify_resources",
         "owner": "CcbFactionsApi",
         "parameters": "id, deltas"
       },
       {
-        "line": "8724",
+        "line": "8736",
         "name": "relationship",
         "owner": "CcbFactionsApi",
         "parameters": "id, target"
       },
       {
-        "line": "8720",
+        "line": "8732",
         "name": "relationships",
         "owner": "CcbFactionsApi",
         "parameters": "id, options"
       },
       {
-        "line": "8732",
+        "line": "8744",
         "name": "rename",
         "owner": "CcbFactionsApi",
         "parameters": "id, name"
       },
       {
-        "line": "8736",
+        "line": "8748",
         "name": "set_known",
         "owner": "CcbFactionsApi",
         "parameters": "id, known"
       },
       {
-        "line": "8752",
+        "line": "8764",
         "name": "set_policy",
         "owner": "CcbFactionsApi",
         "parameters": "id, options"
       },
       {
-        "line": "8757",
+        "line": "8769",
         "name": "set_relationship",
         "owner": "CcbFactionsApi",
         "parameters": "id, target, options"
@@ -20365,379 +20420,379 @@
         "parameters": ""
       },
       {
-        "line": "8178",
+        "line": "8190",
         "name": "alert_entity",
         "owner": "CcbHordesApi",
         "parameters": "token, destination, intensity"
       },
       {
-        "line": "8145",
+        "line": "8157",
         "name": "contains",
         "owner": "CcbHordesApi",
         "parameters": "group, monster"
       },
       {
-        "line": "8134",
+        "line": "8146",
         "name": "definition",
         "owner": "CcbHordesApi",
         "parameters": "id, options"
       },
       {
-        "line": "8129",
+        "line": "8141",
         "name": "definitions",
         "owner": "CcbHordesApi",
         "parameters": "options"
       },
       {
-        "line": "8150",
+        "line": "8162",
         "name": "entities",
         "owner": "CcbHordesApi",
         "parameters": "center, options"
       },
       {
-        "line": "8154",
+        "line": "8166",
         "name": "entity",
         "owner": "CcbHordesApi",
         "parameters": "token"
       },
       {
-        "line": "8163",
+        "line": "8175",
         "name": "legacy_group",
         "owner": "CcbHordesApi",
         "parameters": "token"
       },
       {
-        "line": "8159",
+        "line": "8171",
         "name": "legacy_groups",
         "owner": "CcbHordesApi",
         "parameters": "center, options"
       },
       {
-        "line": "8125",
+        "line": "8137",
         "name": "limits",
         "owner": "CcbHordesApi",
         "parameters": ""
       },
       {
-        "line": "8140",
+        "line": "8152",
         "name": "monsters",
         "owner": "CcbHordesApi",
         "parameters": "id, recursive, options"
       },
       {
-        "line": "8182",
+        "line": "8194",
         "name": "remove_entity",
         "owner": "CcbHordesApi",
         "parameters": "token"
       },
       {
-        "line": "8195",
+        "line": "8207",
         "name": "remove_legacy_group",
         "owner": "CcbHordesApi",
         "parameters": "token"
       },
       {
-        "line": "8172",
+        "line": "8184",
         "name": "spawn_entity",
         "owner": "CcbHordesApi",
         "parameters": "position, monster"
       },
       {
-        "line": "8186",
+        "line": "8198",
         "name": "spawn_legacy_group",
         "owner": "CcbHordesApi",
         "parameters": "options"
       },
       {
-        "line": "8167",
+        "line": "8179",
         "name": "summary",
         "owner": "CcbHordesApi",
         "parameters": "position"
       },
       {
-        "line": "8191",
+        "line": "8203",
         "name": "update_legacy_group",
         "owner": "CcbHordesApi",
         "parameters": "token, options"
       },
       {
-        "line": "9054",
+        "line": "9066",
         "name": "category_count",
         "owner": "CcbInventoryApi",
         "parameters": "character, category"
       },
       {
-        "line": "9007",
+        "line": "9019",
         "name": "choose",
         "owner": "CcbInventoryApi",
         "parameters": "character, candidates, title"
       },
       {
-        "line": "9012",
+        "line": "9024",
         "name": "choose_many",
         "owner": "CcbInventoryApi",
         "parameters": "character, candidates, title"
       },
       {
-        "line": "9022",
+        "line": "9034",
         "name": "choose_many_map",
         "owner": "CcbInventoryApi",
         "parameters": "character, candidates, options"
       },
       {
-        "line": "9017",
+        "line": "9029",
         "name": "choose_map",
         "owner": "CcbInventoryApi",
         "parameters": "character, candidates, options"
       },
       {
-        "line": "9087",
+        "line": "9099",
         "name": "consume",
         "owner": "CcbInventoryApi",
         "parameters": "character, item_type, count, charges"
       },
       {
-        "line": "9098",
+        "line": "9110",
         "name": "consume_sum",
         "owner": "CcbInventoryApi",
         "parameters": "character, entries"
       },
       {
-        "line": "9076",
+        "line": "9088",
         "name": "give",
         "owner": "CcbInventoryApi",
         "parameters": "character, item_type, quantity, options"
       },
       {
-        "line": "9081",
+        "line": "9093",
         "name": "give_group",
         "owner": "CcbInventoryApi",
         "parameters": "character, group, options"
       },
       {
-        "line": "9094",
+        "line": "9106",
         "name": "hand_in",
         "owner": "CcbInventoryApi",
         "parameters": "character, recipient, item_type, count, charges"
       },
       {
-        "line": "9050",
+        "line": "9062",
         "name": "has_item_flag",
         "owner": "CcbInventoryApi",
         "parameters": "character, flag"
       },
       {
-        "line": "9031",
+        "line": "9043",
         "name": "has_items_sum",
         "owner": "CcbInventoryApi",
         "parameters": "character, entries"
       },
       {
-        "line": "9037",
+        "line": "9049",
         "name": "has_software",
         "owner": "CcbInventoryApi",
         "parameters": "character, software, minimum_charges, device"
       },
       {
-        "line": "9067",
+        "line": "9079",
         "name": "has_stolen_from",
         "owner": "CcbInventoryApi",
         "parameters": "holder, owner"
       },
       {
-        "line": "9042",
+        "line": "9054",
         "name": "has_worn_flag",
         "owner": "CcbInventoryApi",
         "parameters": "character, flag, body_part"
       },
       {
-        "line": "9046",
+        "line": "9058",
         "name": "is_wearing",
         "owner": "CcbInventoryApi",
         "parameters": "character, item_type"
       },
       {
-        "line": "9059",
+        "line": "9071",
         "name": "item_radiation",
         "owner": "CcbInventoryApi",
         "parameters": "character, flag, aggregate"
       },
       {
-        "line": "9027",
+        "line": "9039",
         "name": "resources",
         "owner": "CcbInventoryApi",
         "parameters": "character, item_type, quantity"
       },
       {
-        "line": "9070",
+        "line": "9082",
         "name": "weapon_state",
         "owner": "CcbInventoryApi",
         "parameters": "character"
       },
       {
-        "line": "9063",
+        "line": "9075",
         "name": "wielded_matches",
         "owner": "CcbInventoryApi",
         "parameters": "character, criterion"
       },
       {
-        "line": "8881",
+        "line": "8893",
         "name": "set_spawn_rate",
         "owner": "CcbItemCategoriesApi",
         "parameters": "id, rate"
       },
       {
-        "line": "8885",
+        "line": "8897",
         "name": "set_spawn_rates",
         "owner": "CcbItemCategoriesApi",
         "parameters": "updates"
       },
       {
-        "line": "8876",
+        "line": "8888",
         "name": "spawn_rate",
         "owner": "CcbItemCategoriesApi",
         "parameters": "id"
       },
       {
-        "line": "8967",
+        "line": "8979",
         "name": "activate",
         "owner": "CcbItemsApi",
         "parameters": "item_handle, character_handle, method, options"
       },
       {
-        "line": "8956",
+        "line": "8968",
         "name": "ammo_sufficient",
         "owner": "CcbItemsApi",
         "parameters": "item_handle, character, method, quantity"
       },
       {
-        "line": "8998",
+        "line": "9010",
         "name": "clear_old_owner",
         "owner": "CcbItemsApi",
         "parameters": "item_handle"
       },
       {
-        "line": "8995",
+        "line": "9007",
         "name": "clear_owner",
         "owner": "CcbItemsApi",
         "parameters": "item_handle, remember_previous"
       },
       {
-        "line": "8946",
+        "line": "8958",
         "name": "erase_var",
         "owner": "CcbItemsApi",
         "parameters": "handle, key"
       },
       {
-        "line": "8907",
+        "line": "8919",
         "name": "food_fun",
         "owner": "CcbItemsApi",
         "parameters": "id"
       },
       {
-        "line": "8937",
+        "line": "8949",
         "name": "get_var",
         "owner": "CcbItemsApi",
         "parameters": "handle, key"
       },
       {
-        "line": "8923",
+        "line": "8935",
         "name": "gun_damage",
         "owner": "CcbItemsApi",
         "parameters": "handle, damage_type, with_ammo"
       },
       {
-        "line": "8950",
+        "line": "8962",
         "name": "has_flag",
         "owner": "CcbItemsApi",
         "parameters": "handle, flag"
       },
       {
-        "line": "8981",
+        "line": "8993",
         "name": "has_technique",
         "owner": "CcbItemsApi",
         "parameters": "handle, technique"
       },
       {
-        "line": "8918",
+        "line": "8930",
         "name": "melee_damage",
         "owner": "CcbItemsApi",
         "parameters": "handle, damage_type"
       },
       {
-        "line": "8900",
+        "line": "8912",
         "name": "page",
         "owner": "CcbItemsApi",
         "parameters": "holder, options, continuation"
       },
       {
-        "line": "8910",
+        "line": "8922",
         "name": "possible_from_group",
         "owner": "CcbItemsApi",
         "parameters": "group"
       },
       {
-        "line": "8928",
+        "line": "8940",
         "name": "quality",
         "owner": "CcbItemsApi",
         "parameters": "handle, quality, strict"
       },
       {
-        "line": "8972",
+        "line": "8984",
         "name": "set_fault",
         "owner": "CcbItemsApi",
         "parameters": "handle, fault, options"
       },
       {
-        "line": "8961",
+        "line": "8973",
         "name": "set_flag",
         "owner": "CcbItemsApi",
         "parameters": "handle, flag, enabled"
       },
       {
-        "line": "8991",
+        "line": "9003",
         "name": "set_owner",
         "owner": "CcbItemsApi",
         "parameters": "item_handle, owner, remember_previous"
       },
       {
-        "line": "8977",
+        "line": "8989",
         "name": "set_random_fault",
         "owner": "CcbItemsApi",
         "parameters": "handle, fault_type, options"
       },
       {
-        "line": "8986",
+        "line": "8998",
         "name": "set_technique",
         "owner": "CcbItemsApi",
         "parameters": "handle, technique, enabled"
       },
       {
-        "line": "8942",
+        "line": "8954",
         "name": "set_var",
         "owner": "CcbItemsApi",
         "parameters": "handle, key, value"
       },
       {
-        "line": "8904",
+        "line": "8916",
         "name": "snapshot",
         "owner": "CcbItemsApi",
         "parameters": "handle, relation_limit"
       },
       {
-        "line": "8895",
+        "line": "8907",
         "name": "transfer",
         "owner": "CcbItemsApi",
         "parameters": "item_handle, source_holder, destination_holder, quantity"
       },
       {
-        "line": "8933",
+        "line": "8945",
         "name": "transform",
         "owner": "CcbItemsApi",
         "parameters": "handle, target, options"
       },
       {
-        "line": "8914",
+        "line": "8926",
         "name": "update",
         "owner": "CcbItemsApi",
         "parameters": "handle, updates"
@@ -20761,631 +20816,631 @@
         "parameters": "position"
       },
       {
-        "line": "6866",
+        "line": "6878",
         "name": "apply",
         "owner": "CcbMapgenApi",
         "parameters": "target, update, options"
       },
       {
-        "line": "8330",
+        "line": "8342",
         "name": "define",
         "owner": "CcbMapgenApi",
         "parameters": "descriptor"
       },
       {
-        "line": "8332",
+        "line": "8344",
         "name": "limits",
         "owner": "CcbMapgenApi",
         "parameters": ""
       },
       {
-        "line": "6871",
+        "line": "6883",
         "name": "on_generate",
         "owner": "CcbMapgenApi",
         "parameters": "handler_id, options"
       },
       {
-        "line": "6876",
+        "line": "6888",
         "name": "on_postprocess",
         "owner": "CcbMapgenApi",
         "parameters": "handler_id, options"
       },
       {
-        "line": "8335",
+        "line": "8347",
         "name": "register_palette",
         "owner": "CcbMapgenApi",
         "parameters": "descriptor"
       },
       {
-        "line": "6860",
+        "line": "6872",
         "name": "update_token",
         "owner": "CcbMapgenApi",
         "parameters": "id"
       },
       {
-        "line": "8656",
+        "line": "8668",
         "name": "abandon",
         "owner": "CcbMissionsApi",
         "parameters": "owner, token"
       },
       {
-        "line": "8622",
+        "line": "8634",
         "name": "assign",
         "owner": "CcbMissionsApi",
         "parameters": "owner, token"
       },
       {
-        "line": "8652",
+        "line": "8664",
         "name": "cancel",
         "owner": "CcbMissionsApi",
         "parameters": "token"
       },
       {
-        "line": "8649",
+        "line": "8661",
         "name": "complete",
         "owner": "CcbMissionsApi",
         "parameters": "owner, token, force"
       },
       {
-        "line": "8591",
+        "line": "8603",
         "name": "definition",
         "owner": "CcbMissionsApi",
         "parameters": "id"
       },
       {
-        "line": "8588",
+        "line": "8600",
         "name": "definitions",
         "owner": "CcbMissionsApi",
         "parameters": "options"
       },
       {
-        "line": "8644",
+        "line": "8656",
         "name": "fail",
         "owner": "CcbMissionsApi",
         "parameters": "owner, token"
       },
       {
-        "line": "8598",
+        "line": "8610",
         "name": "get",
         "owner": "CcbMissionsApi",
         "parameters": "token"
       },
       {
-        "line": "8605",
+        "line": "8617",
         "name": "has_active",
         "owner": "CcbMissionsApi",
         "parameters": "owner, id"
       },
       {
-        "line": "8635",
+        "line": "8647",
         "name": "is_complete",
         "owner": "CcbMissionsApi",
         "parameters": "owner, token, npc_id"
       },
       {
-        "line": "8595",
+        "line": "8607",
         "name": "list",
         "owner": "CcbMissionsApi",
         "parameters": "owner, options"
       },
       {
-        "line": "8609",
+        "line": "8621",
         "name": "random_definition",
         "owner": "CcbMissionsApi",
         "parameters": "origin, position"
       },
       {
-        "line": "8613",
+        "line": "8625",
         "name": "reserve",
         "owner": "CcbMissionsApi",
         "parameters": "id, npc_id"
       },
       {
-        "line": "8618",
+        "line": "8630",
         "name": "reserve_random",
         "owner": "CcbMissionsApi",
         "parameters": "origin, position, npc_id"
       },
       {
-        "line": "8630",
+        "line": "8642",
         "name": "select",
         "owner": "CcbMissionsApi",
         "parameters": "owner, token"
       },
       {
-        "line": "8601",
+        "line": "8613",
         "name": "selected",
         "owner": "CcbMissionsApi",
         "parameters": "owner"
       },
       {
-        "line": "8626",
+        "line": "8638",
         "name": "set_deadline",
         "owner": "CcbMissionsApi",
         "parameters": "token, deadline"
       },
       {
-        "line": "8640",
+        "line": "8652",
         "name": "step_complete",
         "owner": "CcbMissionsApi",
         "parameters": "owner, token, step"
       },
       {
-        "line": "9908",
+        "line": "9920",
         "name": "add",
         "owner": "CcbMoraleApi",
         "parameters": "character, morale, bonus, max_bonus, options"
       },
       {
-        "line": "9914",
+        "line": "9926",
         "name": "remove",
         "owner": "CcbMoraleApi",
         "parameters": "character, morale"
       },
       {
-        "line": "10119",
+        "line": "10131",
         "name": "grant",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation, variant"
       },
       {
-        "line": "10089",
+        "line": "10101",
         "name": "has",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation"
       },
       {
-        "line": "10103",
+        "line": "10115",
         "name": "is_purifiable",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation"
       },
       {
-        "line": "10096",
+        "line": "10108",
         "name": "is_visible_to",
         "owner": "CcbMutationsApi",
         "parameters": "observed, observer, mutation"
       },
       {
-        "line": "10148",
+        "line": "10160",
         "name": "mutate_category",
         "owner": "CcbMutationsApi",
         "parameters": "character, category, use_vitamins, true_random"
       },
       {
-        "line": "10126",
+        "line": "10138",
         "name": "remove",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation"
       },
       {
-        "line": "10140",
+        "line": "10152",
         "name": "remove_category",
         "owner": "CcbMutationsApi",
         "parameters": "character, category"
       },
       {
-        "line": "10157",
+        "line": "10169",
         "name": "remove_type",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation_type"
       },
       {
-        "line": "10134",
+        "line": "10146",
         "name": "set_active",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation, active"
       },
       {
-        "line": "10111",
+        "line": "10123",
         "name": "set_purifiable",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation, purifiable"
       },
       {
-        "line": "9371",
+        "line": "9383",
         "name": "finish",
         "owner": "CcbNpcDialogueActionsApi",
         "parameters": "handle"
       },
       {
-        "line": "9374",
+        "line": "9386",
         "name": "provoke_combat",
         "owner": "CcbNpcDialogueActionsApi",
         "parameters": "handle"
       },
       {
-        "line": "9343",
+        "line": "9355",
         "name": "open_style",
         "owner": "CcbNpcGroomingApi",
         "parameters": "provider, client, area"
       },
       {
-        "line": "9348",
+        "line": "9360",
         "name": "provide",
         "owner": "CcbNpcGroomingApi",
         "parameters": "provider, client, service"
       },
       {
-        "line": "9331",
+        "line": "9343",
         "name": "open_bionic_service",
         "owner": "CcbNpcMedicalApi",
         "parameters": "provider, operation, patient"
       },
       {
-        "line": "9326",
+        "line": "9338",
         "name": "provide_aid",
         "owner": "CcbNpcMedicalApi",
         "parameters": "provider, patient, level, include_allies"
       },
       {
-        "line": "9335",
+        "line": "9347",
         "name": "repair_bionic_limbs",
         "owner": "CcbNpcMedicalApi",
         "parameters": "provider, patient"
       },
       {
-        "line": "9296",
+        "line": "9308",
         "name": "add_assigned",
         "owner": "CcbNpcMissionsApi",
         "parameters": "provider, owner, mission"
       },
       {
-        "line": "9300",
+        "line": "9312",
         "name": "assign_selected",
         "owner": "CcbNpcMissionsApi",
         "parameters": "provider, owner"
       },
       {
-        "line": "9317",
+        "line": "9329",
         "name": "claim_selected_reward",
         "owner": "CcbNpcMissionsApi",
         "parameters": "provider, owner"
       },
       {
-        "line": "9313",
+        "line": "9325",
         "name": "clear_selected",
         "owner": "CcbNpcMissionsApi",
         "parameters": "provider, owner"
       },
       {
-        "line": "9309",
+        "line": "9321",
         "name": "fail_selected",
         "owner": "CcbNpcMissionsApi",
         "parameters": "provider, owner"
       },
       {
-        "line": "9291",
+        "line": "9303",
         "name": "offer",
         "owner": "CcbNpcMissionsApi",
         "parameters": "provider, mission"
       },
       {
-        "line": "9287",
+        "line": "9299",
         "name": "select",
         "owner": "CcbNpcMissionsApi",
         "parameters": "provider, token"
       },
       {
-        "line": "9283",
+        "line": "9295",
         "name": "state",
         "owner": "CcbNpcMissionsApi",
         "parameters": "provider"
       },
       {
-        "line": "9305",
+        "line": "9317",
         "name": "succeed_selected",
         "owner": "CcbNpcMissionsApi",
         "parameters": "provider, owner, force"
       },
       {
-        "line": "9355",
+        "line": "9367",
         "name": "offerings",
         "owner": "CcbNpcTrainingApi",
         "parameters": "teacher, student"
       },
       {
-        "line": "9360",
+        "line": "9372",
         "name": "start",
         "owner": "CcbNpcTrainingApi",
         "parameters": "teacher, students, subject"
       },
       {
-        "line": "9365",
+        "line": "9377",
         "name": "start_selected",
         "owner": "CcbNpcTrainingApi",
         "parameters": "provider, student, mode"
       },
       {
-        "line": "9428",
+        "line": "9440",
         "name": "add_debt",
         "owner": "CcbNpcsApi",
         "parameters": "handle, amount"
       },
       {
-        "line": "9432",
+        "line": "9444",
         "name": "add_faction_rep",
         "owner": "CcbNpcsApi",
         "parameters": "handle, amount"
       },
       {
-        "line": "9451",
+        "line": "9463",
         "name": "ai_rule_catalog",
         "owner": "CcbNpcsApi",
         "parameters": ""
       },
       {
-        "line": "9528",
+        "line": "9540",
         "name": "ai_rules",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9496",
+        "line": "9508",
         "name": "become_hostile",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9390",
+        "line": "9402",
         "name": "class",
         "owner": "CcbNpcsApi",
         "parameters": "id"
       },
       {
-        "line": "9387",
+        "line": "9399",
         "name": "classes",
         "owner": "CcbNpcsApi",
         "parameters": "options"
       },
       {
-        "line": "9498",
+        "line": "9510",
         "name": "clear_stolen_item_claim",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9507",
+        "line": "9519",
         "name": "companion_state",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9470",
+        "line": "9482",
         "name": "copy_ai_rules",
         "owner": "CcbNpcsApi",
         "parameters": "target, source"
       },
       {
-        "line": "9402",
+        "line": "9414",
         "name": "count_allies",
         "owner": "CcbNpcsApi",
         "parameters": "global"
       },
       {
-        "line": "9500",
+        "line": "9512",
         "name": "destinations",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9399",
+        "line": "9411",
         "name": "find_unique",
         "owner": "CcbNpcsApi",
         "parameters": "unique_id"
       },
       {
-        "line": "9481",
+        "line": "9493",
         "name": "follow_temporarily",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9396",
+        "line": "9408",
         "name": "get",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9412",
+        "line": "9424",
         "name": "has_follower_nearby",
         "owner": "CcbNpcsApi",
         "parameters": "origin, class, radius"
       },
       {
-        "line": "9407",
+        "line": "9419",
         "name": "has_role_nearby",
         "owner": "CcbNpcsApi",
         "parameters": "origin, role, radius"
       },
       {
-        "line": "9489",
+        "line": "9501",
         "name": "join_player",
         "owner": "CcbNpcsApi",
         "parameters": "handle, avatar"
       },
       {
-        "line": "9505",
+        "line": "9517",
         "name": "lead_to",
         "owner": "CcbNpcsApi",
         "parameters": "handle, goal"
       },
       {
-        "line": "9492",
+        "line": "9504",
         "name": "leave_player",
         "owner": "CcbNpcsApi",
         "parameters": "handle, avatar"
       },
       {
-        "line": "9393",
+        "line": "9405",
         "name": "list",
         "owner": "CcbNpcsApi",
         "parameters": "options"
       },
       {
-        "line": "9483",
+        "line": "9495",
         "name": "make_neutral",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9473",
+        "line": "9485",
         "name": "make_thankful",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9424",
+        "line": "9436",
         "name": "modify_opinion",
         "owner": "CcbNpcsApi",
         "parameters": "handle, deltas"
       },
       {
-        "line": "9514",
+        "line": "9526",
         "name": "offer_item",
         "owner": "CcbNpcsApi",
         "parameters": "recipient, giver, item, use_item"
       },
       {
-        "line": "9509",
+        "line": "9521",
         "name": "open_companion_missions",
         "owner": "CcbNpcsApi",
         "parameters": "handle, role"
       },
       {
-        "line": "9522",
+        "line": "9534",
         "name": "open_control_menu",
         "owner": "CcbNpcsApi",
         "parameters": "avatar"
       },
       {
-        "line": "9519",
+        "line": "9531",
         "name": "open_dialogue",
         "owner": "CcbNpcsApi",
         "parameters": "npc, speaker, topic"
       },
       {
-        "line": "9520",
+        "line": "9532",
         "name": "open_rules",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9503",
+        "line": "9515",
         "name": "plan_travel",
         "owner": "CcbNpcsApi",
         "parameters": "handle, goal"
       },
       {
-        "line": "9477",
+        "line": "9489",
         "name": "record_refusal",
         "owner": "CcbNpcsApi",
         "parameters": "handle, request"
       },
       {
-        "line": "9416",
+        "line": "9428",
         "name": "rename",
         "owner": "CcbNpcsApi",
         "parameters": "handle, name"
       },
       {
-        "line": "9456",
+        "line": "9468",
         "name": "set_ai_policy",
         "owner": "CcbNpcsApi",
         "parameters": "handle, family, rule"
       },
       {
-        "line": "9466",
+        "line": "9478",
         "name": "set_ally_override",
         "owner": "CcbNpcsApi",
         "parameters": "handle, rule, state"
       },
       {
-        "line": "9461",
+        "line": "9473",
         "name": "set_ally_rule",
         "owner": "CcbNpcsApi",
         "parameters": "handle, rule, enabled"
       },
       {
-        "line": "9420",
+        "line": "9432",
         "name": "set_attitude",
         "owner": "CcbNpcsApi",
         "parameters": "handle, attitude"
       },
       {
-        "line": "9436",
+        "line": "9448",
         "name": "set_class",
         "owner": "CcbNpcsApi",
         "parameters": "handle, class"
       },
       {
-        "line": "9508",
+        "line": "9520",
         "name": "set_companion_role",
         "owner": "CcbNpcsApi",
         "parameters": "handle, role"
       },
       {
-        "line": "9440",
+        "line": "9452",
         "name": "set_faction",
         "owner": "CcbNpcsApi",
         "parameters": "handle, faction"
       },
       {
-        "line": "9444",
+        "line": "9456",
         "name": "set_first_topic",
         "owner": "CcbNpcsApi",
         "parameters": "handle, topic"
       },
       {
-        "line": "9504",
+        "line": "9516",
         "name": "set_goal",
         "owner": "CcbNpcsApi",
         "parameters": "handle, goal"
       },
       {
-        "line": "9506",
+        "line": "9518",
         "name": "set_guard_position",
         "owner": "CcbNpcsApi",
         "parameters": "handle, position"
       },
       {
-        "line": "9495",
+        "line": "9507",
         "name": "set_guarding",
         "owner": "CcbNpcsApi",
         "parameters": "handle, enabled"
       },
       {
-        "line": "9449",
+        "line": "9461",
         "name": "set_radio_representative",
         "owner": "CcbNpcsApi",
         "parameters": "handle, avatar, enabled"
       },
       {
-        "line": "9484",
+        "line": "9496",
         "name": "start_fleeing",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9485",
+        "line": "9497",
         "name": "start_mugging",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9482",
+        "line": "9494",
         "name": "stop_temporary_following",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
       },
       {
-        "line": "9525",
+        "line": "9537",
         "name": "take_control",
         "owner": "CcbNpcsApi",
         "parameters": "handle, avatar"
       },
       {
-        "line": "9497",
+        "line": "9509",
         "name": "warn_player_departure",
         "owner": "CcbNpcsApi",
         "parameters": "handle"
@@ -21409,199 +21464,199 @@
         "parameters": "position"
       },
       {
-        "line": "9780",
+        "line": "9792",
         "name": "complete",
         "owner": "CcbPlatformAchievementsApi",
         "parameters": "id"
       },
       {
-        "line": "8263",
+        "line": "8275",
         "name": "assign_npc_job",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "handle, job"
       },
       {
-        "line": "9814",
+        "line": "9826",
         "name": "assign_timed",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "character, id, duration"
       },
       {
-        "line": "9819",
+        "line": "9831",
         "name": "cancel",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "character"
       },
       {
-        "line": "8266",
+        "line": "8278",
         "name": "clear_backlog",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "character_handle"
       },
       {
-        "line": "8269",
+        "line": "8281",
         "name": "dismount",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "npc_handle"
       },
       {
-        "line": "8276",
+        "line": "8288",
         "name": "drop_item",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "character_handle, item_handle, quantity, placement, force_ground"
       },
       {
-        "line": "8279",
+        "line": "8291",
         "name": "drop_nonfavorite_items",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "npc_handle"
       },
       {
-        "line": "8282",
+        "line": "8294",
         "name": "offer_interruption",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "reason"
       },
       {
-        "line": "8285",
+        "line": "8297",
         "name": "offer_portal_storm_interruption",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "message"
       },
       {
-        "line": "8291",
+        "line": "8303",
         "name": "pickup_item",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "character_handle, item_handle, quantity, autopickup"
       },
       {
-        "line": "8299",
+        "line": "8311",
         "name": "read",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "character_handle, book_handle, duration, ereader_handle, continuous, learner_handle"
       },
       {
-        "line": "8302",
+        "line": "8314",
         "name": "resume",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "character_handle"
       },
       {
-        "line": "8305",
+        "line": "8317",
         "name": "revert_npc_job",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "handle"
       },
       {
-        "line": "9805",
+        "line": "9817",
         "name": "snapshot",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "character"
       },
       {
-        "line": "8310",
+        "line": "8322",
         "name": "socialize",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "character_handle, partner_handle, duration"
       },
       {
-        "line": "8316",
+        "line": "8328",
         "name": "start_training",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "teacher_handle, trainee_handles, subject_id, duration"
       },
       {
-        "line": "8319",
+        "line": "8331",
         "name": "suspend",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "character_handle"
       },
       {
-        "line": "8322",
+        "line": "8334",
         "name": "target_practice",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "character_handle"
       },
       {
-        "line": "8327",
+        "line": "8339",
         "name": "wait_for_npc",
         "owner": "CcbPlatformActivitiesApi",
         "parameters": "character_handle, npc_handle, duration"
       },
       {
-        "line": "10177",
+        "line": "10189",
         "name": "grant",
         "owner": "CcbPlatformBionicsApi",
         "parameters": "character, id"
       },
       {
-        "line": "10183",
+        "line": "10195",
         "name": "remove_type",
         "owner": "CcbPlatformBionicsApi",
         "parameters": "character, id"
       },
       {
-        "line": "10171",
+        "line": "10183",
         "name": "summary",
         "owner": "CcbPlatformBionicsApi",
         "parameters": "character"
       },
       {
-        "line": "5439",
+        "line": "5451",
         "name": "Achievement",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5371",
+        "line": "5383",
         "name": "ActivityType",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5332",
+        "line": "5344",
         "name": "AddictionType",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5328",
+        "line": "5340",
         "name": "AmmoEffect",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5084",
+        "line": "5096",
         "name": "AmmunitionType",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5196",
+        "line": "5208",
         "name": "Anatomy",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5276",
+        "line": "5288",
         "name": "AsciiArt",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5395",
+        "line": "5407",
         "name": "AttackVector",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5288",
+        "line": "5300",
         "name": "BashDamageProfile",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5156",
+        "line": "5168",
         "name": "Behavior",
         "owner": "CcbPlatformContent",
         "parameters": "options"
@@ -21613,133 +21668,133 @@
         "parameters": "options"
       },
       {
-        "line": "5447",
+        "line": "5459",
         "name": "Blacklist",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5200",
+        "line": "5212",
         "name": "BodyGraph",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5188",
+        "line": "5200",
         "name": "BodyPart",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5120",
+        "line": "5132",
         "name": "ButcheryRequirement",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5336",
+        "line": "5348",
         "name": "CharacterModifier",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5559",
+        "line": "5571",
         "name": "City",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5563",
+        "line": "5575",
         "name": "CityBuilding",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5344",
+        "line": "5356",
         "name": "ClimbingAid",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5292",
+        "line": "5304",
         "name": "ClothingMod",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5443",
+        "line": "5455",
         "name": "Conduct",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5236",
+        "line": "5248",
         "name": "ConnectGroup",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5411",
+        "line": "5423",
         "name": "Construction",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5244",
+        "line": "5256",
         "name": "ConstructionCategory",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5248",
+        "line": "5260",
         "name": "ConstructionGroup",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5260",
+        "line": "5272",
         "name": "DamageInfoOrder",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5076",
+        "line": "5088",
         "name": "DamageType",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5543",
+        "line": "5555",
         "name": "Dimension",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5539",
+        "line": "5551",
         "name": "DimensionRegionLayout",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5212",
+        "line": "5224",
         "name": "DiseaseType",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5435",
+        "line": "5447",
         "name": "Dream",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5164",
+        "line": "5176",
         "name": "EffectType",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5224",
+        "line": "5236",
         "name": "Emission",
         "owner": "CcbPlatformContent",
         "parameters": "options"
@@ -21751,7 +21806,7 @@
         "parameters": "options"
       },
       {
-        "line": "5367",
+        "line": "5379",
         "name": "EndScreen",
         "owner": "CcbPlatformContent",
         "parameters": "options"
@@ -21769,157 +21824,157 @@
         "parameters": "options"
       },
       {
-        "line": "5324",
+        "line": "5336",
         "name": "ExplosionLight",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5020",
+        "line": "5032",
         "name": "Faction",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5567",
+        "line": "5579",
         "name": "FactionMission",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5427",
+        "line": "5439",
         "name": "Fault",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5431",
+        "line": "5443",
         "name": "FaultFix",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5320",
+        "line": "5332",
         "name": "FaultGroup",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5172",
+        "line": "5184",
         "name": "FieldType",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5555",
+        "line": "5567",
         "name": "ForestBiomeComponent",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5575",
+        "line": "5587",
         "name": "ForestBiomeMapgen",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5415",
+        "line": "5427",
         "name": "Furniture",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5423",
+        "line": "5435",
         "name": "Gate",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5152",
+        "line": "5164",
         "name": "Harvest",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5148",
+        "line": "5160",
         "name": "HarvestDropType",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5375",
+        "line": "5387",
         "name": "HelpTopic",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5284",
+        "line": "5296",
         "name": "HitRange",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5016",
+        "line": "5028",
         "name": "Item",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5124",
+        "line": "5136",
         "name": "ItemAction",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5088",
+        "line": "5100",
         "name": "ItemCategory",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5176",
+        "line": "5188",
         "name": "ItemGroup",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5072",
+        "line": "5084",
         "name": "JsonFlag",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5280",
+        "line": "5292",
         "name": "LimbScore",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5483",
+        "line": "5495",
         "name": "MagicType",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5451",
+        "line": "5463",
         "name": "MapExtra",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5312",
+        "line": "5324",
         "name": "MapExtraCollection",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5403",
+        "line": "5415",
         "name": "MartialArt",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5080",
+        "line": "5092",
         "name": "Material",
         "owner": "CcbPlatformContent",
         "parameters": "options"
@@ -21931,7 +21986,7 @@
         "parameters": "options"
       },
       {
-        "line": "5459",
+        "line": "5471",
         "name": "Migration",
         "owner": "CcbPlatformContent",
         "parameters": "options"
@@ -21943,55 +21998,55 @@
         "parameters": "options"
       },
       {
-        "line": "5204",
+        "line": "5216",
         "name": "Monster",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5467",
+        "line": "5479",
         "name": "MonsterAdjustment",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5160",
+        "line": "5172",
         "name": "MonsterAttack",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5228",
+        "line": "5240",
         "name": "MonsterFaction",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5216",
+        "line": "5228",
         "name": "MonsterFlag",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5136",
+        "line": "5148",
         "name": "MonsterGroup",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5256",
+        "line": "5268",
         "name": "MoodFace",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5208",
+        "line": "5220",
         "name": "MoraleType",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5487",
+        "line": "5499",
         "name": "MovementMode",
         "owner": "CcbPlatformContent",
         "parameters": "options"
@@ -22003,91 +22058,91 @@
         "parameters": "options"
       },
       {
-        "line": "5240",
+        "line": "5252",
         "name": "MutationCategory",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5232",
+        "line": "5244",
         "name": "MutationType",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5268",
+        "line": "5280",
         "name": "NamedColor",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5052",
+        "line": "5064",
         "name": "NestedRecipeCategory",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5028",
+        "line": "5040",
         "name": "Npc",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5024",
+        "line": "5036",
         "name": "NpcClass",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5547",
+        "line": "5559",
         "name": "OmtPlaceholder",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5535",
+        "line": "5547",
         "name": "OptionSlider",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5355",
+        "line": "5367",
         "name": "OverlayOrder",
         "owner": "CcbPlatformContent",
         "parameters": ""
       },
       {
-        "line": "5140",
+        "line": "5152",
         "name": "OvermapConnection",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5296",
+        "line": "5308",
         "name": "OvermapLandUseCode",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5304",
+        "line": "5316",
         "name": "OvermapLocation",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5036",
+        "line": "5048",
         "name": "OvermapSpecial",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5032",
+        "line": "5044",
         "name": "OvermapTerrain",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5300",
+        "line": "5312",
         "name": "OvermapVision",
         "owner": "CcbPlatformContent",
         "parameters": "options"
@@ -22099,7 +22154,7 @@
         "parameters": "options"
       },
       {
-        "line": "5383",
+        "line": "5395",
         "name": "Playlist",
         "owner": "CcbPlatformContent",
         "parameters": "options"
@@ -22117,7 +22172,7 @@
         "parameters": "options"
       },
       {
-        "line": "5308",
+        "line": "5320",
         "name": "ProfessionGroup",
         "owner": "CcbPlatformContent",
         "parameters": "options"
@@ -22135,109 +22190,109 @@
         "parameters": "options"
       },
       {
-        "line": "5100",
+        "line": "5112",
         "name": "Proficiency",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5096",
+        "line": "5108",
         "name": "ProficiencyCategory",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5048",
+        "line": "5060",
         "name": "Recipe",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5092",
+        "line": "5104",
         "name": "RecipeCategory",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5112",
+        "line": "5124",
         "name": "RecipeGroup",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5531",
+        "line": "5543",
         "name": "RegionSettings",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5571",
+        "line": "5583",
         "name": "RegionSettingsCity",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5503",
+        "line": "5515",
         "name": "RegionSettingsForest",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5511",
+        "line": "5523",
         "name": "RegionSettingsForestMapgen",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5523",
+        "line": "5535",
         "name": "RegionSettingsForestTrail",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5527",
+        "line": "5539",
         "name": "RegionSettingsHighway",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5495",
+        "line": "5507",
         "name": "RegionSettingsLake",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5515",
+        "line": "5527",
         "name": "RegionSettingsMapExtras",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5499",
+        "line": "5511",
         "name": "RegionSettingsOcean",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5491",
+        "line": "5503",
         "name": "RegionSettingsRavine",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5507",
+        "line": "5519",
         "name": "RegionSettingsRiver",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5519",
+        "line": "5531",
         "name": "RegionSettingsTerrainFurniture",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5551",
+        "line": "5563",
         "name": "RegionTerrainFurniture",
         "owner": "CcbPlatformContent",
         "parameters": "options"
@@ -22249,97 +22304,97 @@
         "parameters": "options"
       },
       {
-        "line": "5108",
+        "line": "5120",
         "name": "Requirement",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5272",
+        "line": "5284",
         "name": "RotatableSymbol",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5128",
+        "line": "5140",
         "name": "Scenario",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5116",
+        "line": "5128",
         "name": "ScentType",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5352",
+        "line": "5364",
         "name": "Score",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5471",
+        "line": "5483",
         "name": "ShopkeeperBlacklist",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5479",
+        "line": "5491",
         "name": "ShopkeeperConsumptionRates",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5475",
+        "line": "5487",
         "name": "ShopkeeperWhitelist",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5064",
+        "line": "5076",
         "name": "Skill",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5060",
+        "line": "5072",
         "name": "SkillDisplay",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5379",
+        "line": "5391",
         "name": "SnippetCategory",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5387",
+        "line": "5399",
         "name": "SoundEffect",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5391",
+        "line": "5403",
         "name": "SoundEffectPreload",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5220",
+        "line": "5232",
         "name": "Species",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5363",
+        "line": "5375",
         "name": "SpeechPool",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5144",
+        "line": "5156",
         "name": "SpeedDescription",
         "owner": "CcbPlatformContent",
         "parameters": "options"
@@ -22351,25 +22406,25 @@
         "parameters": "options"
       },
       {
-        "line": "5340",
+        "line": "5352",
         "name": "StartLocation",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5180",
+        "line": "5192",
         "name": "SubBodyPart",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5399",
+        "line": "5411",
         "name": "Technique",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5419",
+        "line": "5431",
         "name": "Terrain",
         "owner": "CcbPlatformContent",
         "parameters": "options"
@@ -22381,55 +22436,55 @@
         "parameters": "options"
       },
       {
-        "line": "5056",
+        "line": "5068",
         "name": "ToolQuality",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5463",
+        "line": "5475",
         "name": "TraitGroup",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5407",
+        "line": "5419",
         "name": "Trap",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5044",
+        "line": "5056",
         "name": "Vehicle",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5132",
+        "line": "5144",
         "name": "VehicleColorPalette",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5316",
+        "line": "5328",
         "name": "VehicleGroup",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5040",
+        "line": "5052",
         "name": "VehiclePart",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5264",
+        "line": "5276",
         "name": "VehiclePartCategory",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5252",
+        "line": "5264",
         "name": "VehiclePartLocation",
         "owner": "CcbPlatformContent",
         "parameters": "options"
@@ -22447,31 +22502,31 @@
         "parameters": "options"
       },
       {
-        "line": "5068",
+        "line": "5080",
         "name": "Vitamin",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5168",
+        "line": "5180",
         "name": "WeakpointSet",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5104",
+        "line": "5116",
         "name": "WeaponCategory",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5455",
+        "line": "5467",
         "name": "WeatherGenerator",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5348",
+        "line": "5360",
         "name": "WeatherType",
         "owner": "CcbPlatformContent",
         "parameters": "options"
@@ -22483,85 +22538,85 @@
         "parameters": "options"
       },
       {
-        "line": "5184",
+        "line": "5196",
         "name": "Wound",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5192",
+        "line": "5204",
         "name": "WoundFix",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5359",
+        "line": "5371",
         "name": "ZoneType",
         "owner": "CcbPlatformContent",
         "parameters": "options"
       },
       {
-        "line": "5580",
+        "line": "5592",
         "name": "add",
         "owner": "CcbPlatformContent",
         "parameters": "definition"
       },
       {
-        "line": "5584",
+        "line": "5596",
         "name": "edit",
         "owner": "CcbPlatformContent",
         "parameters": "definition"
       },
       {
-        "line": "5889",
+        "line": "5901",
         "name": "edit_activity_type",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5850",
+        "line": "5862",
         "name": "edit_addiction_type",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5846",
+        "line": "5858",
         "name": "edit_ammo_effect",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5630",
+        "line": "5642",
         "name": "edit_ammunition_type",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5718",
+        "line": "5730",
         "name": "edit_anatomy",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5798",
+        "line": "5810",
         "name": "edit_ascii_art",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5905",
+        "line": "5917",
         "name": "edit_attack_vector",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5806",
+        "line": "5818",
         "name": "edit_bash_damage_profile",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5678",
+        "line": "5690",
         "name": "edit_behavior",
         "owner": "CcbPlatformContent",
         "parameters": "id"
@@ -22573,97 +22628,97 @@
         "parameters": "id"
       },
       {
-        "line": "5722",
+        "line": "5734",
         "name": "edit_body_graph",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5710",
+        "line": "5722",
         "name": "edit_body_part",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5854",
+        "line": "5866",
         "name": "edit_character_modifier",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5985",
+        "line": "5997",
         "name": "edit_city",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5862",
+        "line": "5874",
         "name": "edit_climbing_aid",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5810",
+        "line": "5822",
         "name": "edit_clothing_mod",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5758",
+        "line": "5770",
         "name": "edit_connect_group",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5766",
+        "line": "5778",
         "name": "edit_construction_category",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5770",
+        "line": "5782",
         "name": "edit_construction_group",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5782",
+        "line": "5794",
         "name": "edit_damage_info_order",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5622",
+        "line": "5634",
         "name": "edit_damage_type",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5969",
+        "line": "5981",
         "name": "edit_dimension",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5965",
+        "line": "5977",
         "name": "edit_dimension_region_layout",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5734",
+        "line": "5746",
         "name": "edit_disease_type",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5686",
+        "line": "5698",
         "name": "edit_effect_type",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5746",
+        "line": "5758",
         "name": "edit_emission",
         "owner": "CcbPlatformContent",
         "parameters": "id"
@@ -22675,7 +22730,7 @@
         "parameters": "id"
       },
       {
-        "line": "5885",
+        "line": "5897",
         "name": "edit_end_screen",
         "owner": "CcbPlatformContent",
         "parameters": "id"
@@ -22693,103 +22748,103 @@
         "parameters": "id"
       },
       {
-        "line": "5842",
+        "line": "5854",
         "name": "edit_explosion_light",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5989",
+        "line": "6001",
         "name": "edit_faction_mission",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5838",
+        "line": "5850",
         "name": "edit_fault_group",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5694",
+        "line": "5706",
         "name": "edit_field_type",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5981",
+        "line": "5993",
         "name": "edit_forest_biome_component",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5997",
+        "line": "6009",
         "name": "edit_forest_biome_mapgen",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5674",
+        "line": "5686",
         "name": "edit_harvest",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5670",
+        "line": "5682",
         "name": "edit_harvest_drop_type",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5893",
+        "line": "5905",
         "name": "edit_help_topic",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5590",
+        "line": "5602",
         "name": "edit_item",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5634",
+        "line": "5646",
         "name": "edit_item_category",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5698",
+        "line": "5710",
         "name": "edit_item_group",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5618",
+        "line": "5630",
         "name": "edit_json_flag",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5802",
+        "line": "5814",
         "name": "edit_limb_score",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5909",
+        "line": "5921",
         "name": "edit_magic_type",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5830",
+        "line": "5842",
         "name": "edit_map_extra_collection",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5626",
+        "line": "5638",
         "name": "edit_material",
         "owner": "CcbPlatformContent",
         "parameters": "id"
@@ -22807,43 +22862,43 @@
         "parameters": "id"
       },
       {
-        "line": "5726",
+        "line": "5738",
         "name": "edit_monster",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5682",
+        "line": "5694",
         "name": "edit_monster_attack",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5750",
+        "line": "5762",
         "name": "edit_monster_faction",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5738",
+        "line": "5750",
         "name": "edit_monster_flag",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5778",
+        "line": "5790",
         "name": "edit_mood_face",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5730",
+        "line": "5742",
         "name": "edit_morale_type",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5913",
+        "line": "5925",
         "name": "edit_movement_mode",
         "owner": "CcbPlatformContent",
         "parameters": "id"
@@ -22855,67 +22910,67 @@
         "parameters": "id"
       },
       {
-        "line": "5762",
+        "line": "5774",
         "name": "edit_mutation_category",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5754",
+        "line": "5766",
         "name": "edit_mutation_type",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5790",
+        "line": "5802",
         "name": "edit_named_color",
         "owner": "CcbPlatformContent",
         "parameters": "name"
       },
       {
-        "line": "5598",
+        "line": "5610",
         "name": "edit_nested_recipe_category",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5973",
+        "line": "5985",
         "name": "edit_omt_placeholder",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5961",
+        "line": "5973",
         "name": "edit_option_slider",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5873",
+        "line": "5885",
         "name": "edit_overlay_order",
         "owner": "CcbPlatformContent",
         "parameters": ""
       },
       {
-        "line": "5814",
+        "line": "5826",
         "name": "edit_overmap_land_use_code",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5822",
+        "line": "5834",
         "name": "edit_overmap_location",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5818",
+        "line": "5830",
         "name": "edit_overmap_vision",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5901",
+        "line": "5913",
         "name": "edit_playlist",
         "owner": "CcbPlatformContent",
         "parameters": "id"
@@ -22933,7 +22988,7 @@
         "parameters": "id"
       },
       {
-        "line": "5826",
+        "line": "5838",
         "name": "edit_profession_group",
         "owner": "CcbPlatformContent",
         "parameters": "id"
@@ -22951,109 +23006,109 @@
         "parameters": "id"
       },
       {
-        "line": "5646",
+        "line": "5658",
         "name": "edit_proficiency",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5642",
+        "line": "5654",
         "name": "edit_proficiency_category",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5594",
+        "line": "5606",
         "name": "edit_recipe",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5638",
+        "line": "5650",
         "name": "edit_recipe_category",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5658",
+        "line": "5670",
         "name": "edit_recipe_group",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5957",
+        "line": "5969",
         "name": "edit_region_settings",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5993",
+        "line": "6005",
         "name": "edit_region_settings_city",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5929",
+        "line": "5941",
         "name": "edit_region_settings_forest",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5937",
+        "line": "5949",
         "name": "edit_region_settings_forest_mapgen",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5949",
+        "line": "5961",
         "name": "edit_region_settings_forest_trail",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5953",
+        "line": "5965",
         "name": "edit_region_settings_highway",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5921",
+        "line": "5933",
         "name": "edit_region_settings_lake",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5941",
+        "line": "5953",
         "name": "edit_region_settings_map_extras",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5925",
+        "line": "5937",
         "name": "edit_region_settings_ocean",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5917",
+        "line": "5929",
         "name": "edit_region_settings_ravine",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5933",
+        "line": "5945",
         "name": "edit_region_settings_river",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5945",
+        "line": "5957",
         "name": "edit_region_settings_terrain_furniture",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5977",
+        "line": "5989",
         "name": "edit_region_terrain_furniture",
         "owner": "CcbPlatformContent",
         "parameters": "id"
@@ -23065,61 +23120,61 @@
         "parameters": "id"
       },
       {
-        "line": "5654",
+        "line": "5666",
         "name": "edit_requirement",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5794",
+        "line": "5806",
         "name": "edit_rotatable_symbol",
         "owner": "CcbPlatformContent",
         "parameters": "key"
       },
       {
-        "line": "5662",
+        "line": "5674",
         "name": "edit_scent_type",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5870",
+        "line": "5882",
         "name": "edit_score",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5610",
+        "line": "5622",
         "name": "edit_skill",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5606",
+        "line": "5618",
         "name": "edit_skill_display",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5897",
+        "line": "5909",
         "name": "edit_snippet_category",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5742",
+        "line": "5754",
         "name": "edit_species",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5881",
+        "line": "5893",
         "name": "edit_speech_pool",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5666",
+        "line": "5678",
         "name": "edit_speed_description",
         "owner": "CcbPlatformContent",
         "parameters": "id"
@@ -23131,13 +23186,13 @@
         "parameters": "id"
       },
       {
-        "line": "5858",
+        "line": "5870",
         "name": "edit_start_location",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5702",
+        "line": "5714",
         "name": "edit_sub_body_part",
         "owner": "CcbPlatformContent",
         "parameters": "id"
@@ -23149,25 +23204,25 @@
         "parameters": "id"
       },
       {
-        "line": "5602",
+        "line": "5614",
         "name": "edit_tool_quality",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5834",
+        "line": "5846",
         "name": "edit_vehicle_group",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5786",
+        "line": "5798",
         "name": "edit_vehicle_part_category",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5774",
+        "line": "5786",
         "name": "edit_vehicle_part_location",
         "owner": "CcbPlatformContent",
         "parameters": "id"
@@ -23185,25 +23240,25 @@
         "parameters": "id"
       },
       {
-        "line": "5614",
+        "line": "5626",
         "name": "edit_vitamin",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5690",
+        "line": "5702",
         "name": "edit_weakpoint_set",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5650",
+        "line": "5662",
         "name": "edit_weapon_category",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5866",
+        "line": "5878",
         "name": "edit_weather_type",
         "owner": "CcbPlatformContent",
         "parameters": "id"
@@ -23215,61 +23270,61 @@
         "parameters": "id"
       },
       {
-        "line": "5706",
+        "line": "5718",
         "name": "edit_wound",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5714",
+        "line": "5726",
         "name": "edit_wound_fix",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5877",
+        "line": "5889",
         "name": "edit_zone_type",
         "owner": "CcbPlatformContent",
         "parameters": "id"
       },
       {
-        "line": "5586",
+        "line": "5598",
         "name": "extend_item_group",
         "owner": "CcbPlatformContent",
         "parameters": "definition"
       },
       {
-        "line": "5012",
+        "line": "5024",
         "name": "plural_text",
         "owner": "CcbPlatformContent",
         "parameters": "singular, plural, context"
       },
       {
-        "line": "5582",
+        "line": "5594",
         "name": "replace",
         "owner": "CcbPlatformContent",
         "parameters": "definition"
       },
       {
-        "line": "5005",
+        "line": "5017",
         "name": "text",
         "owner": "CcbPlatformContent",
         "parameters": "text, context"
       },
       {
-        "line": "6194",
+        "line": "6206",
         "name": "extend_topic",
         "owner": "CcbPlatformDialogueApi",
         "parameters": "descriptor"
       },
       {
-        "line": "6197",
+        "line": "6209",
         "name": "limits",
         "owner": "CcbPlatformDialogueApi",
         "parameters": ""
       },
       {
-        "line": "6190",
+        "line": "6202",
         "name": "register_topic",
         "owner": "CcbPlatformDialogueApi",
         "parameters": "descriptor"
@@ -23281,1075 +23336,1075 @@
         "parameters": "dimension"
       },
       {
-        "line": "10393",
+        "line": "10405",
         "name": "dimension",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": ""
       },
       {
-        "line": "10431",
+        "line": "10443",
         "name": "field_exists",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position, field_id"
       },
       {
-        "line": "10414",
+        "line": "10426",
         "name": "furniture_has_flag",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position, flag"
       },
       {
-        "line": "10426",
+        "line": "10438",
         "name": "furniture_id",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position"
       },
       {
-        "line": "10441",
+        "line": "10453",
         "name": "is_indoor_tile",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position"
       },
       {
-        "line": "10397",
+        "line": "10409",
         "name": "is_night",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": ""
       },
       {
-        "line": "10401",
+        "line": "10413",
         "name": "is_outside",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position"
       },
       {
-        "line": "10408",
+        "line": "10420",
         "name": "line_of_sight",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "from, to, range, with_fields"
       },
       {
-        "line": "10446",
+        "line": "10458",
         "name": "safe_mode_dangerous",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "direction"
       },
       {
-        "line": "10436",
+        "line": "10448",
         "name": "terrain_has_flag",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position, flag"
       },
       {
-        "line": "10420",
+        "line": "10432",
         "name": "terrain_id",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position"
       },
       {
-        "line": "4913",
+        "line": "4925",
         "name": "get",
         "owner": "CcbPlatformGameplayOptionsApi",
         "parameters": "id"
       },
       {
-        "line": "4916",
+        "line": "4928",
         "name": "has",
         "owner": "CcbPlatformGameplayOptionsApi",
         "parameters": "id"
       },
       {
-        "line": "4919",
+        "line": "4931",
         "name": "value",
         "owner": "CcbPlatformGameplayOptionsApi",
         "parameters": "id"
       },
       {
-        "line": "6475",
+        "line": "6487",
         "name": "choose",
         "owner": "CcbPlatformInteractionApi",
         "parameters": "entries, options"
       },
       {
-        "line": "6460",
+        "line": "6472",
         "name": "confirm",
         "owner": "CcbPlatformInteractionApi",
         "parameters": "message"
       },
       {
-        "line": "6470",
+        "line": "6482",
         "name": "input_number",
         "owner": "CcbPlatformInteractionApi",
         "parameters": "description, default_value"
       },
       {
-        "line": "6465",
+        "line": "6477",
         "name": "input_text",
         "owner": "CcbPlatformInteractionApi",
         "parameters": "title, options"
       },
       {
-        "line": "9772",
+        "line": "9784",
         "name": "is_wearing",
         "owner": "CcbPlatformInventoryApi",
         "parameters": "character, item"
       },
       {
-        "line": "9763",
+        "line": "9775",
         "name": "wielded",
         "owner": "CcbPlatformInventoryApi",
         "parameters": "character"
       },
       {
-        "line": "4923",
+        "line": "4935",
         "name": "known_snippets",
         "owner": "CcbPlatformLoreApi",
         "parameters": ""
       },
       {
-        "line": "4926",
+        "line": "4938",
         "name": "knows_snippet",
         "owner": "CcbPlatformLoreApi",
         "parameters": "id"
       },
       {
-        "line": "4929",
+        "line": "4941",
         "name": "remember_snippet",
         "owner": "CcbPlatformLoreApi",
         "parameters": "id"
       },
       {
-        "line": "10311",
+        "line": "10323",
         "name": "forget",
         "owner": "CcbPlatformMartialArtsApi",
         "parameters": "character, id"
       },
       {
-        "line": "10305",
+        "line": "10317",
         "name": "learn",
         "owner": "CcbPlatformMartialArtsApi",
         "parameters": "character, id"
       },
       {
-        "line": "10473",
+        "line": "10485",
         "name": "apply",
         "owner": "CcbPlatformMathApi",
         "parameters": "expression, actor, context"
       },
       {
-        "line": "10466",
+        "line": "10478",
         "name": "evaluate",
         "owner": "CcbPlatformMathApi",
         "parameters": "expression, actor, context"
       },
       {
-        "line": "4941",
+        "line": "4953",
         "name": "add",
         "owner": "CcbPlatformMessagesApi",
         "parameters": "message, type"
       },
       {
-        "line": "4945",
+        "line": "4957",
         "name": "add_from_outdoors",
         "owner": "CcbPlatformMessagesApi",
         "parameters": "message, type"
       },
       {
-        "line": "4949",
+        "line": "4961",
         "name": "add_if_audible",
         "owner": "CcbPlatformMessagesApi",
         "parameters": "message, type"
       },
       {
-        "line": "10387",
+        "line": "10399",
         "name": "is_loaded",
         "owner": "CcbPlatformModQueries",
         "parameters": "mod_id"
       },
       {
-        "line": "8338",
+        "line": "8350",
         "name": "load_order",
         "owner": "CcbPlatformModQueries",
         "parameters": "id"
       },
       {
-        "line": "10328",
+        "line": "10340",
         "name": "add",
         "owner": "CcbPlatformMoraleApi",
         "parameters": "character, id, bonus, max_bonus, options"
       },
       {
-        "line": "10334",
+        "line": "10346",
         "name": "remove",
         "owner": "CcbPlatformMoraleApi",
         "parameters": "character, id"
       },
       {
-        "line": "4935",
+        "line": "4947",
         "name": "emit",
         "owner": "CcbPlatformNativeEventsApi",
         "parameters": "type_name, requested_args"
       },
       {
-        "line": "6413",
+        "line": "6425",
         "name": "canvas",
         "owner": "CcbPlatformPresentation",
         "parameters": "options, draw"
       },
       {
-        "line": "6430",
+        "line": "6442",
         "name": "choose",
         "owner": "CcbPlatformPresentation",
         "parameters": "prompt, entries"
       },
       {
-        "line": "6425",
+        "line": "6437",
         "name": "confirm",
         "owner": "CcbPlatformPresentation",
         "parameters": "question"
       },
       {
-        "line": "6435",
+        "line": "6447",
         "name": "input_text",
         "owner": "CcbPlatformPresentation",
         "parameters": "prompt, options"
       },
       {
-        "line": "6421",
+        "line": "6433",
         "name": "notice",
         "owner": "CcbPlatformPresentation",
         "parameters": "message"
       },
       {
-        "line": "8362",
+        "line": "8374",
         "name": "notice_any_key",
         "owner": "CcbPlatformPresentation",
         "parameters": "message"
       },
       {
-        "line": "8365",
+        "line": "8377",
         "name": "notice_large",
         "owner": "CcbPlatformPresentation",
         "parameters": "message"
       },
       {
-        "line": "8368",
+        "line": "8380",
         "name": "notice_top",
         "owner": "CcbPlatformPresentation",
         "parameters": "message"
       },
       {
-        "line": "6418",
+        "line": "6430",
         "name": "play_sound",
         "owner": "CcbPlatformPresentation",
         "parameters": "file, volume"
       },
       {
-        "line": "10347",
+        "line": "10359",
         "name": "chance",
         "owner": "CcbPlatformRandomApi",
         "parameters": "numerator, denominator"
       },
       {
-        "line": "10369",
+        "line": "10381",
         "name": "contested",
         "owner": "CcbPlatformRandomApi",
         "parameters": "check, difficulty, die_size"
       },
       {
-        "line": "10342",
+        "line": "10354",
         "name": "int",
         "owner": "CcbPlatformRandomApi",
         "parameters": "minimum, maximum"
       },
       {
-        "line": "10351",
+        "line": "10363",
         "name": "one_in",
         "owner": "CcbPlatformRandomApi",
         "parameters": "denominator"
       },
       {
-        "line": "10356",
+        "line": "10368",
         "name": "probability",
         "owner": "CcbPlatformRandomApi",
         "parameters": "numerator, denominator"
       },
       {
-        "line": "10363",
+        "line": "10375",
         "name": "sample_integers",
         "owner": "CcbPlatformRandomApi",
         "parameters": "minimum, maximum, count, with_replacement"
       },
       {
-        "line": "10227",
+        "line": "10239",
         "name": "all",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, options"
       },
       {
-        "line": "10237",
+        "line": "10249",
         "name": "by_flag",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "flag, character, options"
       },
       {
-        "line": "10232",
+        "line": "10244",
         "name": "by_skill",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "skill, character, options"
       },
       {
-        "line": "10279",
+        "line": "10291",
         "name": "forget",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, id"
       },
       {
-        "line": "10296",
+        "line": "10308",
         "name": "forget_category",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, category, subcategory"
       },
       {
-        "line": "10242",
+        "line": "10254",
         "name": "get",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, id, batch"
       },
       {
-        "line": "10246",
+        "line": "10258",
         "name": "has_flag",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "id, flag"
       },
       {
-        "line": "10267",
+        "line": "10279",
         "name": "knows",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, id"
       },
       {
-        "line": "10273",
+        "line": "10285",
         "name": "learn",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, id"
       },
       {
-        "line": "10223",
+        "line": "10235",
         "name": "list",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, options"
       },
       {
-        "line": "6070",
+        "line": "6082",
         "name": "character_recurring",
         "owner": "CcbPlatformRuntime",
         "parameters": "effect_handler, interval_handler"
       },
       {
-        "line": "6091",
+        "line": "6103",
         "name": "dialogue_topic",
         "owner": "CcbPlatformRuntime",
         "parameters": "topic_id, handler_id"
       },
       {
-        "line": "6062",
+        "line": "6074",
         "name": "handler",
         "owner": "CcbPlatformRuntime",
         "parameters": "id, callback, payload_version"
       },
       {
-        "line": "6084",
+        "line": "6096",
         "name": "hook",
         "owner": "CcbPlatformRuntime",
         "parameters": "hook_name, handler_id"
       },
       {
-        "line": "6224",
+        "line": "6236",
         "name": "migrate_task_payload",
         "owner": "CcbPlatformRuntime",
         "parameters": "handler_id, from_version, to_version, callback"
       },
       {
-        "line": "6080",
+        "line": "6092",
         "name": "on",
         "owner": "CcbPlatformRuntime",
         "parameters": "event_name, handler_id"
       },
       {
-        "line": "10632",
+        "line": "10644",
         "name": "activity_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10622",
+        "line": "10634",
         "name": "bionics_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10569",
+        "line": "10581",
         "name": "character_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character"
       },
       {
-        "line": "10612",
+        "line": "10624",
         "name": "current_tile_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, field_limit"
       },
       {
-        "line": "10590",
+        "line": "10602",
         "name": "effects_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10600",
+        "line": "10612",
         "name": "equipment_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10585",
+        "line": "10597",
         "name": "inventory_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10607",
+        "line": "10619",
         "name": "item_contents_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, item_handle, offset, limit"
       },
       {
-        "line": "10545",
+        "line": "10557",
         "name": "message",
         "owner": "CcbPlatformServices",
         "parameters": "text"
       },
       {
-        "line": "10627",
+        "line": "10639",
         "name": "missions_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10573",
+        "line": "10585",
         "name": "movement_modes_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character"
       },
       {
-        "line": "10617",
+        "line": "10629",
         "name": "mutations_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10638",
+        "line": "10650",
         "name": "nearby_creatures_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, radius, limit"
       },
       {
-        "line": "10595",
+        "line": "10607",
         "name": "skills_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10576",
+        "line": "10588",
         "name": "time_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": ""
       },
       {
-        "line": "10552",
+        "line": "10564",
         "name": "translate",
         "owner": "CcbPlatformServices",
         "parameters": "text, context"
       },
       {
-        "line": "10562",
+        "line": "10574",
         "name": "translate_plural",
         "owner": "CcbPlatformServices",
         "parameters": "singular, plural, count, context"
       },
       {
-        "line": "10565",
+        "line": "10577",
         "name": "turn",
         "owner": "CcbPlatformServices",
         "parameters": ""
       },
       {
-        "line": "10579",
+        "line": "10591",
         "name": "weather_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": ""
       },
       {
-        "line": "4967",
+        "line": "4979",
         "name": "expand",
         "owner": "CcbPlatformSnippetsApi",
         "parameters": "text"
       },
       {
-        "line": "4970",
+        "line": "4982",
         "name": "get",
         "owner": "CcbPlatformSnippetsApi",
         "parameters": "id"
       },
       {
-        "line": "4973",
+        "line": "4985",
         "name": "has",
         "owner": "CcbPlatformSnippetsApi",
         "parameters": "id"
       },
       {
-        "line": "4976",
+        "line": "4988",
         "name": "has_category",
         "owner": "CcbPlatformSnippetsApi",
         "parameters": "category"
       },
       {
-        "line": "4979",
+        "line": "4991",
         "name": "random",
         "owner": "CcbPlatformSnippetsApi",
         "parameters": "category"
       },
       {
-        "line": "4982",
+        "line": "4994",
         "name": "random_named",
         "owner": "CcbPlatformSnippetsApi",
         "parameters": "category"
       },
       {
-        "line": "4957",
+        "line": "4969",
         "name": "play_from_outdoors",
         "owner": "CcbPlatformSoundApi",
         "parameters": "id, variant, volume"
       },
       {
-        "line": "4962",
+        "line": "4974",
         "name": "play_if_audible",
         "owner": "CcbPlatformSoundApi",
         "parameters": "id, variant, volume"
       },
       {
-        "line": "6241",
+        "line": "6253",
         "name": "get",
         "owner": "CcbPlatformStateScope",
         "parameters": "key, fallback"
       },
       {
-        "line": "6252",
+        "line": "6264",
         "name": "keys",
         "owner": "CcbPlatformStateScope",
         "parameters": "after_key, requested_limit"
       },
       {
-        "line": "6245",
+        "line": "6257",
         "name": "set",
         "owner": "CcbPlatformStateScope",
         "parameters": "key, value"
       },
       {
-        "line": "10380",
+        "line": "10392",
         "name": "all_equal",
         "owner": "CcbPlatformStringPredicates",
         "parameters": "values"
       },
       {
-        "line": "10376",
+        "line": "10388",
         "name": "any_equal",
         "owner": "CcbPlatformStringPredicates",
         "parameters": "values"
       },
       {
-        "line": "6328",
+        "line": "6340",
         "name": "after",
         "owner": "CcbPlatformTasks",
         "parameters": "turns, handler_id, payload, payload_version, scope, actor, participants"
       },
       {
-        "line": "6333",
+        "line": "6345",
         "name": "cancel",
         "owner": "CcbPlatformTasks",
         "parameters": "task_id"
       },
       {
-        "line": "8347",
+        "line": "8359",
         "name": "every",
         "owner": "CcbPlatformTasks",
         "parameters": "interval_turns, handler_id, payload, payload_version, scope, actor, participants"
       },
       {
-        "line": "8350",
+        "line": "8362",
         "name": "get",
         "owner": "CcbPlatformTasks",
         "parameters": "id"
       },
       {
-        "line": "8355",
+        "line": "8367",
         "name": "list",
         "owner": "CcbPlatformTasks",
         "parameters": "handler_id, scope, requested_limit"
       },
       {
-        "line": "8359",
+        "line": "8371",
         "name": "next",
         "owner": "CcbPlatformTasks",
         "parameters": "handler_id, scope"
       },
       {
-        "line": "4990",
+        "line": "5002",
         "name": "expand_for",
         "owner": "CcbPlatformTextApi",
         "parameters": "text, speaker_handle, interlocutor_handle, item_id"
       },
       {
-        "line": "4994",
+        "line": "5006",
         "name": "limits",
         "owner": "CcbPlatformTilesetApi",
         "parameters": ""
       },
       {
-        "line": "4997",
+        "line": "5009",
         "name": "register",
         "owner": "CcbPlatformTilesetApi",
         "parameters": "descriptor"
       },
       {
-        "line": "9856",
+        "line": "9868",
         "name": "add",
         "owner": "CcbPlatformWoundsApi",
         "parameters": "character, body_part, wound"
       },
       {
-        "line": "9865",
+        "line": "9877",
         "name": "remove",
         "owner": "CcbPlatformWoundsApi",
         "parameters": "character, body_part, wound"
       },
       {
-        "line": "9844",
+        "line": "9856",
         "name": "snapshot",
         "owner": "CcbPlatformWoundsApi",
         "parameters": "character, body_part"
       },
       {
-        "line": "7495",
+        "line": "7507",
         "name": "move",
         "owner": "CcbRelocationApi",
         "parameters": "entity, target, options"
       },
       {
-        "line": "7501",
+        "line": "7513",
         "name": "travel_to_omt",
         "owner": "CcbRelocationApi",
         "parameters": "avatar, target, options"
       },
       {
-        "line": "10261",
+        "line": "10273",
         "name": "for_recipe",
         "owner": "CcbRequirementsApi",
         "parameters": "character, id, batch"
       },
       {
-        "line": "10256",
+        "line": "10268",
         "name": "get",
         "owner": "CcbRequirementsApi",
         "parameters": "character, id, batch"
       },
       {
-        "line": "10251",
+        "line": "10263",
         "name": "list",
         "owner": "CcbRequirementsApi",
         "parameters": "character, options"
       },
       {
-        "line": "9896",
+        "line": "9908",
         "name": "offered",
         "owner": "CcbSkillsApi",
         "parameters": "teacher, student"
       },
       {
-        "line": "9753",
+        "line": "9765",
         "name": "commit",
         "owner": "CcbTradeApi",
         "parameters": "token, settlement"
       },
       {
-        "line": "9748",
+        "line": "9760",
         "name": "get",
         "owner": "CcbTradeApi",
         "parameters": "token"
       },
       {
-        "line": "9722",
+        "line": "9734",
         "name": "open",
         "owner": "CcbTradeApi",
         "parameters": "seller, buyer, cost, title"
       },
       {
-        "line": "9737",
+        "line": "9749",
         "name": "order_price",
         "owner": "CcbTradeApi",
         "parameters": "seller, buyer, item_type, count"
       },
       {
-        "line": "9729",
+        "line": "9741",
         "name": "pay",
         "owner": "CcbTradeApi",
         "parameters": "seller, buyer, cost"
       },
       {
-        "line": "9744",
+        "line": "9756",
         "name": "quote",
         "owner": "CcbTradeApi",
         "parameters": "seller, buyer, lines, options"
       },
       {
-        "line": "9949",
+        "line": "9961",
         "name": "id",
         "owner": "CcbTypesApi",
         "parameters": "kind, value"
       },
       {
-        "line": "9952",
+        "line": "9964",
         "name": "id_kinds",
         "owner": "CcbTypesApi",
         "parameters": ""
       },
       {
-        "line": "9967",
+        "line": "9979",
         "name": "get",
         "owner": "CcbVariablesApi",
         "parameters": "character, key"
       },
       {
-        "line": "9983",
+        "line": "9995",
         "name": "get_global",
         "owner": "CcbVariablesApi",
         "parameters": "key"
       },
       {
-        "line": "9979",
+        "line": "9991",
         "name": "remove",
         "owner": "CcbVariablesApi",
         "parameters": "character, key"
       },
       {
-        "line": "9992",
+        "line": "10004",
         "name": "remove_global",
         "owner": "CcbVariablesApi",
         "parameters": "key"
       },
       {
-        "line": "10001",
+        "line": "10013",
         "name": "resolve",
         "owner": "CcbVariablesApi",
         "parameters": "context, actor, scope, key"
       },
       {
-        "line": "9974",
+        "line": "9986",
         "name": "set",
         "owner": "CcbVariablesApi",
         "parameters": "character, key, value"
       },
       {
-        "line": "9988",
+        "line": "10000",
         "name": "set_global",
         "owner": "CcbVariablesApi",
         "parameters": "key, value"
       },
       {
-        "line": "10009",
+        "line": "10021",
         "name": "set_resolved",
         "owner": "CcbVariablesApi",
         "parameters": "context, actor, scope, key, value"
       },
       {
-        "line": "8444",
+        "line": "8456",
         "name": "definition",
         "owner": "CcbVehiclesApi",
         "parameters": "id"
       },
       {
-        "line": "8441",
+        "line": "8453",
         "name": "definitions",
         "owner": "CcbVehiclesApi",
         "parameters": "options"
       },
       {
-        "line": "8499",
+        "line": "8511",
         "name": "destroy",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle"
       },
       {
-        "line": "8454",
+        "line": "8466",
         "name": "fuels",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle"
       },
       {
-        "line": "8447",
+        "line": "8459",
         "name": "get",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle"
       },
       {
-        "line": "8491",
+        "line": "8503",
         "name": "has_part_flag",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle, flag, enabled"
       },
       {
-        "line": "8486",
+        "line": "8498",
         "name": "is_player_controlling",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle"
       },
       {
-        "line": "8530",
+        "line": "8542",
         "name": "open_part_service",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle, mechanic, repair_multiplier, install_multiplier"
       },
       {
-        "line": "8451",
+        "line": "8463",
         "name": "parts",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle, options"
       },
       {
-        "line": "8479",
+        "line": "8491",
         "name": "prototype_value",
         "owner": "CcbVehiclesApi",
         "parameters": "id, post_cataclysm"
       },
       {
-        "line": "8508",
+        "line": "8520",
         "name": "quote_full_repair",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle, mechanic, repair_multiplier"
       },
       {
-        "line": "8458",
+        "line": "8470",
         "name": "rename",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle, name"
       },
       {
-        "line": "8462",
+        "line": "8474",
         "name": "set_cruise_velocity",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle, velocity"
       },
       {
-        "line": "8503",
+        "line": "8515",
         "name": "set_owner",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle, owner"
       },
       {
-        "line": "8475",
+        "line": "8487",
         "name": "set_part_enabled",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle, part, enabled"
       },
       {
-        "line": "8470",
+        "line": "8482",
         "name": "set_tracking",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle, enabled"
       },
       {
-        "line": "8496",
+        "line": "8508",
         "name": "spawn",
         "owner": "CcbVehiclesApi",
         "parameters": "prototype, position, options"
       },
       {
-        "line": "8513",
+        "line": "8525",
         "name": "start_full_repair",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle, mechanic, repair_multiplier"
       },
       {
-        "line": "8466",
+        "line": "8478",
         "name": "stop",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle, options"
       },
       {
-        "line": "8483",
+        "line": "8495",
         "name": "value",
         "owner": "CcbVehiclesApi",
         "parameters": "vehicle, options"
       },
       {
-        "line": "7718",
+        "line": "7730",
         "name": "activate_lightning",
         "owner": "CcbWeatherApi",
         "parameters": ""
       },
       {
-        "line": "7698",
+        "line": "7710",
         "name": "clear_override",
         "owner": "CcbWeatherApi",
         "parameters": ""
       },
       {
-        "line": "7712",
+        "line": "7724",
         "name": "clear_overrides",
         "owner": "CcbWeatherApi",
         "parameters": ""
       },
       {
-        "line": "7705",
+        "line": "7717",
         "name": "clear_temperature_override",
         "owner": "CcbWeatherApi",
         "parameters": ""
       },
       {
-        "line": "7667",
+        "line": "7679",
         "name": "current",
         "owner": "CcbWeatherApi",
         "parameters": ""
       },
       {
-        "line": "7674",
+        "line": "7686",
         "name": "forecast",
         "owner": "CcbWeatherApi",
         "parameters": "options"
       },
       {
-        "line": "7670",
+        "line": "7682",
         "name": "generator",
         "owner": "CcbWeatherApi",
         "parameters": ""
       },
       {
-        "line": "7677",
+        "line": "7689",
         "name": "limits",
         "owner": "CcbWeatherApi",
         "parameters": ""
       },
       {
-        "line": "7724",
+        "line": "7736",
         "name": "override_light",
         "owner": "CcbWeatherApi",
         "parameters": "level, duration, key"
       },
       {
-        "line": "7715",
+        "line": "7727",
         "name": "refresh",
         "owner": "CcbWeatherApi",
         "parameters": ""
       },
       {
-        "line": "7695",
+        "line": "7707",
         "name": "set_override",
         "owner": "CcbWeatherApi",
         "parameters": "id"
       },
       {
-        "line": "7702",
+        "line": "7714",
         "name": "set_temperature_override",
         "owner": "CcbWeatherApi",
         "parameters": "temperature"
       },
       {
-        "line": "7709",
+        "line": "7721",
         "name": "set_wind",
         "owner": "CcbWeatherApi",
         "parameters": "options"
       },
       {
-        "line": "7664",
+        "line": "7676",
         "name": "type",
         "owner": "CcbWeatherApi",
         "parameters": "id"
       },
       {
-        "line": "7660",
+        "line": "7672",
         "name": "types",
         "owner": "CcbWeatherApi",
         "parameters": "options"
       },
       {
-        "line": "7843",
+        "line": "7855",
         "name": "at",
         "owner": "CcbZonesApi",
         "parameters": "position, options"
       },
       {
-        "line": "7852",
+        "line": "7864",
         "name": "contains",
         "owner": "CcbZonesApi",
         "parameters": "token, position"
       },
       {
-        "line": "7857",
+        "line": "7869",
         "name": "create",
         "owner": "CcbZonesApi",
         "parameters": "options"
       },
       {
-        "line": "7847",
+        "line": "7859",
         "name": "get",
         "owner": "CcbZonesApi",
         "parameters": "token"
       },
       {
-        "line": "7838",
+        "line": "7850",
         "name": "list",
         "owner": "CcbZonesApi",
         "parameters": "options"
       },
       {
-        "line": "7883",
+        "line": "7895",
         "name": "remove",
         "owner": "CcbZonesApi",
         "parameters": "token"
       },
       {
-        "line": "7862",
+        "line": "7874",
         "name": "rename",
         "owner": "CcbZonesApi",
         "parameters": "token, name"
       },
       {
-        "line": "7867",
+        "line": "7879",
         "name": "set_enabled",
         "owner": "CcbZonesApi",
         "parameters": "token, enabled"
       },
       {
-        "line": "7879",
+        "line": "7891",
         "name": "set_position",
         "owner": "CcbZonesApi",
         "parameters": "token, start, finish"
       },
       {
-        "line": "7872",
+        "line": "7884",
         "name": "set_temporary_disabled",
         "owner": "CcbZonesApi",
         "parameters": "token, disabled"
       },
       {
-        "line": "7834",
+        "line": "7846",
         "name": "type",
         "owner": "CcbZonesApi",
         "parameters": "id"
       },
       {
-        "line": "7830",
+        "line": "7842",
         "name": "types",
         "owner": "CcbZonesApi",
         "parameters": "options"
@@ -25459,139 +25514,139 @@
         "parameters": ""
       },
       {
-        "line": "6404",
+        "line": "6416",
         "name": "button",
         "owner": "PlatformCanvasContext",
         "parameters": "id, label, x, y, width, height, request_focus"
       },
       {
-        "line": "6366",
+        "line": "6378",
         "name": "close",
         "owner": "PlatformCanvasContext",
         "parameters": ""
       },
       {
-        "line": "6364",
+        "line": "6376",
         "name": "is_open",
         "owner": "PlatformCanvasContext",
         "parameters": ""
       },
       {
-        "line": "6377",
+        "line": "6389",
         "name": "rect",
         "owner": "PlatformCanvasContext",
         "parameters": "x, y, width, height, r, g, b, a"
       },
       {
-        "line": "6394",
+        "line": "6406",
         "name": "sprite",
         "owner": "PlatformCanvasContext",
         "parameters": "id, x, y, width, height"
       },
       {
-        "line": "6386",
+        "line": "6398",
         "name": "text",
         "owner": "PlatformCanvasContext",
         "parameters": "x, y, value, r, g, b, a"
       },
       {
-        "line": "6119",
+        "line": "6131",
         "name": "by_radio",
         "owner": "PlatformDialogueContext",
         "parameters": ""
       },
       {
-        "line": "6142",
+        "line": "6154",
         "name": "expand_text",
         "owner": "PlatformDialogueContext",
         "parameters": "text, item_id"
       },
       {
-        "line": "6104",
+        "line": "6116",
         "name": "generation",
         "owner": "PlatformDialogueContext",
         "parameters": ""
       },
       {
-        "line": "6152",
+        "line": "6164",
         "name": "get",
         "owner": "PlatformDialogueContext",
         "parameters": "key"
       },
       {
-        "line": "6116",
+        "line": "6128",
         "name": "has_interlocutor",
         "owner": "PlatformDialogueContext",
         "parameters": ""
       },
       {
-        "line": "6122",
+        "line": "6134",
         "name": "has_reason",
         "owner": "PlatformDialogueContext",
         "parameters": ""
       },
       {
-        "line": "6113",
+        "line": "6125",
         "name": "has_speaker",
         "owner": "PlatformDialogueContext",
         "parameters": ""
       },
       {
-        "line": "6148",
+        "line": "6160",
         "name": "interlocutor",
         "owner": "PlatformDialogueContext",
         "parameters": ""
       },
       {
-        "line": "6125",
+        "line": "6137",
         "name": "reason",
         "owner": "PlatformDialogueContext",
         "parameters": ""
       },
       {
-        "line": "6159",
+        "line": "6171",
         "name": "remove",
         "owner": "PlatformDialogueContext",
         "parameters": "key"
       },
       {
-        "line": "6137",
+        "line": "6149",
         "name": "roll_trial",
         "owner": "PlatformDialogueContext",
         "parameters": "kind, difficulty, skill"
       },
       {
-        "line": "6156",
+        "line": "6168",
         "name": "set",
         "owner": "PlatformDialogueContext",
         "parameters": "key, value"
       },
       {
-        "line": "6145",
+        "line": "6157",
         "name": "speaker",
         "owner": "PlatformDialogueContext",
         "parameters": ""
       },
       {
-        "line": "6107",
+        "line": "6119",
         "name": "topic",
         "owner": "PlatformDialogueContext",
         "parameters": ""
       },
       {
-        "line": "6110",
+        "line": "6122",
         "name": "topic_item",
         "owner": "PlatformDialogueContext",
         "parameters": ""
       },
       {
-        "line": "6131",
+        "line": "6143",
         "name": "trial_chance",
         "owner": "PlatformDialogueContext",
         "parameters": "kind, difficulty, skill"
       },
       {
-        "line": "6101",
+        "line": "6113",
         "name": "valid",
         "owner": "PlatformDialogueContext",
         "parameters": ""
@@ -26575,355 +26630,355 @@
         "parameters": "species_id"
       },
       {
-        "line": "6521",
+        "line": "6533",
         "name": "above",
         "owner": "ScriptMapgenContext",
         "parameters": ""
       },
       {
-        "line": "6755",
+        "line": "6767",
         "name": "add_computer_chat_topic",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, topic_id"
       },
       {
-        "line": "6745",
+        "line": "6757",
         "name": "add_computer_eoc",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, eoc_id"
       },
       {
-        "line": "6740",
+        "line": "6752",
         "name": "add_computer_failure",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, failure"
       },
       {
-        "line": "6735",
+        "line": "6747",
         "name": "add_computer_option",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, name, action, security"
       },
       {
-        "line": "6656",
+        "line": "6668",
         "name": "add_field",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, field_id, intensity, age_turns"
       },
       {
-        "line": "6524",
+        "line": "6536",
         "name": "below",
         "owner": "ScriptMapgenContext",
         "parameters": ""
       },
       {
-        "line": "6500",
+        "line": "6512",
         "name": "east",
         "owner": "ScriptMapgenContext",
         "parameters": ""
       },
       {
-        "line": "6807",
+        "line": "6819",
         "name": "fill_groundcover",
         "owner": "ScriptMapgenContext",
         "parameters": ""
       },
       {
-        "line": "6565",
+        "line": "6577",
         "name": "furniture_at",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y"
       },
       {
-        "line": "6535",
+        "line": "6547",
         "name": "get_direction",
         "owner": "ScriptMapgenContext",
         "parameters": "index"
       },
       {
-        "line": "6528",
+        "line": "6540",
         "name": "get_nesw",
         "owner": "ScriptMapgenContext",
         "parameters": "index"
       },
       {
-        "line": "6545",
+        "line": "6557",
         "name": "get_rot_suffix",
         "owner": "ScriptMapgenContext",
         "parameters": ""
       },
       {
-        "line": "6542",
+        "line": "6554",
         "name": "get_rotation",
         "owner": "ScriptMapgenContext",
         "parameters": ""
       },
       {
-        "line": "6494",
+        "line": "6506",
         "name": "id",
         "owner": "ScriptMapgenContext",
         "parameters": ""
       },
       {
-        "line": "6719",
+        "line": "6731",
         "name": "make_rubble",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, furniture_id, items, floor_terrain_id, overwrite"
       },
       {
-        "line": "6509",
+        "line": "6521",
         "name": "neast",
         "owner": "ScriptMapgenContext",
         "parameters": ""
       },
       {
-        "line": "6497",
+        "line": "6509",
         "name": "north",
         "owner": "ScriptMapgenContext",
         "parameters": ""
       },
       {
-        "line": "6518",
+        "line": "6530",
         "name": "nwest",
         "owner": "ScriptMapgenContext",
         "parameters": ""
       },
       {
-        "line": "6491",
+        "line": "6503",
         "name": "operations_remaining",
         "owner": "ScriptMapgenContext",
         "parameters": ""
       },
       {
-        "line": "6488",
+        "line": "6500",
         "name": "operations_used",
         "owner": "ScriptMapgenContext",
         "parameters": ""
       },
       {
-        "line": "6728",
+        "line": "6740",
         "name": "place_computer",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, name, security, access_denied, mission_target"
       },
       {
-        "line": "6705",
+        "line": "6717",
         "name": "place_corpse",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, monster_id, age_days"
       },
       {
-        "line": "6711",
+        "line": "6723",
         "name": "place_corpse_from_group",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, group_id, age_days"
       },
       {
-        "line": "6677",
+        "line": "6689",
         "name": "place_gas_pump",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, charges, fuel_id"
       },
       {
-        "line": "6628",
+        "line": "6640",
         "name": "place_item",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, item_id, quantity, charges, faction_id"
       },
       {
-        "line": "6637",
+        "line": "6649",
         "name": "place_item_group",
         "owner": "ScriptMapgenContext",
         "parameters": "x1, y1, x2, y2, group_id, chance, faction_id"
       },
       {
-        "line": "6643",
+        "line": "6655",
         "name": "place_liquid",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, item_id, charges"
       },
       {
-        "line": "6699",
+        "line": "6711",
         "name": "place_monster",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, monster_id, count, friendly, name, mission_target"
       },
       {
-        "line": "6690",
+        "line": "6702",
         "name": "place_monster_group",
         "owner": "ScriptMapgenContext",
         "parameters": "x1, y1, x2, y2, group_id, chance, density, individual, friendly, name, mission_target"
       },
       {
-        "line": "6766",
+        "line": "6778",
         "name": "place_sealed_item",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, furniture_id, item_id, quantity, charges, item_group_name, item_group_chance, faction_id"
       },
       {
-        "line": "6772",
+        "line": "6784",
         "name": "place_sign",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, text, furniture_id"
       },
       {
-        "line": "6648",
+        "line": "6660",
         "name": "place_toilet",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, charges"
       },
       {
-        "line": "6671",
+        "line": "6683",
         "name": "place_vending_machine",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, item_group_id, reinforced, lootable, powered, networked"
       },
       {
-        "line": "6792",
+        "line": "6804",
         "name": "queue_npc",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, template_id, unique_id"
       },
       {
-        "line": "6782",
+        "line": "6794",
         "name": "queue_point",
         "owner": "ScriptMapgenContext",
         "parameters": "name, x, y"
       },
       {
-        "line": "6805",
+        "line": "6817",
         "name": "queue_zone",
         "owner": "ScriptMapgenContext",
         "parameters": "x1, y1, x2, y2, zone_type, faction, name, filter"
       },
       {
-        "line": "6555",
+        "line": "6567",
         "name": "random_chance",
         "owner": "ScriptMapgenContext",
         "parameters": "numerator, denominator"
       },
       {
-        "line": "6550",
+        "line": "6562",
         "name": "random_int",
         "owner": "ScriptMapgenContext",
         "parameters": "minimum, maximum"
       },
       {
-        "line": "6662",
+        "line": "6674",
         "name": "remove_field",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, field_id"
       },
       {
-        "line": "6609",
+        "line": "6621",
         "name": "reset",
         "owner": "ScriptMapgenContext",
         "parameters": "terrain_id"
       },
       {
-        "line": "6512",
+        "line": "6524",
         "name": "seast",
         "owner": "ScriptMapgenContext",
         "parameters": ""
       },
       {
-        "line": "6750",
+        "line": "6762",
         "name": "set_computer_access_handler",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, handler_id"
       },
       {
-        "line": "6539",
+        "line": "6551",
         "name": "set_dir",
         "owner": "ScriptMapgenContext",
         "parameters": "index, value"
       },
       {
-        "line": "6582",
+        "line": "6594",
         "name": "set_furniture",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, id"
       },
       {
-        "line": "6600",
+        "line": "6612",
         "name": "set_furniture_id",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, id"
       },
       {
-        "line": "6777",
+        "line": "6789",
         "name": "set_graffiti",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, text"
       },
       {
-        "line": "6620",
+        "line": "6632",
         "name": "set_item_faction",
         "owner": "ScriptMapgenContext",
         "parameters": "x1, y1, x2, y2, faction"
       },
       {
-        "line": "6576",
+        "line": "6588",
         "name": "set_terrain",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, id"
       },
       {
-        "line": "6594",
+        "line": "6606",
         "name": "set_terrain_id",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, id"
       },
       {
-        "line": "6588",
+        "line": "6600",
         "name": "set_trap",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, id"
       },
       {
-        "line": "6606",
+        "line": "6618",
         "name": "set_trap_id",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y, id"
       },
       {
-        "line": "6503",
+        "line": "6515",
         "name": "south",
         "owner": "ScriptMapgenContext",
         "parameters": ""
       },
       {
-        "line": "6515",
+        "line": "6527",
         "name": "swest",
         "owner": "ScriptMapgenContext",
         "parameters": ""
       },
       {
-        "line": "6560",
+        "line": "6572",
         "name": "terrain_at",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y"
       },
       {
-        "line": "6570",
+        "line": "6582",
         "name": "trap_at",
         "owner": "ScriptMapgenContext",
         "parameters": "x, y"
       },
       {
-        "line": "6485",
+        "line": "6497",
         "name": "valid",
         "owner": "ScriptMapgenContext",
         "parameters": ""
       },
       {
-        "line": "6506",
+        "line": "6518",
         "name": "west",
         "owner": "ScriptMapgenContext",
         "parameters": ""
       },
       {
-        "line": "6531",
+        "line": "6543",
         "name": "zlevel",
         "owner": "ScriptMapgenContext",
         "parameters": ""
@@ -29973,47 +30028,47 @@
   "public_root": {
     "fields": [
       {
-        "line": 10642,
+        "line": 10654,
         "name": "ModDefinition",
         "type": "fun(options:"
       },
       {
-        "line": 10643,
+        "line": 10655,
         "name": "content",
         "type": "CcbPlatformContent"
       },
       {
-        "line": 10645,
+        "line": 10657,
         "name": "dialogue",
         "type": "CcbPlatformDialogueApi"
       },
       {
-        "line": 10641,
+        "line": 10653,
         "name": "platform_version",
         "type": "1"
       },
       {
-        "line": 10648,
+        "line": 10660,
         "name": "presentation",
         "type": "CcbPlatformPresentation"
       },
       {
-        "line": 10644,
+        "line": 10656,
         "name": "runtime",
         "type": "CcbPlatformRuntime"
       },
       {
-        "line": 10649,
+        "line": 10661,
         "name": "services",
         "type": "CcbPlatformServices"
       },
       {
-        "line": 10646,
+        "line": 10658,
         "name": "state",
         "type": "CcbPlatformState"
       },
       {
-        "line": 10647,
+        "line": 10659,
         "name": "tasks",
         "type": "CcbPlatformTasks"
       }

--- a/data/lua/reference/ccb_platform_api_v1_coverage.json
+++ b/data/lua/reference/ccb_platform_api_v1_coverage.json
@@ -1079,8 +1079,8 @@
   ],
   "platform_sync": {
     "contract_export_roots_missing_from_inventory": [],
-    "luals_class_count": 692,
-    "luals_function_count": 1276,
+    "luals_class_count": 695,
+    "luals_function_count": 1277,
     "native_export_root_count": 179,
     "native_export_roots_declared": 179,
     "native_export_roots_in_public_contract": 179,

--- a/data/lua/reference/ccb_platform_api_v1_coverage.json
+++ b/data/lua/reference/ccb_platform_api_v1_coverage.json
@@ -1079,8 +1079,8 @@
   ],
   "platform_sync": {
     "contract_export_roots_missing_from_inventory": [],
-    "luals_class_count": 695,
-    "luals_function_count": 1277,
+    "luals_class_count": 698,
+    "luals_function_count": 1278,
     "native_export_root_count": 179,
     "native_export_roots_declared": 179,
     "native_export_roots_in_public_contract": 179,

--- a/data/lua/reference/ccb_platform_api_v1_coverage.json
+++ b/data/lua/reference/ccb_platform_api_v1_coverage.json
@@ -1079,7 +1079,7 @@
   ],
   "platform_sync": {
     "contract_export_roots_missing_from_inventory": [],
-    "luals_class_count": 698,
+    "luals_class_count": 700,
     "luals_function_count": 1278,
     "native_export_root_count": 179,
     "native_export_roots_declared": 179,

--- a/data/lua/reference/ccb_platform_api_v1_coverage.json
+++ b/data/lua/reference/ccb_platform_api_v1_coverage.json
@@ -1079,8 +1079,8 @@
   ],
   "platform_sync": {
     "contract_export_roots_missing_from_inventory": [],
-    "luals_class_count": 700,
-    "luals_function_count": 1278,
+    "luals_class_count": 702,
+    "luals_function_count": 1279,
     "native_export_root_count": 179,
     "native_export_roots_declared": 179,
     "native_export_roots_in_public_contract": 179,

--- a/data/lua/reference/ccb_platform_api_v1_coverage.json
+++ b/data/lua/reference/ccb_platform_api_v1_coverage.json
@@ -1079,7 +1079,7 @@
   ],
   "platform_sync": {
     "contract_export_roots_missing_from_inventory": [],
-    "luals_class_count": 691,
+    "luals_class_count": 692,
     "luals_function_count": 1276,
     "native_export_root_count": 179,
     "native_export_roots_declared": 179,

--- a/data/lua/types/ccb_platform_v1.d.lua
+++ b/data/lua/types/ccb_platform_v1.d.lua
@@ -10307,8 +10307,62 @@ function CcbPlatformRecipesApi.forget(character, id) end
 ---@return CcbResult result `value` is a CcbPlatformRecipeCategoryForget.
 function CcbPlatformRecipesApi.forget_category(character, category, subcategory) end
 
+---@class CcbTechniqueIdPage
+---@field items GameId[]
+---@field total integer
+---@field returned integer
+---@field truncated boolean
+
+---@class CcbTechniqueFlagPage
+---@field items string[]
+---@field total integer
+---@field returned integer
+---@field truncated boolean
+
+---@class CcbTechniqueDefinitionSnapshot
+---@field id GameId GameId<martial_art_technique>.
+---@field name string Localized technique name.
+---@field description string Complete native rule description.
+---@field flavor_description string Localized authored short description, without generated rule text.
+---@field goal string
+---@field avatar_message string
+---@field npc_message string
+---@field defensive boolean
+---@field side_switch boolean
+---@field dummy boolean
+---@field critical_only boolean
+---@field critical_compatible boolean
+---@field reach_only boolean
+---@field reach_compatible boolean
+---@field dodge_counter boolean
+---@field block_counter boolean
+---@field miss_recovery boolean
+---@field grab_break boolean
+---@field disarms boolean
+---@field take_weapon boolean
+---@field needs_ammo boolean
+---@field wall_adjacent boolean
+---@field weight integer
+---@field repeat_min integer
+---@field repeat_max integer
+---@field down_duration integer
+---@field stun_duration integer
+---@field knockback_distance integer
+---@field knockback_spread number
+---@field knockback_follow boolean
+---@field area string
+---@field flags CcbTechniqueFlagPage
+---@field attack_vectors CcbTechniqueIdPage GameId<attack_vector> entries.
+---@field eocs CcbTechniqueIdPage Native attached condition identifiers; not a Lua authoring interface.
+
 ---@class CcbPlatformMartialArtsApi: CcbMartialArtsApi
 local CcbPlatformMartialArtsApi = {}
+
+---Read a detached native technique definition, including short and complete descriptions.
+---@param id GameId GameId<martial_art_technique>.
+---@return CcbTechniqueDefinitionSnapshot
+function CcbPlatformMartialArtsApi.technique_definition(id) end
+
 
 ---Learn one martial-art style without coupling the mutation to presentation.
 ---@param character GameHandle Character handle.

--- a/data/lua/types/ccb_platform_v1.d.lua
+++ b/data/lua/types/ccb_platform_v1.d.lua
@@ -10458,8 +10458,8 @@ function CcbPlatformMoraleApi.remove(character, id) end
 ---@class CcbPlatformRandomApi: CcbRandomApi
 local CcbPlatformRandomApi = {}
 
----@param minimum integer Inclusive lower bound in -1000000000..1000000000.
----@param maximum integer Inclusive upper bound in -1000000000..1000000000.
+---@param minimum integer Inclusive lower bound in native signed integer range -2147483648..2147483647.
+---@param maximum integer Inclusive upper bound in native signed integer range -2147483648..2147483647.
 ---@return integer
 function CcbPlatformRandomApi.int(minimum, maximum) end
 
@@ -10468,7 +10468,7 @@ function CcbPlatformRandomApi.int(minimum, maximum) end
 ---@return boolean
 function CcbPlatformRandomApi.chance(numerator, denominator) end
 
----@param denominator number Converted to a native integer; values at or below one always succeed.
+---@param denominator number Truncated toward zero into -2147483648..2147483647; values at or below one always succeed.
 ---@return boolean
 function CcbPlatformRandomApi.one_in(denominator) end
 

--- a/data/lua/types/ccb_platform_v1.d.lua
+++ b/data/lua/types/ccb_platform_v1.d.lua
@@ -10010,6 +10010,23 @@ function CcbTypesApi.id_kinds() end
 ---@class CcbVariablesApi
 local CcbVariablesApi = {}
 
+---@class CcbVariableCopyValue
+---@field source_exists boolean
+---@field destination_existed boolean
+
+---@class CcbVariableCopyResult: CcbResult
+---@field value? CcbVariableCopyValue
+
+---Copy native values without converting arrays, nulls, or coordinates through Lua.
+---Both owners are validated before mutation; missing sources write a stored empty value.
+---An active write callback is required. Use nil owners for the global variable store.
+---@param source_owner GameHandle|nil
+---@param source_key string Variable key, 1..128 bytes without ASCII controls or NUL.
+---@param destination_owner GameHandle|nil
+---@param destination_key string
+---@return CcbVariableCopyResult
+function CcbVariablesApi.copy(source_owner, source_key, destination_owner, destination_key) end
+
 ---@param character GameHandle Explicit live variable-owning actor.
 ---@param key string Variable name containing 1..128 bytes, without ASCII controls or NUL.
 ---@return CcbVariableReadResult

--- a/data/lua/types/ccb_platform_v1.d.lua
+++ b/data/lua/types/ccb_platform_v1.d.lua
@@ -10016,6 +10016,7 @@ local CcbVariablesApi = {}
 function CcbVariablesApi.get(character, key) end
 
 ---Write phases and an active callback are required for variable mutations.
+---Actor/global nil writes store an empty native value with exists=true; remove deletes the key.
 ---@param character GameHandle Explicit live variable-owning actor.
 ---@param key string
 ---@param value boolean|number|string|TripointCoord|nil Finite numbers, bounded strings, absolute map-square coordinates, or nil.
@@ -10049,6 +10050,7 @@ function CcbVariablesApi.remove_global(key) end
 ---@return CcbVariableReadResult
 function CcbVariablesApi.resolve(context, actor, scope, key) end
 
+---For context scope, nil clears the Lua table entry; Lua tables cannot retain a stored nil.
 ---@param context table<string, any>|nil
 ---@param actor GameHandle|nil Explicit owner, including indirect actor references.
 ---@param scope 'u'|'npc'|'global'|'context'|'var'

--- a/data/lua/types/ccb_platform_v1.d.lua
+++ b/data/lua/types/ccb_platform_v1.d.lua
@@ -7408,8 +7408,34 @@ function CcbCampsApi.recall_worker(camp, manager, worker) end
 ---@class CcbBodyPartsResult : CcbResult
 ---@field value GameId[]|nil Complete body-part IDs in native anatomy order; present on success.
 
+---@class CcbTechniqueChoiceOptions
+---@field critical? boolean Defaults to false.
+---@field dodge_counter? boolean Defaults to false.
+---@field block_counter? boolean Defaults to false.
+---@field blacklist? (string|GameId)[] Up to 256 technique IDs; typed entries use martial_art_technique kind.
+
+---@class CcbTechniqueChoice
+---@field found boolean Whether native selection produced a technique.
+---@field accepted boolean Same selection outcome as found.
+---@field technique GameId GameId<martial_art_technique>; inspect found before applying it.
+---@field attack_vector GameId GameId<attack_vector>.
+---@field contact_area GameId GameId<sub_body_part>.
+---@field attacker GameHandle Exact selecting Character.
+---@field target GameHandle Exact target Creature.
+
+---@class CcbTechniqueChoiceResult: CcbResult
+---@field value CcbTechniqueChoice|nil Present on success.
+
 ---@class CcbCharactersApi
 local CcbCharactersApi = {}
+
+---Select through native combat rules in an active write callback; does not execute the attack.
+---@param attacker GameHandle Exact live Character.
+---@param target GameHandle Exact live Creature.
+---@param options? CcbTechniqueChoiceOptions
+---@return CcbTechniqueChoiceResult
+function CcbCharactersApi.choose_technique(attacker, target, options) end
+
 
 --- Return the actual game avatar, independently of dialogue participants.
 ---@return GameHandle player Generation-checked player handle.

--- a/data/lua/types/ccb_platform_v1.d.lua
+++ b/data/lua/types/ccb_platform_v1.d.lua
@@ -6471,9 +6471,20 @@ local CcbPlatformInteractionApi = {}
 ---@return boolean confirmed
 function CcbPlatformInteractionApi.confirm(message) end
 
+---@class PlatformInteractionTextInputOptions
+---@field default? string Initial editable value, at most 4096 bytes.
+---@field description? string Help text, at most 4096 bytes.
+---@field identifier? string Input history identifier, at most 128 bytes.
+---@field width? integer Input width, 10..240; defaults to 40.
+
+---@class PlatformInteractionTextInputResult
+---@field accepted boolean
+---@field cancelled boolean
+---@field value string Entered text when accepted; default text when cancelled.
+
 ---@param title string
----@param options? PlatformTextInputOptions
----@return string|nil text
+---@param options? PlatformInteractionTextInputOptions
+---@return PlatformInteractionTextInputResult result
 function CcbPlatformInteractionApi.input_text(title, options) end
 
 ---@param description string

--- a/data/lua/types/ccb_platform_v1.d.lua
+++ b/data/lua/types/ccb_platform_v1.d.lua
@@ -4906,16 +4906,28 @@ function CcbPlatformContent.edit_widget(id) end
 ---@param dimension string
 ---@return any
 function CcbPlatformEnvironmentQueries.clear_saved_dimension(dimension) end
+---@class CcbGameplayOptionSnapshot
+---@field id string
+---@field type string Native option type, such as string_select, string_input, bool, int, or float.
+---@field value string Native serialized value; not the localized display text.
+---@field display_value string Localized value shown to players.
+---@field default_value string Native default description.
+---@field name string Localized menu text.
+---@field description string Localized tooltip.
+---@field page string Native options page.
+---@field hidden boolean
+---@field prerequisite_satisfied boolean
+
 ---@class CcbPlatformGameplayOptionsApi
 local CcbPlatformGameplayOptionsApi = {}
----@param id string
----@return any
+---@param id string Existing or unknown bounded native option name.
+---@return CcbGameplayOptionSnapshot? Nil when the option is unknown.
 function CcbPlatformGameplayOptionsApi.get(id) end
 ---@param id string
----@return any
+---@return boolean
 function CcbPlatformGameplayOptionsApi.has(id) end
 ---@param id string
----@return any
+---@return string? Native serialized value, or nil for an unknown option.
 function CcbPlatformGameplayOptionsApi.value(id) end
 ---@class CcbPlatformLoreApi
 local CcbPlatformLoreApi = {}

--- a/data/lua/types/ccb_platform_v1.d.lua
+++ b/data/lua/types/ccb_platform_v1.d.lua
@@ -10048,11 +10048,11 @@ function CcbVariablesApi.set_resolved(context, actor, scope, key, value) end
 ---@class CcbEffectsApi
 local CcbEffectsApi = {}
 
----Apply an effect through native Creature rules. Zero duration is preserved;
+---Apply an effect through native Creature rules. Nonpositive duration is preserved;
 ---it still applies immediately and expires when native effect processing runs.
 ---@param character GameHandle
 ---@param effect GameId
----@param duration TimeDuration Between zero turns and 365 days.
+---@param duration TimeDuration Native signed turn range; the effect definition applies its own maximum duration.
 ---@param options? CcbEffectAddOptions
 ---@return CcbResult
 function CcbEffectsApi.add(character, effect, duration, options) end

--- a/src/lua_platform_effects.cpp
+++ b/src/lua_platform_effects.cpp
@@ -381,7 +381,8 @@ sol::table add_effect(
 {
     require_id_kind(
         requested_id, "effect", "services.effects.add" );
-    validate_effect_duration( duration, "services.effects.add", true );
+    // TimeDuration already checks the native signed turn range. Preserve
+    // negative and long durations; Creature/effect owns expiry and clamping.
     const effect_add_options options =
         read_add_options( requested_options );
     sol::state_view state( lua );

--- a/src/lua_platform_martial_arts.cpp
+++ b/src/lua_platform_martial_arts.cpp
@@ -156,6 +156,7 @@ sol::table snapshot_technique_definition(
                        "martial_art_technique", definition.id.str() );
     result["name"] = definition.name.translated();
     result["description"] = definition.get_description();
+    result["flavor_description"] = definition.description.translated();
     result["goal"] = definition.goal;
     result["avatar_message"] = definition.avatar_message.translated();
     result["npc_message"] = definition.npc_message.translated();

--- a/src/lua_platform_runtime_services.cpp
+++ b/src/lua_platform_runtime_services.cpp
@@ -2843,9 +2843,10 @@ void install_runtime_api( const std::shared_ptr<runtime> &value,
     };
     const auto random_integer = [require_random_runtime]( const std::int64_t minimum,
     const std::int64_t maximum ) {
-        if( minimum < -1000000000LL || maximum > 1000000000LL || minimum > maximum ) {
+        if( minimum < std::numeric_limits<int>::min() ||
+            maximum > std::numeric_limits<int>::max() || minimum > maximum ) {
             throw std::invalid_argument(
-                "services.random.int requires an ordered range within -1000000000..1000000000" );
+                "services.random.int requires an ordered range within native integer bounds" );
         }
         const std::shared_ptr<runtime> owner = require_random_runtime();
         std::uniform_int_distribution<std::int64_t> distribution( minimum, maximum );
@@ -2871,12 +2872,13 @@ void install_runtime_api( const std::shared_ptr<runtime> &value,
     } );
     random.set_function( "one_in", [require_random_runtime]( const double raw_denominator ) {
         const std::shared_ptr<runtime> owner = require_random_runtime();
-        if( !std::isfinite( raw_denominator ) || raw_denominator < -1000000000.0 ||
-            raw_denominator > 1000000000.0 ) {
+        const double truncated = std::trunc( raw_denominator );
+        if( !std::isfinite( truncated ) || truncated < std::numeric_limits<int>::min() ||
+            truncated > std::numeric_limits<int>::max() ) {
             throw std::invalid_argument(
                 "services.random.one_in requires a finite denominator within native bounds" );
         }
-        const std::int64_t denominator = static_cast<std::int64_t>( raw_denominator );
+        const std::int64_t denominator = static_cast<std::int64_t>( truncated );
         if( denominator <= 1 ) {
             return true;
         }

--- a/src/lua_platform_variables.cpp
+++ b/src/lua_platform_variables.cpp
@@ -569,6 +569,46 @@ sol::table set_resolved_variable(
                runtime_generation, world_generation );
 }
 
+sol::table copy_variable(
+    sol::this_state lua, const sol::optional<game_handle> &source_owner,
+    const std::string &source_key, const sol::optional<game_handle> &target_owner,
+    const std::string &target_key, const game_handle_runtime &runtime_generation,
+    const std::size_t world_generation )
+{
+    validate_context_key( source_key );
+    validate_context_key( target_key );
+    sol::state_view state( lua );
+    resolved_variable_talker source;
+    resolved_variable_talker target;
+    if( source_owner ) {
+        source = resolve_variable_talker( *source_owner, runtime_generation, world_generation );
+        if( source.error ) {
+            return make_game_error_result( state, *source.error );
+        }
+    }
+    if( target_owner ) {
+        target = resolve_variable_talker( *target_owner, runtime_generation, world_generation );
+        if( target.error ) {
+            return make_game_error_result( state, *target.error );
+        }
+    }
+    const diag_value *stored = source_owner ? resolved_variable_get( source, source_key ) :
+                               get_globals().maybe_get_global_value( source_key );
+    // Snapshot before writing: source and destination may name the same value.
+    const diag_value copied = stored == nullptr ? diag_value() : *stored;
+    const bool existed = ( target_owner ? resolved_variable_get( target, target_key ) :
+                           get_globals().maybe_get_global_value( target_key ) ) != nullptr;
+    sol::table result = state.create_table();
+    result["source_exists"] = stored != nullptr;
+    result["destination_existed"] = existed;
+    if( target_owner ) {
+        resolved_variable_set( target, target_key, copied );
+    } else {
+        get_globals().set_global_value( target_key, copied );
+    }
+    return make_game_value_result( state, sol::make_object( state, std::move( result ) ) );
+}
+
 } // namespace
 
 void install_variable_api(
@@ -582,6 +622,19 @@ void install_variable_api(
     sol::state_view lua( services.lua_state() );
 
     sol::table variables = lua.create_table();
+    variables.set_function(
+        "copy",
+        [current_runtime_generation, current_world_generation,
+         require_read, require_write, has_active_callback](
+            sol::this_state lua_state, const sol::optional<game_handle> &source_owner,
+            const std::string & source_key, const sol::optional<game_handle> &target_owner,
+    const std::string & target_key ) {
+        require_read();
+        require_write();
+        require_active_callback( has_active_callback, "services.variables.copy" );
+        return copy_variable( lua_state, source_owner, source_key, target_owner, target_key,
+                              current_runtime_generation(), current_world_generation() );
+    } );
     variables.set_function(
         "get",
         [current_runtime_generation, current_world_generation,

--- a/src/lua_platform_variables.cpp
+++ b/src/lua_platform_variables.cpp
@@ -61,6 +61,9 @@ void validate_context_key( const std::string &key )
 diag_value context_value_from_lua(
     const sol::object &value, const std::string &key )
 {
+    if( value.get_type() == sol::type::nil ) {
+        return diag_value();
+    }
     if( value.get_type() == sol::type::boolean ) {
         return diag_value( value.as<bool>() ? 1.0 : 0.0 );
     }
@@ -95,7 +98,7 @@ diag_value context_value_from_lua(
     }
     throw std::invalid_argument(
         "services.variables context value '" + key +
-        "' must be boolean, number, string, or TripointCoord" );
+        "' must be nil, boolean, number, string, or TripointCoord" );
 }
 
 sol::object context_value_to_lua(
@@ -459,7 +462,7 @@ sol::table resolve_variable(
                        state, sol::make_object( state, std::move( result ) ) );
         }
         const resolved_variable_talker resolved = resolve_variable_talker(
-                    *actor, runtime_generation, world_generation );
+                *actor, runtime_generation, world_generation );
         if( resolved.error ) {
             return make_game_error_result( state, *resolved.error );
         }
@@ -582,7 +585,7 @@ void install_variable_api(
     variables.set_function(
         "get",
         [current_runtime_generation, current_world_generation,
-                                     require_read](
+         require_read](
             sol::this_state lua_state, const game_handle & handle,
     const std::string & key ) {
         require_read();
@@ -594,7 +597,7 @@ void install_variable_api(
     variables.set_function(
         "set",
         [current_runtime_generation, current_world_generation,
-                                     require_write, has_active_callback](
+         require_write, has_active_callback](
             sol::this_state lua_state, const game_handle & handle,
     const std::string & key, const sol::object & value ) {
         require_write();
@@ -608,7 +611,7 @@ void install_variable_api(
     variables.set_function(
         "remove",
         [current_runtime_generation, current_world_generation,
-                                     require_write, has_active_callback](
+         require_write, has_active_callback](
             sol::this_state lua_state, const game_handle & handle,
     const std::string & key ) {
         require_write();
@@ -655,7 +658,7 @@ void install_variable_api(
     variables.set_function(
         "set_resolved",
         [current_runtime_generation, current_world_generation,
-                                     require_write, has_active_callback](
+         require_write, has_active_callback](
             sol::this_state lua_state, const sol::optional<sol::table> &context,
             const sol::optional<game_handle> &actor, const std::string & scope,
     const std::string & key, const sol::object & value ) {

--- a/tests/lua_platform_day_semantic_test.cpp
+++ b/tests/lua_platform_day_semantic_test.cpp
@@ -1,0 +1,70 @@
+#if defined(CATA_ENABLE_LUA_PLATFORM) && CATA_ENABLE_LUA_PLATFORM
+
+#include <array>
+#include <memory>
+
+#include "calendar.h"
+#include "cata_catch.h"
+#include "cata_scope_helpers.h"
+#include "condition.h"
+#include "dialogue.h"
+#include "lua_platform_runtime.h"
+#include "lua_platform_sol.h"
+
+TEST_CASE( "lua_platform_is_day_matches_legacy_calendar_boundaries",
+           "[lua][platform][day][semantic]" )
+{
+    using namespace cata::lua_platform;
+    clear_active_runtimes();
+    restore_on_out_of_scope restore_turn( calendar::turn );
+    const bool old_day = calendar::eternal_day();
+    const bool old_night = calendar::eternal_night();
+    sol::state lua;
+    sol::table ccb = lua.create_table();
+    const std::shared_ptr<runtime> owner = make_runtime( "day_semantics", 4901, lua );
+    on_out_of_scope cleanup( [old_day, old_night]() {
+        clear_active_runtimes();
+        calendar::set_eternal_day( old_day );
+        calendar::set_eternal_night( old_night );
+    } );
+    install_runtime_api( owner, lua, ccb );
+    set_active_runtimes( { owner } );
+    runtime_world_ready( true );
+    lua["services"] = ccb["services"];
+    // This is the migrator's ordinary Lua expression, using the real service.
+    sol::protected_function predicate = lua.load(
+                                            "return not services.gameplay.environment.is_night()" );
+    conditional_t legacy( "is_day" );
+    dialogue context;
+    for( const bool eternal_day : {
+             false, true
+         } ) {
+        for( const bool eternal_night : {
+                 false, true
+             } ) {
+            calendar::set_eternal_day( eternal_day );
+            calendar::set_eternal_night( eternal_night );
+            for( int season = 0; season < 4; ++season ) {
+                const time_point date = calendar::turn_zero + calendar::season_length() * season;
+                const std::array<time_point, 6> boundaries = {{
+                        date, sunrise( date ), daylight_time( date ), noon( date ),
+                        sunset( date ), night_time( date )
+                    }
+                };
+                for( const time_point boundary : boundaries ) {
+                    for( const int offset : {
+                             -1, 0, 1
+                         } ) {
+                        calendar::turn = boundary + time_duration::from_seconds( offset );
+                        CAPTURE( eternal_day, eternal_night, season, offset );
+                        const sol::protected_function_result actual = predicate();
+                        REQUIRE( actual.valid() );
+                        CHECK( actual.get<bool>() == legacy( context ) );
+                    }
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/tests/lua_platform_effects_test.cpp
+++ b/tests/lua_platform_effects_test.cpp
@@ -500,6 +500,38 @@ TEST_CASE( "lua_platform_effects_zero_duration_matches_legacy_application",
     CHECK( after.get_duration() == 0_turns );
 }
 
+TEST_CASE( "lua_platform_effects_signed_and_long_durations_match_legacy",
+           "[lua][platform][effects][semantic]" )
+{
+    effect_fixture legacy( 4600 );
+    effect_fixture modern( 4700 );
+    const bool npc_target = GENERATE( false, true );
+    const int turns = GENERATE( -10, -1, 366 * 24 * 60 * 60 );
+    const std::string prefix = npc_target ? "npc_" : "u_";
+    legacy.legacy_effect( R"({")" + prefix + R"(add_effect":"bleed","duration":)" +
+                          std::to_string( turns ) + R"(,"target_part":"arm_l","intensity":1})" );
+    sol::table options = modern.lua.create_table();
+    options["body_part"] = cata::lua_platform::script_game_id( "body_part", "arm_l" );
+    options["intensity"] = 1;
+    sol::protected_function add = modern.services["effects"]["add"];
+    sol::protected_function_result call = add( modern.handle( npc_target ),
+        cata::lua_platform::script_game_id( "effect", "bleed" ),
+        cata::lua_platform::script_time_duration::from_native( time_duration::from_turns( turns ) ),
+        options );
+    REQUIRE( call.valid() );
+    sol::table result = call;
+    REQUIRE( result["ok"].get<bool>() );
+    const effect &before = legacy.target( npc_target ).get_effect( effect_bleed, body_part_arm_l.id() );
+    const effect &after = modern.target( npc_target ).get_effect( effect_bleed, body_part_arm_l.id() );
+    REQUIRE_FALSE( before.is_null() );
+    REQUIRE_FALSE( after.is_null() );
+    CHECK( before.get_duration() == after.get_duration() );
+    CHECK( before.get_intensity() == after.get_intensity() );
+    if( turns < 0 ) {
+        CHECK( after.get_duration() == time_duration::from_turns( turns ) );
+    }
+}
+
 TEST_CASE( "lua_platform_effects_negative_add_intensity_is_not_a_delta",
            "[lua][platform][effects][semantic]" )
 {

--- a/tests/lua_platform_environment_predicate_test.cpp
+++ b/tests/lua_platform_environment_predicate_test.cpp
@@ -1,0 +1,78 @@
+#if defined(CATA_ENABLE_LUA_PLATFORM) && CATA_ENABLE_LUA_PLATFORM
+
+#include <memory>
+#include <string>
+
+#include "calendar.h"
+#include "cata_catch.h"
+#include "cata_scope_helpers.h"
+#include "condition.h"
+#include "dialogue.h"
+#include "flexbuffer_json.h"
+#include "json_loader.h"
+#include "lua_platform_runtime.h"
+#include "lua_platform_sol.h"
+#include "weather.h"
+
+TEST_CASE( "lua_platform_environment_strings_match_native_predicates",
+           "[lua][platform][environment_predicate][semantic]" )
+{
+    using namespace cata::lua_platform;
+    clear_active_runtimes();
+    restore_on_out_of_scope restore_turn( calendar::turn );
+    restore_on_out_of_scope restore_weather( get_weather().weather_id );
+    const bool old_eternal = calendar::eternal_season();
+    sol::state lua;
+    sol::table ccb = lua.create_table();
+    const std::shared_ptr<runtime> owner = make_runtime( "environment_strings", 4902, lua );
+    on_out_of_scope cleanup( [old_eternal]() {
+        clear_active_runtimes();
+        calendar::set_eternal_season( old_eternal );
+    } );
+    install_runtime_api( owner, lua, ccb );
+    set_active_runtimes( { owner } );
+    runtime_world_ready( true );
+    lua["services"] = ccb["services"];
+    dialogue context;
+    sol::protected_function season_query = lua.load(
+            "return services.time_snapshot().season_id == wanted" );
+    for( const bool eternal : {
+             false, true
+         } ) {
+        calendar::set_eternal_season( eternal );
+        for( int season = 0; season < 4; ++season ) {
+            calendar::turn = calendar::turn_zero + calendar::season_length() * season;
+            for( const std::string wanted : {
+                     "spring", "summer", "autumn", "winter", "", "unknown"
+                 } ) {
+                CAPTURE( eternal, season, wanted );
+                lua["wanted"] = wanted;
+                conditional_t legacy( json_loader::from_string(
+                                          "{\"is_season\":\"" + wanted + "\"}" ).get_object() );
+                const sol::protected_function_result actual = season_query();
+                REQUIRE( actual.valid() );
+                CHECK( actual.get<bool>() == legacy( context ) );
+            }
+        }
+    }
+    sol::protected_function weather_query = lua.load(
+            "return services.weather.current().weather.value == wanted" );
+    for( const std::string current : {
+             "sunny", "rain", "snowing"
+         } ) {
+        get_weather().weather_id = weather_type_id( current );
+        for( const std::string wanted : {
+                 "sunny", "rain", "snowing", "", "unknown"
+             } ) {
+            CAPTURE( current, wanted );
+            lua["wanted"] = wanted;
+            conditional_t legacy( json_loader::from_string(
+                                      "{\"is_weather\":\"" + wanted + "\"}" ).get_object() );
+            const sol::protected_function_result actual = weather_query();
+            REQUIRE( actual.valid() );
+            CHECK( actual.get<bool>() == legacy( context ) );
+        }
+    }
+}
+
+#endif

--- a/tests/lua_platform_random_range_test.cpp
+++ b/tests/lua_platform_random_range_test.cpp
@@ -1,0 +1,66 @@
+#if defined(CATA_ENABLE_LUA_PLATFORM) && CATA_ENABLE_LUA_PLATFORM
+
+#include <memory>
+
+#include "cata_catch.h"
+#include "cata_scope_helpers.h"
+#include "lua_platform_runtime.h"
+#include "lua_platform_sol.h"
+#include "rng.h"
+
+TEST_CASE( "lua_platform_random_accepts_native_integer_boundaries",
+           "[lua][platform][random_range][semantic]" )
+{
+    using namespace cata::lua_platform;
+    clear_active_runtimes();
+    sol::state lua;
+    lua.open_libraries( sol::lib::base, sol::lib::math );
+    sol::table ccb = lua.create_table();
+    const std::shared_ptr<runtime> owner = make_runtime( "random_range", 4903, lua );
+    on_out_of_scope cleanup( []() {
+        clear_active_runtimes();
+    } );
+    install_runtime_api( owner, lua, ccb );
+    set_active_runtimes( { owner } );
+    lua["ccb"] = ccb;
+    lua.set_function( "check", []( const bool value ) {
+        CHECK( value );
+    } );
+    lua.set_function( "native_one_in", []( const double value ) {
+        return one_in( static_cast<int>( value ) );
+    } );
+    const sol::protected_function_result installed = lua.safe_script( R"(
+local random = ccb.services.random
+ccb.runtime.handler("check_ranges", function()
+    local lo, hi = -2147483648, 2147483647
+    check(random.int(lo, lo) == lo)
+    check(random.int(hi, hi) == hi)
+    for i = 1, 8 do
+        local value = random.int(lo, hi)
+        check(value >= lo and value <= hi and value == math.floor(value))
+    end
+    for _, denominator in ipairs({lo - 0.9, lo, -1.9, 0, 1, 1.9}) do
+        check(random.one_in(denominator) == native_one_in(denominator))
+    end
+    check(type(random.one_in(hi)) == "boolean")
+    check(type(random.one_in(hi + 0.9)) == "boolean")
+    check(not pcall(random.int, lo - 1, hi))
+    check(not pcall(random.int, lo, hi + 1))
+    check(not pcall(random.int, 1, 0))
+    for _, denominator in ipairs({lo - 1, hi + 1, math.huge, -math.huge, 0/0}) do
+        check(not pcall(random.one_in, denominator))
+    end
+    done = true
+end)
+ccb.runtime.on("world_ready", "check_ranges")
+)" );
+    REQUIRE( installed.valid() );
+    runtime_world_ready( true );
+    CHECK( lua["done"].get_or( false ) );
+    const sol::protected_function_result outside_callback = lua.safe_script(
+            "return pcall(ccb.services.random.int, 0, 1)" );
+    REQUIRE( outside_callback.valid() );
+    CHECK_FALSE( outside_callback.get<bool>() );
+}
+
+#endif

--- a/tests/lua_platform_string_comparison_test.cpp
+++ b/tests/lua_platform_string_comparison_test.cpp
@@ -1,0 +1,41 @@
+#if defined(CATA_ENABLE_LUA_PLATFORM) && CATA_ENABLE_LUA_PLATFORM
+
+#include <string>
+
+#include "avatar.h"
+#include "cata_catch.h"
+#include "condition.h"
+#include "dialogue.h"
+#include "flexbuffer_json.h"
+#include "json_loader.h"
+#include "npc.h"
+
+TEST_CASE( "lua_platform_string_comparison_native_short_circuit_contract",
+           "[lua][platform][string_comparison][semantic]" )
+{
+    avatar player;
+    npc partner;
+    player.normalize();
+    partner.normalize();
+    player.set_value( "comparison", "alpha" );
+    partner.set_value( "comparison", "alpha" );
+    dialogue context( get_talker_for( player ), get_talker_for( partner ) );
+    const auto evaluate = [&context]( const std::string & input ) {
+        const conditional_t condition( json_loader::from_string( input ).get_object() );
+        return condition( context );
+    };
+    // Evaluating the final mutator would request an invalid game option.
+    // A decisive pair must prevent that evaluation entirely.
+    CHECK( evaluate(
+               R"({"compare_string":[{"u_val":"comparison"},{"npc_val":"comparison"},{"mutator":"game_option","option":"INVALID_UNREACHED_OPTION"}]})" ) );
+    partner.set_value( "comparison", "beta" );
+    CHECK_FALSE( evaluate(
+                     R"({"compare_string_match_all":[{"u_val":"comparison"},{"npc_val":"comparison"},{"mutator":"game_option","option":"INVALID_UNREACHED_OPTION"}]})" ) );
+    CHECK_FALSE( evaluate( R"({"compare_string":[]})" ) );
+    CHECK_FALSE( evaluate( R"({"compare_string":["only"]})" ) );
+    CHECK( evaluate( R"({"compare_string_match_all":["only"]})" ) );
+    CHECK_FALSE( evaluate( R"({"compare_string":["a","b","c"]})" ) );
+    CHECK( evaluate( R"({"compare_string_match_all":["a","a","a"]})" ) );
+}
+
+#endif

--- a/tests/lua_platform_string_variables_test.cpp
+++ b/tests/lua_platform_string_variables_test.cpp
@@ -6,6 +6,7 @@
 #include "avatar.h"
 #include "cata_catch.h"
 #include "character_id.h"
+#include "character.h"
 #include "condition.h"
 #include "dialogue.h"
 #include "flexbuffer_json.h"
@@ -111,6 +112,30 @@ TEST_CASE( "lua_platform_string_variable_owners_match_native_assignment",
     CHECK( null_snapshot["exists"].get<bool>() );
     CHECK( null_snapshot["value"].get<sol::object>().get_type() == sol::type::nil );
 
+    diag_value nested;
+    nested._deserialize( json_loader::from_string( "[null,[1,null,\"tail\"],{\"tripoint\":[1,2,3]}]" ),
+                         false );
+    Character &copy_source = source_npc ? static_cast<Character &>( partner ) : player;
+    copy_source.set_value( "nested_source", nested );
+    sol::protected_function copy = services["variables"]["copy"];
+    sol::protected_function_result copied = copy(
+            source_npc ? partner_handle : player_handle, "nested_source",
+            target_npc ? partner_handle : player_handle, "nested_target" );
+    REQUIRE( copied.valid() );
+    sol::table copy_result = copied;
+    REQUIRE( copy_result["ok"].get<bool>() );
+    CHECK( target.get_value( "nested_target" ) == nested );
+    copy_source.set_value( "nested_source", "changed after copy" );
+    CHECK( target.get_value( "nested_target" ) == nested );
+    const auto stale_target = cata::lua_platform::game_handle::from_creature(
+                                  player, { "avatar", 4801, 0, 0, 0, {} }, runtime, 2 );
+    sol::protected_function_result rejected = copy(
+            partner_handle, "string_input", stale_target, "nested_target" );
+    REQUIRE( rejected.valid() );
+    sol::table error_result = rejected;
+    CHECK_FALSE( error_result["ok"].get<bool>() );
+    CHECK( target.get_value( "nested_target" ) == nested );
+
 }
 
 TEST_CASE( "lua_platform_global_null_is_distinct_from_removal",
@@ -142,6 +167,23 @@ TEST_CASE( "lua_platform_global_null_is_distinct_from_removal",
     REQUIRE( result["ok"].get<bool>() );
     REQUIRE( get_globals().maybe_get_global_value( key ) != nullptr );
     CHECK( get_globals().get_global_value( key ).is_empty() );
+    sol::protected_function copy = services["variables"]["copy"];
+    sol::protected_function_result self_copy = copy( sol::nil, key, sol::nil, key );
+    REQUIRE( self_copy.valid() );
+    sol::table self_result = self_copy;
+    REQUIRE( self_result["ok"].get<bool>() );
+    sol::table self_metadata = self_result["value"];
+    CHECK( self_metadata["source_exists"].get<bool>() );
+    CHECK( self_metadata["destination_existed"].get<bool>() );
+    CHECK( get_globals().get_global_value( key ).is_empty() );
+    sol::protected_function_result missing_copy = copy(
+            sol::nil, "lua_semantic_missing_copy_source", sol::nil, key );
+    REQUIRE( missing_copy.valid() );
+    sol::table missing_result = missing_copy;
+    REQUIRE( missing_result["ok"].get<bool>() );
+    sol::table missing_metadata = missing_result["value"];
+    CHECK_FALSE( missing_metadata["source_exists"].get<bool>() );
+    CHECK( get_globals().maybe_get_global_value( key ) != nullptr );
     sol::protected_function remove = services["variables"]["remove_global"];
     sol::protected_function_result erased = remove( key );
     REQUIRE( erased.valid() );

--- a/tests/lua_platform_string_variables_test.cpp
+++ b/tests/lua_platform_string_variables_test.cpp
@@ -9,6 +9,7 @@
 #include "condition.h"
 #include "dialogue.h"
 #include "flexbuffer_json.h"
+#include "global_vars.h"
 #include "json_loader.h"
 #include "lua_platform_bindings_values.h"
 #include "lua_platform_handle.h"
@@ -92,6 +93,59 @@ TEST_CASE( "lua_platform_string_variable_owners_match_native_assignment",
     REQUIRE( write_result["ok"].get<bool>() );
     const Character &target = target_npc ? static_cast<const Character &>( partner ) : player;
     CHECK( target.get_value( "platform_output" ).str() == target.get_value( "legacy_output" ).str() );
+    sol::protected_function_result null_write = set(
+            data, target_npc ? partner_handle : player_handle,
+            target_npc ? "npc" : "u", "platform_output", sol::nil );
+    REQUIRE( null_write.valid() );
+    sol::table null_result = null_write;
+    REQUIRE( null_result["ok"].get<bool>() );
+    REQUIRE( target.maybe_get_value( "platform_output" ) != nullptr );
+    CHECK( target.get_value( "platform_output" ).is_empty() );
+    sol::protected_function_result null_read = resolve(
+            data, target_npc ? partner_handle : player_handle,
+            target_npc ? "npc" : "u", "platform_output" );
+    REQUIRE( null_read.valid() );
+    sol::table null_read_result = null_read;
+    REQUIRE( null_read_result["ok"].get<bool>() );
+    sol::table null_snapshot = null_read_result["value"];
+    CHECK( null_snapshot["exists"].get<bool>() );
+    CHECK( null_snapshot["value"].get<sol::object>().get_type() == sol::type::nil );
+
+}
+
+TEST_CASE( "lua_platform_global_null_is_distinct_from_removal",
+           "[lua][platform][strings][semantic]" )
+{
+    const std::string key = "lua_semantic_null_global";
+    struct global_cleanup {
+        const std::string &key;
+        ~global_cleanup() {
+            get_globals().remove_global_value( key );
+        }
+    } cleanup{ key };
+    REQUIRE( get_globals().maybe_get_global_value( key ) == nullptr );
+    const auto owner = cata::lua_platform::make_game_handle_runtime_owner();
+    const cata::lua_platform::game_handle_runtime runtime{ owner, 1 };
+    sol::state lua;
+    sol::table services = lua.create_table();
+    cata::lua_platform::install_variable_api( services, [runtime]() {
+        return runtime;
+    }, []() {
+        return std::size_t( 1 );
+    }, []() {}, []() {}, []() {
+        return true;
+    } );
+    sol::protected_function set = services["variables"]["set_global"];
+    sol::protected_function_result write = set( key, sol::nil );
+    REQUIRE( write.valid() );
+    sol::table result = write;
+    REQUIRE( result["ok"].get<bool>() );
+    REQUIRE( get_globals().maybe_get_global_value( key ) != nullptr );
+    CHECK( get_globals().get_global_value( key ).is_empty() );
+    sol::protected_function remove = services["variables"]["remove_global"];
+    sol::protected_function_result erased = remove( key );
+    REQUIRE( erased.valid() );
+    CHECK( get_globals().maybe_get_global_value( key ) == nullptr );
 }
 
 #endif

--- a/tests/lua_platform_string_variables_test.cpp
+++ b/tests/lua_platform_string_variables_test.cpp
@@ -1,0 +1,97 @@
+#if defined(CATA_ENABLE_LUA_PLATFORM) && CATA_ENABLE_LUA_PLATFORM
+
+#include <cstddef>
+#include <string>
+
+#include "avatar.h"
+#include "cata_catch.h"
+#include "character_id.h"
+#include "condition.h"
+#include "dialogue.h"
+#include "flexbuffer_json.h"
+#include "json_loader.h"
+#include "lua_platform_bindings_values.h"
+#include "lua_platform_handle.h"
+#include "lua_platform_variables.h"
+#include "math_parser_diag_value.h"
+#include "npc.h"
+
+TEST_CASE( "lua_platform_string_variable_owners_match_native_assignment",
+           "[lua][platform][strings][semantic]" )
+{
+    avatar player;
+    npc partner;
+    player.normalize();
+    partner.normalize();
+    player.setID( character_id( 4801 ), true );
+    partner.setID( character_id( 4802 ), true );
+    cata::lua_platform::register_npc_handle_identity( partner );
+    struct identity_cleanup {
+        npc &value;
+        ~identity_cleanup() {
+            cata::lua_platform::retire_npc_handle_identity( value );
+        }
+    } cleanup{ partner };
+    player.set_value( "string_input", "alpha value" );
+    partner.set_value( "string_input", "beta value" );
+    const bool source_npc = GENERATE( false, true );
+    const bool target_npc = GENERATE( false, true );
+    const bool indirect = GENERATE( false, true );
+    const std::string source_key = source_npc ? "npc_val" : "u_val";
+    const std::string target_key = target_npc ? "npc_val" : "u_val";
+    dialogue context( get_talker_for( player ), get_talker_for( partner ) );
+    context.set_value( "destination", target_npc ? "n_legacy_output" : "u_legacy_output" );
+    talk_effect_t legacy;
+    const std::string input = "{\"set_string_var\":{\"" + source_key +
+                              "\":\"string_input\"},\"target_var\":{\"" +
+                              ( indirect ? "var_val" : target_key ) + "\":\"" +
+                              ( indirect ? "destination" : "legacy_output" ) + "\"}}";
+    legacy.parse_sub_effect( json_loader::from_string( input ).get_object(), "string_acceptance" );
+    for( const talk_effect_fun_t &effect : legacy.effects ) {
+        effect( context );
+    }
+    const auto owner = cata::lua_platform::make_game_handle_runtime_owner();
+    const cata::lua_platform::game_handle_runtime runtime{ owner, 1 };
+    sol::state lua;
+    sol::table services = lua.create_table();
+    cata::lua_platform::install_value_type_api( lua, services, []() {} );
+    cata::lua_platform::install_game_handle_api( lua, services, [runtime]() {
+        return runtime;
+    }, []() {
+        return std::size_t( 1 );
+    }, []() {} );
+    cata::lua_platform::install_variable_api( services, [runtime]() {
+        return runtime;
+    }, []() {
+        return std::size_t( 1 );
+    }, []() {}, []() {}, []() {
+        return true;
+    } );
+    const auto player_handle = cata::lua_platform::game_handle::from_creature(
+                                   player, { "avatar", 4801, 0, 0, 0, {} }, runtime, 1 );
+    const auto partner_handle = cata::lua_platform::game_handle::from_creature(
+                                    partner, { "npc", 4802, 0, 0, 0, {} }, runtime, 1 );
+    sol::table data = lua.create_table();
+    sol::protected_function resolve = services["variables"]["resolve"];
+    sol::protected_function_result read = resolve(
+            data, source_npc ? partner_handle : player_handle,
+            source_npc ? "npc" : "u", "string_input" );
+    REQUIRE( read.valid() );
+    sol::table read_result = read;
+    REQUIRE( read_result["ok"].get<bool>() );
+    sol::table snapshot = read_result["value"];
+    const std::string value = snapshot["value"];
+    CHECK( value == ( source_npc ? "beta value" : "alpha value" ) );
+    // Generated Lua resolves indirect prefixes before this single-owner API.
+    sol::protected_function set = services["variables"]["set_resolved"];
+    sol::protected_function_result write = set(
+            data, target_npc ? partner_handle : player_handle,
+            target_npc ? "npc" : "u", "platform_output", value );
+    REQUIRE( write.valid() );
+    sol::table write_result = write;
+    REQUIRE( write_result["ok"].get<bool>() );
+    const Character &target = target_npc ? static_cast<const Character &>( partner ) : player;
+    CHECK( target.get_value( "platform_output" ).str() == target.get_value( "legacy_output" ).str() );
+}
+
+#endif

--- a/tests/lua_platform_technique_description_test.cpp
+++ b/tests/lua_platform_technique_description_test.cpp
@@ -1,0 +1,52 @@
+#if defined(CATA_ENABLE_LUA_PLATFORM) && CATA_ENABLE_LUA_PLATFORM
+
+#include <cstddef>
+#include <string>
+
+#include "cata_catch.h"
+#include "condition.h"
+#include "dialogue.h"
+#include "dialogue_helpers.h"
+#include "flexbuffer_json.h"
+#include "json_loader.h"
+#include "lua_platform_handle.h"
+#include "lua_platform_bindings_values.h"
+#include "lua_platform_martial_arts.h"
+#include "martialarts.h"
+#include "type_id.h"
+
+TEST_CASE( "lua_platform_technique_short_description_matches_native_string_mutator",
+           "[lua][platform][martial_arts][semantic]" )
+{
+    const matec_id technique( "tech_base_headbutt" );
+    REQUIRE( technique.is_valid() );
+    dialogue context;
+    const JsonObject input = json_loader::from_string(
+                                 R"({"value":{"mutator":"ma_technique_description","matec_id":"tech_base_headbutt"}})" ).get_object();
+    const str_or_var legacy = get_str_or_var( input.get_member( "value" ), "value" );
+    const std::string expected = legacy.evaluate( context );
+    REQUIRE_FALSE( expected.empty() );
+    REQUIRE( expected != technique->get_description() );
+
+    sol::state lua;
+    sol::table services = lua.create_table();
+    cata::lua_platform::install_value_type_api( lua, services, []() {} );
+    const auto owner = cata::lua_platform::make_game_handle_runtime_owner();
+    const cata::lua_platform::game_handle_runtime generation{ owner, 1 };
+    cata::lua_platform::install_martial_art_api(
+    services, [generation]() {
+        return generation;
+    }, []() {
+        return std::size_t( 1 );
+    }, []() {}, []() {} );
+    sol::protected_function get = services["martial_arts"]["technique_definition"];
+    sol::protected_function_result call = get(
+            cata::lua_platform::script_game_id( "martial_art_technique", technique.str() ) );
+    REQUIRE( call.valid() );
+    sol::table snapshot = call;
+    CHECK( snapshot["flavor_description"].get<std::string>() == expected );
+    CHECK( snapshot["description"].get<std::string>() == technique->get_description() );
+    CHECK( snapshot["name"].get<std::string>() == technique->name.translated() );
+}
+
+#endif

--- a/tools/agent/generate_lua_first_replacement_ledger.py
+++ b/tools/agent/generate_lua_first_replacement_ledger.py
@@ -85,12 +85,30 @@ CONTROL_FLOW = {
     "weighted_list_eocs",
 }
 
-# No disposition is verified during the source-only implementation sprint.
-# These sets are intentionally empty. A future final semantic-gate batch may
-# add exact selectors after recording native behavior and real inventory
-# evidence; source presence or a previous local run is not enough.
+# JSON object types remain unverified. Promote exact selectors only after
+# recording native behavior and real inventory evidence; source presence or
+# a previous local run is not enough. EOC acceptance is recorded separately.
 IMPLEMENTED_VERIFIED = frozenset()
 BOUNDED_IMPLEMENTED_VERIFIED = frozenset()
+
+# Exact, complete EOC selector scopes accepted against native behavior and real
+# content. is_day is parameterless: f_is_day and the public environment query
+# both use is_night(calendar::turn), including twilight. The native gate
+# compares the installed Lua service at calendar boundaries; migration uses
+# direct and negated conditions from TALK_TEST.json. This is not a promotion of
+# other environment predicates or of the surrounding content's migration.
+VERIFIED_EOC = {
+    ("eoc-conditions", "is_day"): {
+        "target": "services.gameplay.environment",
+        "evidence": [
+            "src/lua_platform_runtime_services.cpp",
+            "tests/lua_platform_day_semantic_test.cpp",
+            "tools/migrate_lua_first.py",
+            "tools/test_migrate_lua_first.py",
+            "data/lua/types/ccb_platform_v1.d.lua",
+        ],
+    },
+}
 
 IMPLEMENTED_JSON = {
     "monster_adjustment": {
@@ -4581,6 +4599,17 @@ def disposition(inventory: str, selector: str, entry: dict) -> dict:
             "evidence": legacy_evidence(inventory, entry),
         }
 
+    verified = VERIFIED_EOC.get((inventory, selector))
+    if verified:
+        return {
+            "inventory": inventory,
+            "selector": selector,
+            "target_kind": "shared_service",
+            "target": verified["target"],
+            "status": "implemented_verified",
+            "legacy_dependency": "none",
+            "evidence": verified["evidence"],
+        }
     bounded_target = BOUNDED_IMPLEMENTED_EOC.get((inventory, selector))
     if (
         bounded_target and

--- a/tools/agent/test_lua_first_replacement_ledger.py
+++ b/tools/agent/test_lua_first_replacement_ledger.py
@@ -95,9 +95,24 @@ class LuaFirstReplacementLedgerTest(unittest.TestCase):
         ):
             classify_migration_todo("selector_todo")
 
-    def test_verified_promotions_are_disabled_until_the_final_gate(self):
+    def test_json_promotions_remain_disabled_until_their_final_gate(self):
         self.assertEqual(IMPLEMENTED_VERIFIED, frozenset())
         self.assertEqual(BOUNDED_IMPLEMENTED_VERIFIED, frozenset())
+
+    def test_only_accepted_day_predicate_is_promoted(self):
+        verified = [entry for entry in build_ledger()["entries"]
+                    if entry["status"] == "implemented_verified"]
+        self.assertEqual(
+            [(entry["inventory"], entry["selector"]) for entry in verified],
+            [("eoc-conditions", "is_day")],
+        )
+        self.assertEqual(verified[0]["verification"], "final_semantic_gate")
+        self.assertIn(
+            "tests/lua_platform_day_semantic_test.cpp", verified[0]["evidence"]
+        )
+        self.assertIn(
+            "tools/test_migrate_lua_first.py", verified[0]["evidence"]
+        )
 
     def test_generator_uses_the_three_real_inventories(self):
         generated = build_ledger()

--- a/tools/lua_api/test_mod_sdk.py
+++ b/tools/lua_api/test_mod_sdk.py
@@ -305,6 +305,19 @@ return inspect
             self.assertEqual(
                 mod_sdk.check_mod(mod, os.environ["CCB_LUALS"]), [])
 
+    def test_day_predicate_has_boolean_editor_type(self):
+        with tempfile.TemporaryDirectory() as directory:
+            mod = self.scaffold(Path(directory), "minimal")
+            (mod / "day.lua").write_text('''local ccb = require("ccb")
+---@return boolean
+return function()
+    local services = ccb.services
+    return not services.gameplay.environment.is_night()
+end
+''', encoding="utf-8")
+            self.assertEqual(
+                mod_sdk.check_mod(mod, os.environ["CCB_LUALS"]), [])
+
     def test_native_variable_copy_has_editor_types(self):
         with tempfile.TemporaryDirectory() as directory:
             mod = self.scaffold(Path(directory), "minimal")

--- a/tools/lua_api/test_mod_sdk.py
+++ b/tools/lua_api/test_mod_sdk.py
@@ -305,6 +305,23 @@ return inspect
             self.assertEqual(
                 mod_sdk.check_mod(mod, os.environ["CCB_LUALS"]), [])
 
+    def test_technique_definition_has_editor_types(self):
+        with tempfile.TemporaryDirectory() as directory:
+            mod = self.scaffold(Path(directory), "minimal")
+            source = mod / "technique.lua"
+            source.write_text('''local ccb = require("ccb")
+local definition = ccb.services.martial_arts.technique_definition(
+    ccb.services.types.id("martial_art_technique", "tech_base_headbutt"))
+---@type string
+local short = definition.flavor_description
+for _, id in ipairs(definition.attack_vectors.items) do
+    assert(id.kind == "attack_vector")
+end
+return short, definition.description
+''', encoding="utf-8")
+            self.assertEqual(
+                mod_sdk.check_mod(mod, os.environ["CCB_LUALS"]), [])
+
     def test_gameplay_option_snapshot_has_editor_types(self):
         with tempfile.TemporaryDirectory() as directory:
             mod = self.scaffold(Path(directory), "minimal")

--- a/tools/lua_api/test_mod_sdk.py
+++ b/tools/lua_api/test_mod_sdk.py
@@ -305,6 +305,24 @@ return inspect
             self.assertEqual(
                 mod_sdk.check_mod(mod, os.environ["CCB_LUALS"]), [])
 
+    def test_gameplay_option_snapshot_has_editor_types(self):
+        with tempfile.TemporaryDirectory() as directory:
+            mod = self.scaffold(Path(directory), "minimal")
+            source = mod / "options.lua"
+            source.write_text('''local ccb = require("ccb")
+local option = ccb.services.gameplay.options.get("USE_LANG")
+if option ~= nil then
+    ---@type CcbGameplayOptionSnapshot
+    local snapshot = option
+    ---@type string
+    local value = snapshot.value
+    return value, snapshot.prerequisite_satisfied
+end
+return ccb.services.gameplay.options.value("USE_LANG")
+''', encoding="utf-8")
+            self.assertEqual(
+                mod_sdk.check_mod(mod, os.environ["CCB_LUALS"]), [])
+
     def test_complete_body_parts_have_editor_types(self):
         with tempfile.TemporaryDirectory() as directory:
             mod = self.scaffold(Path(directory), "minimal")

--- a/tools/lua_api/test_mod_sdk.py
+++ b/tools/lua_api/test_mod_sdk.py
@@ -305,6 +305,26 @@ return inspect
             self.assertEqual(
                 mod_sdk.check_mod(mod, os.environ["CCB_LUALS"]), [])
 
+    def test_technique_choice_has_editor_types(self):
+        with tempfile.TemporaryDirectory() as directory:
+            mod = self.scaffold(Path(directory), "minimal")
+            source = mod / "choose_technique.lua"
+            source.write_text('''local ccb = require("ccb")
+---@param attacker GameHandle
+---@param target GameHandle
+return function(attacker, target)
+    local result = ccb.services.characters.choose_technique(
+        attacker, target,
+        {critical = true, blacklist = {"tech_base_headbutt"}})
+    if result.ok then
+        local choice = assert(result.value)
+        return choice.found, choice.technique.value, choice.contact_area
+    end
+end
+''', encoding="utf-8")
+            self.assertEqual(
+                mod_sdk.check_mod(mod, os.environ["CCB_LUALS"]), [])
+
     def test_technique_definition_has_editor_types(self):
         with tempfile.TemporaryDirectory() as directory:
             mod = self.scaffold(Path(directory), "minimal")

--- a/tools/lua_api/test_mod_sdk.py
+++ b/tools/lua_api/test_mod_sdk.py
@@ -305,6 +305,22 @@ return inspect
             self.assertEqual(
                 mod_sdk.check_mod(mod, os.environ["CCB_LUALS"]), [])
 
+    def test_interaction_input_uses_native_options_and_result(self):
+        with tempfile.TemporaryDirectory() as directory:
+            mod = self.scaffold(Path(directory), "minimal")
+            source = mod / "input.lua"
+            source.write_text('''local ccb = require("ccb")
+local result = ccb.services.interaction.input_text("Title", {
+    default = "original", identifier = "history", width = 40})
+---@type boolean
+local accepted = result.accepted
+---@type string
+local text = result.value
+return accepted, result.cancelled, text
+''', encoding="utf-8")
+            self.assertEqual(
+                mod_sdk.check_mod(mod, os.environ["CCB_LUALS"]), [])
+
     def test_technique_choice_has_editor_types(self):
         with tempfile.TemporaryDirectory() as directory:
             mod = self.scaffold(Path(directory), "minimal")

--- a/tools/lua_api/test_mod_sdk.py
+++ b/tools/lua_api/test_mod_sdk.py
@@ -305,6 +305,23 @@ return inspect
             self.assertEqual(
                 mod_sdk.check_mod(mod, os.environ["CCB_LUALS"]), [])
 
+    def test_native_variable_copy_has_editor_types(self):
+        with tempfile.TemporaryDirectory() as directory:
+            mod = self.scaffold(Path(directory), "minimal")
+            source = mod / "copy.lua"
+            source.write_text('''local ccb = require("ccb")
+---@param owner GameHandle
+return function(owner)
+    local result = ccb.services.variables.copy(nil, "global", owner, "local")
+    if result.ok then
+        local metadata = assert(result.value)
+        return metadata.source_exists, metadata.destination_existed
+    end
+end
+''', encoding="utf-8")
+            self.assertEqual(
+                mod_sdk.check_mod(mod, os.environ["CCB_LUALS"]), [])
+
     def test_interaction_input_uses_native_options_and_result(self):
         with tempfile.TemporaryDirectory() as directory:
             mod = self.scaffold(Path(directory), "minimal")

--- a/tools/migrate_lua_first.py
+++ b/tools/migrate_lua_first.py
@@ -26829,55 +26829,22 @@ def render_eoc_condition_expression(
             return None
         numerator = finite_number_literal(chance["x"])
         denominator = finite_number_literal(chance["y"])
-        if numerator is None:
-            numerator_expression = render_eoc_numeric_expression(
-                chance["x"], "0", "actor"
-            )
-            if numerator_expression is None:
-                return None
-            numerator_expression = (
-                "math.max(0, math.min(1000000000, (" +
-                numerator_expression + ")))"
-            )
-        else:
-            if numerator < 0 or numerator > 1000000000:
-                return None
-            numerator_expression = lua_number(numerator)
-        if denominator is None:
-            denominator_expression = render_eoc_numeric_expression(
-                chance["y"], "1", "actor"
-            )
-            if denominator_expression is None:
-                return None
-            denominator_expression = (
-                "math.max(1, math.min(1000000000, (" +
-                denominator_expression + ")))"
-            )
-        else:
-            if denominator <= 0 or denominator > 1000000000:
-                return None
-            denominator_expression = lua_number(denominator)
+        if numerator is not None and numerator < 0:
+            return None
+        if denominator is not None and denominator <= 0:
+            return None
         if numerator is not None and denominator is not None and numerator > denominator:
             return None
-        if numerator is not None and denominator is None:
-            numerator_expression = (
-                "math.min(" + denominator_expression + ", " +
-                numerator_expression + ")"
-            )
-        elif numerator is None and denominator is not None:
-            numerator_expression = (
-                "math.min(" + denominator_expression + ", " +
-                numerator_expression + ")"
-            )
-        elif numerator is None and denominator is None:
-            numerator_expression = (
-                "math.min(" + denominator_expression + ", " +
-                numerator_expression + ")"
-            )
-        return (
-            "services.random.probability("
-            f"{numerator_expression}, {denominator_expression})"
-        )
+        expressions = [_effect_numeric_expression(
+            chance[key], "actor", "actor" if character_actor_proven else None, npc_query_actor)
+            for key in ("x", "y")]
+        if any(expression is None for expression in expressions):
+            return None
+        # Each operand is evaluated once. The public service accepts finite
+        # fractional values without the integer random service's range bound.
+        # Invalid ratios remain explicit errors instead of being clamped to a
+        # different probability.
+        return f"services.random.probability({expressions[0]}, {expressions[1]})"
 
     if set(condition) <= {"roll_contested", "difficulty", "die_size"} and {
         "roll_contested", "difficulty"

--- a/tools/migrate_lua_first.py
+++ b/tools/migrate_lua_first.py
@@ -24553,6 +24553,19 @@ def render_dynamic_character_wound(
     return lines
 
 
+def render_direct_variable_snapshot(value: Any, owner: str) -> str | None:
+    """Retain presence separately from the Lua representation of a stored null."""
+    if not isinstance(value, dict) or len(value) != 1:
+        return None
+    key, name = next(iter(value.items()))
+    scopes = {"u_val": "u", "npc_val": "npc", "global_val": "global", "context_val": "context"}
+    if key not in scopes or render_eoc_value_expression(value, "nil", owner) is None:
+        return None
+    actual_owner = owner if key in {"u_val", "npc_val"} else "nil"
+    return ('service_value(services.variables.resolve(context.data, '
+            f'{actual_owner}, {lua_quote(scopes[key])}, {lua_quote(name)}))')
+
+
 def render_participant_string_expression(
     value: Any, target_expression: str,
     avatar_expression: str | None, npc_expression: str | None,
@@ -24651,9 +24664,19 @@ def render_participant_string_expression(
                 'elseif name:sub(1, 2) == "n_" then scope, owner, name = "npc", ' +
                 npc_expression + ', name:sub(3) '
                 'elseif name:sub(1, 1) == "_" then scope, name = "context", name:sub(2) end; '
-                'return tostring(service_value(services.variables.resolve('
-                'context.data, owner, scope, name)).value or ' + fallback + ') end)()'
+                'local result = service_value(services.variables.resolve('
+                'context.data, owner, scope, name)); '
+                'if result.exists == false then return ' + fallback + ' end; '
+                'return tostring(result.value or "") end)()'
             )
+        if "default" in value:
+            variable = {key: item for key, item in value.items() if key != "default"}
+            snapshot = render_direct_variable_snapshot(variable, owner)
+            fallback = value["default"]
+            if snapshot is None or not bounded_utf8_string(fallback, 8192, allow_empty=True):
+                return None
+            return ('(function(result) if result.exists == false then return '
+                    f'{lua_quote(fallback)} end; return tostring(result.value or "") end)({snapshot})')
     return render_eoc_string_expression(value, owner)
 
 
@@ -24981,10 +25004,10 @@ def render_participant_translation_expression(
             return None
         fallback = render_participant_translation_expression(
             value["default"], target_expression, avatar_expression, npc_expression)
-        raw = render_eoc_value_expression({key: value[key]}, "nil", owner or target_expression)
+        raw = render_direct_variable_snapshot({key: value[key]}, owner or target_expression)
         if fallback is None or raw is None:
             return None
-        return ('(function(value) if value ~= nil then return tostring(value) end; '
+        return ('(function(result) if result.exists ~= false then return tostring(result.value or \"\") end; '
                 f'return {fallback} end)({raw})')
     return render_participant_string_expression(
         value, target_expression, avatar_expression, npc_expression)

--- a/tools/migrate_lua_first.py
+++ b/tools/migrate_lua_first.py
@@ -25014,17 +25014,24 @@ def render_static_character_string_var(
             actor_expression = "actor"
 
     def render_value(value: Any) -> str | None:
+        if i18n and (isinstance(value, str) or (
+                isinstance(value, dict) and ("str" in value or "str_sp" in value))):
+            literal = value if isinstance(value, str) else value.get("str_sp", value.get("str"))
+            translation_context = value.get("ctxt") if isinstance(value, dict) else None
+            if not bounded_utf8_string(literal, 8192, allow_empty=True):
+                return None
+            if translation_context is not None and not bounded_utf8_string(
+                    translation_context, 8192, allow_empty=True):
+                return None
+            arguments = lua_quote(literal)
+            if translation_context is not None:
+                arguments += ", " + lua_quote(translation_context)
+            return f"services.translate({arguments})"
         rendered = render_participant_string_expression(
             value, actor_expression,
             "actor" if avatar_actor_proven else None,
             npc_actor_expression or ("actor" if npc_actor_proven else None),
         )
-        if rendered is None and i18n and isinstance(value, dict):
-            literal = value.get("str", value.get("str_sp"))
-            if isinstance(literal, str) and bounded_utf8_string(
-                literal, 8192, allow_empty=True
-            ):
-                rendered = lua_quote(literal)
         if rendered is None:
             return None
         return rendered

--- a/tools/migrate_lua_first.py
+++ b/tools/migrate_lua_first.py
@@ -25052,13 +25052,16 @@ def render_static_character_string_var(
         initial = display_text(input_options.get("default_text"), "")
         if not all(isinstance(value, str) for value in (title, description, initial)):
             return None
+        identifier = input_options.get("identifier", "")
+        if not bounded_utf8_string(identifier, 128, allow_empty=True):
+            return None
         lines.extend([
             f"    local value = {value_expression}",
             "    local input = services.interaction.input_text(",
-            f"        {lua_quote(title)}, {{ initial = {lua_quote(initial)}, "
-            f"description = {lua_quote(description)} }})",
-            "    if input ~= nil then",
-            "        value = input",
+            f"        {lua_quote(title)}, {{ default = {lua_quote(initial)}, "
+            f"description = {lua_quote(description)}, identifier = {lua_quote(identifier)} }})",
+            "    if input.accepted then",
+            "        value = input.value",
             "    end",
         ])
         value_expression = "value"

--- a/tools/migrate_lua_first.py
+++ b/tools/migrate_lua_first.py
@@ -24927,18 +24927,21 @@ def render_static_character_copy_var(
         ]
 
     lines = address(source, "copy_source")
-    lines.extend([
-        '    local copied = { exists = false }',
-        '    if copy_source_key ~= nil then',
-        '        copied = service_value(services.variables.resolve(',
-        '            context.data, copy_source_owner, copy_source_scope, copy_source_key))',
-        '    end',
-    ])
     lines.extend(address(target, "copy_target"))
     lines.extend([
         '    if copy_target_key == nil then error("missing target variable") end',
-        '    service_value(services.variables.set_resolved(',
-        '        context.data, copy_target_owner, copy_target_scope, copy_target_key, copied.value))',
+        '    if copy_source_key ~= nil and copy_source_scope ~= "context" and copy_target_scope ~= "context" then',
+        '        service_value(services.variables.copy(',
+        '            copy_source_owner, copy_source_key, copy_target_owner, copy_target_key))',
+        '    else',
+        '        local copied = { exists = false }',
+        '        if copy_source_key ~= nil then',
+        '            copied = service_value(services.variables.resolve(',
+        '                context.data, copy_source_owner, copy_source_scope, copy_source_key))',
+        '        end',
+        '        service_value(services.variables.set_resolved(',
+        '            context.data, copy_target_owner, copy_target_scope, copy_target_key, copied.value))',
+        '    end',
     ])
     return lines
 

--- a/tools/migrate_lua_first.py
+++ b/tools/migrate_lua_first.py
@@ -18955,6 +18955,27 @@ def render_static_mutation_effect(
     return None
 
 
+def _effect_duration_expression(
+    value: Any, target: str = "actor", alpha: str | None = None, beta: str | None = None,
+) -> str | None:
+    turns = parse_turns(value)
+    if turns is not None:
+        if not NATIVE_INT_MIN <= turns <= NATIVE_INT_MAX:
+            return None
+        return f'services.time.duration({turns}, "turn")'
+    if isinstance(value, list):
+        value = [parse_turns(endpoint) if parse_turns(endpoint) is not None else endpoint for endpoint in value]
+    rendered = _effect_numeric_expression(value, target, alpha, beta)
+    if rendered is None:
+        return None
+    # EOC duration conversion truncates toward zero. TimeDuration rejects
+    # overflow; do not turn negative/long values into zero or one year.
+    return (
+        'services.time.duration((function(value) return value < 0 and math.ceil(value) '
+        f'or math.floor(value) end)({rendered}), "turn")'
+    )
+
+
 def render_static_character_effect(
     effect: dict[str, Any],
     key: str,
@@ -18978,12 +18999,7 @@ def render_static_character_effect(
         return None
     # Preserve zero duration: native application and later expiry are distinct.
     permanent = raw_duration == "PERMANENT"
-    duration = 1 if permanent else parse_turns(raw_duration)
-    duration_expression = (
-        f"services.time.duration({duration}, \"turn\")"
-        if duration is not None and 0 <= duration <= MAX_EFFECT_DURATION_TURNS
-        else _duration_expression(raw_duration, minimum=0, truncate=True)
-    )
+    duration_expression = _effect_duration_expression(1 if permanent else raw_duration, target_expression)
     if duration_expression is None:
         return None
     if (
@@ -19171,17 +19187,7 @@ def render_dynamic_character_effect(
     effect_id = identifier(effect[key], "effect")
     permanent = effect.get("duration") == "PERMANENT"
     raw_duration = effect.get("duration", "1 turn")
-    if isinstance(raw_duration, dict) and set(raw_duration) != {"math"}:
-        turns = numeric(raw_duration)
-        duration = None if turns is None else (
-            "services.time.duration(math.max(0, math.min(" + str(MAX_EFFECT_DURATION_TURNS) +
-            ', math.floor((' + turns + ')))), "turn")'
-        )
-    else:
-        duration = _duration_expression(
-            "1 turn" if permanent else raw_duration,
-            minimum=0, actor_expression=alpha or target_expression, truncate=True,
-        )
+    duration = _effect_duration_expression(1 if permanent else raw_duration, target_expression, alpha, beta)
     if effect_id is None or duration is None:
         return None
     intensity = numeric(effect.get("intensity", 0))

--- a/tools/migrate_lua_first.py
+++ b/tools/migrate_lua_first.py
@@ -24979,6 +24979,8 @@ def render_static_character_string_var(
         return None
     if target[0] == "npc" and not npc_actor_proven:
         return None
+    if target[0] == "var" and not (avatar_actor_proven and npc_actor_proven):
+        return None
     parse_tags = effect.get("parse_tags", False)
     i18n = effect.get("i18n", False)
     if not isinstance(parse_tags, bool) or not isinstance(i18n, bool):
@@ -25081,10 +25083,21 @@ def render_static_character_string_var(
             f"        {actor_expression}, {lua_quote(target[1])}, {value_expression})",
         ])
     else:
+        beta = npc_actor_expression or "actor"
         lines.extend([
-            "    service_value(services.variables.set_resolved(",
-            f"        context.data, {actor_expression}, \"var\", "
-            f"{lua_quote(target[1])}, {value_expression}))",
+            f"    local assigned_value = {value_expression}",
+            f"    local target_name = context.data[{lua_quote(target[1])}]",
+            '    if target_name == nil or target_name == "" then error("missing target variable") end',
+            '    local target_scope, target_owner = "global", nil',
+            '    if target_name:sub(1, 2) == "u_" then',
+            '        target_scope, target_owner, target_name = "u", actor, target_name:sub(3)',
+            '    elseif target_name:sub(1, 2) == "n_" then',
+            f'        target_scope, target_owner, target_name = "npc", {beta}, target_name:sub(3)',
+            '    elseif target_name:sub(1, 1) == "_" then',
+            '        target_scope, target_name = "context", target_name:sub(2)',
+            '    end',
+            '    service_value(services.variables.set_resolved(',
+            '        context.data, target_owner, target_scope, target_name, assigned_value))',
         ])
     return lines
 

--- a/tools/migrate_lua_first.py
+++ b/tools/migrate_lua_first.py
@@ -26055,8 +26055,6 @@ def render_eoc_condition_expression(
             )
         if condition == "is_day":
             return "not services.gameplay.environment.is_night()"
-        if condition == "is_night":
-            return "services.gameplay.environment.is_night()"
         if npc_query_actor is not None:
             if condition == "npc_is_alive":
                 return (

--- a/tools/migrate_lua_first.py
+++ b/tools/migrate_lua_first.py
@@ -25043,8 +25043,9 @@ def render_static_character_string_var(
     if len(expressions) == 1:
         value_expression = expressions[0]
     else:
-        lines.append(f"    local values = {{ {', '.join(expressions)} }}")
-        value_expression = "values[services.random.int(1, #values)]"
+        choices = [f"function() return {expression} end" for expression in expressions]
+        lines.append(f"    local values = {{ {', '.join(choices)} }}")
+        value_expression = "values[services.random.int(1, #values)]()"
 
     input_options = effect.get("string_input")
     if input_options is not None:

--- a/tools/migrate_lua_first.py
+++ b/tools/migrate_lua_first.py
@@ -25027,12 +25027,6 @@ def render_static_character_string_var(
                 rendered = lua_quote(literal)
         if rendered is None:
             return None
-        if parse_tags:
-            beta = npc_actor_expression or "(context.actors and context.actors.beta)"
-            rendered = (
-                "service_value(services.text.expand_for("
-                f"{rendered}, {actor_expression}, {beta}))"
-            )
         return rendered
 
     rendered_values = [render_value(value) for value in values]
@@ -25068,6 +25062,14 @@ def render_static_character_string_var(
             "    end",
         ])
         value_expression = "value"
+
+    if parse_tags:
+        alpha = "actor" if avatar_actor_proven else "services.characters.avatar()"
+        beta = npc_actor_expression or (
+            "actor" if npc_actor_proven else "services.characters.avatar()")
+        value_expression = (
+            "service_value(services.text.expand_for("
+            f"{value_expression}, {alpha}, {beta}))")
 
     if target[0] == "context":
         lines.append(

--- a/tools/migrate_lua_first.py
+++ b/tools/migrate_lua_first.py
@@ -19137,7 +19137,7 @@ def _effect_numeric_expression(
             return None
         for endpoint in value:
             literal = finite_number_literal(endpoint)
-            if literal is not None and abs(math.trunc(literal)) > 1000000000:
+            if literal is not None and not -2147483648 <= math.trunc(literal) <= 2147483647:
                 return None
         endpoints = [_effect_numeric_expression(endpoint, target, alpha, beta) for endpoint in value]
         if any(endpoint is None for endpoint in endpoints):
@@ -26812,19 +26812,14 @@ def render_eoc_condition_expression(
 
     if set(condition) == {"one_in_chance"}:
         value = finite_number_literal(condition["one_in_chance"])
-        if value is not None:
-            if value < -1000000000 or value > 1000000000:
-                return None
-            return f"services.random.one_in({lua_number(value)})"
-        dynamic = render_eoc_numeric_expression(
-            condition["one_in_chance"], "0", "actor"
-        )
-        if dynamic is None:
+        if value is not None and not -2147483648 <= math.trunc(value) <= 2147483647:
             return None
-        return (
-            "services.random.one_in(math.max(-1000000000, math.min("
-            f"1000000000, ({dynamic}))))"
-        )
+        denominator = _effect_numeric_expression(
+            condition["one_in_chance"], "actor",
+            "actor" if character_actor_proven else None, npc_query_actor)
+        if denominator is None:
+            return None
+        return f"services.random.one_in({denominator})"
 
     if set(condition) == {"x_in_y_chance"}:
         chance = condition["x_in_y_chance"]

--- a/tools/migrate_lua_first.py
+++ b/tools/migrate_lua_first.py
@@ -24962,6 +24962,50 @@ def render_static_character_copy_var(
     return lines
 
 
+def render_participant_translation_expression(
+    value: Any, target_expression: str,
+    avatar_expression: str | None, npc_expression: str | None,
+) -> str | None:
+    """Translate authored literals; stored dialogue values are already translated."""
+    if isinstance(value, str) or (
+            isinstance(value, dict) and ("str" in value or "str_sp" in value)):
+        literal = value if isinstance(value, str) else value.get("str_sp", value.get("str"))
+        translation_context = value.get("ctxt") if isinstance(value, dict) else None
+        if not bounded_utf8_string(literal, 8192, allow_empty=True):
+            return None
+        if translation_context is not None and not bounded_utf8_string(
+                translation_context, 8192, allow_empty=True):
+            return None
+        arguments = lua_quote(literal)
+        if translation_context is not None:
+            arguments += ", " + lua_quote(translation_context)
+        return f"services.translate({arguments})"
+    if isinstance(value, dict) and "default" in value:
+        # A translated fallback must run only when the variable is absent.
+        # Keep unsupported indirect fallback shapes explicit for now.
+        keys = set(value) - {"default"}
+        if len(keys) != 1:
+            return None
+        key = next(iter(keys))
+        owner = {"u_val": avatar_expression, "npc_val": npc_expression}.get(key)
+        if key not in {"u_val", "npc_val", "context_val", "global_val"} or (
+                key in {"u_val", "npc_val"} and owner is None):
+            return None
+        default = value["default"]
+        if not (isinstance(default, str) or isinstance(default, dict) and (
+                "str" in default or "str_sp" in default)):
+            return None
+        fallback = render_participant_translation_expression(
+            value["default"], target_expression, avatar_expression, npc_expression)
+        raw = render_eoc_value_expression({key: value[key]}, "nil", owner or target_expression)
+        if fallback is None or raw is None:
+            return None
+        return ('(function(value) if value ~= nil then return tostring(value) end; '
+                f'return {fallback} end)({raw})')
+    return render_participant_string_expression(
+        value, target_expression, avatar_expression, npc_expression)
+
+
 def render_static_character_string_var(
     effect: dict[str, Any],
     avatar_actor_proven: bool,
@@ -25014,27 +25058,12 @@ def render_static_character_string_var(
             actor_expression = "actor"
 
     def render_value(value: Any) -> str | None:
-        if i18n and (isinstance(value, str) or (
-                isinstance(value, dict) and ("str" in value or "str_sp" in value))):
-            literal = value if isinstance(value, str) else value.get("str_sp", value.get("str"))
-            translation_context = value.get("ctxt") if isinstance(value, dict) else None
-            if not bounded_utf8_string(literal, 8192, allow_empty=True):
-                return None
-            if translation_context is not None and not bounded_utf8_string(
-                    translation_context, 8192, allow_empty=True):
-                return None
-            arguments = lua_quote(literal)
-            if translation_context is not None:
-                arguments += ", " + lua_quote(translation_context)
-            return f"services.translate({arguments})"
-        rendered = render_participant_string_expression(
+        renderer = render_participant_translation_expression if i18n else render_participant_string_expression
+        return renderer(
             value, actor_expression,
             "actor" if avatar_actor_proven else None,
             npc_actor_expression or ("actor" if npc_actor_proven else None),
         )
-        if rendered is None:
-            return None
-        return rendered
 
     rendered_values = [render_value(value) for value in values]
     if any(value is None for value in rendered_values):
@@ -25054,19 +25083,26 @@ def render_static_character_string_var(
             "title", "description", "default_text", "identifier",
         }:
             return None
-        title = display_text(input_options.get("title"), "")
-        description = display_text(input_options.get("description"), "")
-        initial = display_text(input_options.get("default_text"), "")
-        if not all(isinstance(value, str) for value in (title, description, initial)):
+        alpha = "actor" if avatar_actor_proven else None
+        beta = npc_actor_expression or ("actor" if npc_actor_proven else None)
+        translated_options = [render_participant_translation_expression(
+            input_options[key], actor_expression, alpha, beta) if key in input_options else '""'
+            for key in ("title", "default_text", "description")]
+        identifier = render_participant_string_expression(
+            input_options["identifier"], actor_expression, alpha, beta) if "identifier" in input_options else '""'
+        if any(option is None for option in translated_options) or identifier is None:
             return None
-        identifier = input_options.get("identifier", "")
-        if not bounded_utf8_string(identifier, 128, allow_empty=True):
-            return None
+        title, initial, description = translated_options
         lines.extend([
             f"    local value = {value_expression}",
+            f"    local input_label_width = #{title}",
+            f"    local input_default = {initial}",
+            f"    local input_title = {title}",
+            f"    local input_description = {description}",
+            f"    local input_identifier = {identifier}",
             "    local input = services.interaction.input_text(",
-            f"        {lua_quote(title)}, {{ default = {lua_quote(initial)}, "
-            f"description = {lua_quote(description)}, identifier = {lua_quote(identifier)} }})",
+            "        input_title, { default = input_default, description = input_description,",
+            "        identifier = input_identifier, width = 40 + input_label_width })",
             "    if input.accepted then",
             "        value = input.value",
             "    end",

--- a/tools/migrate_lua_first.py
+++ b/tools/migrate_lua_first.py
@@ -26761,25 +26761,26 @@ def render_eoc_condition_expression(
                 f"services.types.id(\"{kind}\", {lua_quote(condition[item_key])})))"
             )
 
-    for key, function_name, minimum in (
-        ("compare_string", "any_equal", 2),
-        ("compare_string_match_all", "all_equal", 1),
-    ):
+    for key, all_equal in (("compare_string", False), ("compare_string_match_all", True)):
         if set(condition) == {key}:
             values = condition[key]
-            if not isinstance(values, list) or len(values) < minimum:
+            if not isinstance(values, list) or all_equal and not values:
                 return None
-            rendered = [
-                render_eoc_string_expression(value)
-                for value in values
-            ]
+            rendered = [render_participant_string_expression(
+                value, "actor", "actor" if character_actor_proven else None, npc_query_actor)
+                for value in values]
             if any(value is None for value in rendered):
                 return None
-            rendered_values = ", ".join(rendered)
-            return (
-                f"services.gameplay.strings.{function_name}"
-                f"({{{rendered_values}}})"
-            )
+            if all_equal:
+                statements = [f"local first = {rendered[0]};"]
+                statements.extend(f"if {value} ~= first then return false end;" for value in rendered[1:])
+                statements.append("return true")
+            else:
+                statements = ["local seen = {}; local value;"]
+                statements.extend(f"value = {value}; if seen[value] then return true end; seen[value] = true;"
+                                  for value in rendered)
+                statements.append("return false")
+            return "(function() " + " ".join(statements) + " end)()"
 
     if set(condition) == {"one_in_chance"}:
         value = finite_number_literal(condition["one_in_chance"])

--- a/tools/migrate_lua_first.py
+++ b/tools/migrate_lua_first.py
@@ -24573,6 +24573,27 @@ def render_participant_string_expression(
             'option.type ~= "string_input" then error("string game option required") end; '
             f'return option.value end)(services.gameplay.options.get({option}))'
         )
+    if isinstance(value, dict) and value.get("mutator") in {
+        "ma_technique_name", "ma_technique_description", "mon_faction",
+    }:
+        monster = value["mutator"] == "mon_faction"
+        id_key = "mtype_id" if monster else "matec_id"
+        if set(value) != {"mutator", id_key}:
+            return None
+        identifier = render_participant_string_expression(
+            value[id_key], target_expression, avatar_expression, npc_expression)
+        if identifier is None:
+            return None
+        if monster:
+            return (
+                '(function(definition) if definition == nil then error("unknown monster definition") end; '
+                f'return definition.default_faction.value end)(services.registry.get("monster", {identifier}))'
+            )
+        field = "name" if value["mutator"].endswith("name") else "flavor_description"
+        return (
+            'services.martial_arts.technique_definition(services.types.id("martial_art_technique", '
+            f'{identifier})).{field}'
+        )
     owner = target_expression
     if isinstance(value, dict):
         for key, expression in (("u_val", avatar_expression), ("npc_val", npc_expression)):
@@ -25007,19 +25028,16 @@ def render_static_character_string_var(
                     f"{actor_expression}, {beta}, {options})).technique.value or "
                     f"{lua_quote('')})"
                 )
-            elif mutator in {"ma_technique_name", "ma_technique_description"} and set(value) == {
-                "mutator", "matec_id",
-            }:
-                technique = render_eoc_string_expression(
-                    value.get("matec_id"), actor_expression
+            elif mutator in {"ma_technique_name", "ma_technique_description", "mon_faction"}:
+                rendered = render_participant_string_expression(
+                    value, actor_expression,
+                    "actor" if avatar_actor_proven else None,
+                    npc_actor_expression or ("actor" if npc_actor_proven else None),
                 )
-                if technique is not None:
-                    field = "name" if mutator.endswith("name") else "description"
-                    rendered = (
-                        "services.martial_arts.technique_definition("
-                        "services.types.id(\"martial_art_technique\", "
-                        f"{technique})).{field}"
-                    )
+        if (isinstance(value, dict) and value.get("mutator") in {
+            "game_option", "ma_technique_name", "ma_technique_description", "mon_faction",
+        } and rendered is None):
+            return None
         if rendered is None:
             rendered = render_eoc_string_expression(value, actor_expression)
         if rendered is None and i18n and isinstance(value, dict):

--- a/tools/migrate_lua_first.py
+++ b/tools/migrate_lua_first.py
@@ -4992,7 +4992,7 @@ def render_static_false_effect(
         ]
     if isinstance(effect, dict) and "copy_var" in effect:
         rendered = render_static_character_copy_var(
-            effect, avatar_actor_proven, npc_actor_proven
+            effect, avatar_actor_proven, npc_actor_proven, npc_actor_expression
         )
         if rendered is None:
             return None
@@ -24891,6 +24891,7 @@ def render_static_character_copy_var(
     effect: dict[str, Any],
     avatar_actor_proven: bool,
     npc_actor_proven: bool,
+    npc_actor_expression: str | None = None,
 ) -> list[str] | None:
     if set(effect) != {"copy_var", "target_var"}:
         return None
@@ -24898,67 +24899,47 @@ def render_static_character_copy_var(
     target = _static_string_variable_descriptor(effect["target_var"])
     if source is None or target is None:
         return None
-    if source[0] == "npc" and not npc_actor_proven:
-        return None
-    if target[0] == "npc" and not npc_actor_proven:
-        return None
-    actor_expression = (
-        "actor" if (avatar_actor_proven or npc_actor_proven)
-        else "services.characters.avatar()"
-    )
+    alpha = "actor" if avatar_actor_proven else None
+    beta = npc_actor_expression or ("actor" if npc_actor_proven else None)
+    for scope, _ in (source, target):
+        if (scope == "u" and alpha is None or scope == "npc" and beta is None or
+                scope == "var" and (alpha is None or beta is None)):
+            return None
 
-    def resolved(scope: str, name: str) -> str:
-        if scope in {"u", "npc"}:
-            return (
-                "service_value(services.variables.get("
-                f"{actor_expression}, {lua_quote(name)}))"
-            )
-        return (
-            "service_value(services.variables.resolve(context.data, "
-            f"{actor_expression}, {lua_quote(scope)}, {lua_quote(name)}))"
-        )
+    def address(descriptor: tuple[str, str], prefix: str) -> list[str]:
+        scope, key = descriptor
+        owner = {"u": alpha, "npc": beta}.get(scope) or "nil"
+        if scope != "var":
+            return [f"    local {prefix}_scope, {prefix}_owner, {prefix}_key = "
+                    f"{lua_quote(scope)}, {owner}, {lua_quote(key)}"]
+        return [
+            f"    local {prefix}_scope, {prefix}_owner = \"global\", nil",
+            f"    local {prefix}_key = context.data[{lua_quote(key)}]",
+            f"    if {prefix}_key ~= nil then",
+            f'        if {prefix}_key:sub(1, 2) == "u_" then',
+            f'            {prefix}_scope, {prefix}_owner, {prefix}_key = "u", {alpha}, {prefix}_key:sub(3)',
+            f'        elseif {prefix}_key:sub(1, 2) == "n_" then',
+            f'            {prefix}_scope, {prefix}_owner, {prefix}_key = "npc", {beta}, {prefix}_key:sub(3)',
+            f'        elseif {prefix}_key:sub(1, 1) == "_" then',
+            f'            {prefix}_scope, {prefix}_key = "context", {prefix}_key:sub(2)',
+            '        end',
+            '    end',
+        ]
 
-    lines = [
-        f"    local copied = {resolved(source[0], source[1])}",
-        "    if copied.exists then",
-    ]
-    if target[0] == "context":
-        lines.append(
-            f"        context.data[{lua_quote(target[1])}] = copied.value"
-        )
-    elif target[0] == "global":
-        lines.append(
-            "        services.variables.set_global("
-            f"{lua_quote(target[1])}, copied.value)"
-        )
-    elif target[0] in {"u", "npc"}:
-        lines.append(
-            "        services.variables.set("
-            f"{actor_expression}, {lua_quote(target[1])}, copied.value)"
-        )
-    else:
-        lines.append(
-            "        service_value(services.variables.set_resolved("
-            f"context.data, {actor_expression}, \"var\", "
-            f"{lua_quote(target[1])}, copied.value))"
-        )
-    lines.append("    else")
-    if target[0] == "context":
-        lines.append(f"        context.data[{lua_quote(target[1])}] = nil")
-    elif target[0] == "global":
-        lines.append(
-            f"        services.variables.remove_global({lua_quote(target[1])})"
-        )
-    elif target[0] in {"u", "npc"}:
-        lines.append(
-            f"        services.variables.remove({actor_expression}, {lua_quote(target[1])})"
-        )
-    else:
-        # The v5 contract has no remove_resolved operation; leaving an
-        # indirect destination untouched is safer than writing a fabricated
-        # nil value into the native variable store.
-        lines.append("        -- missing source leaves an indirect target unchanged")
-    lines.append("    end")
+    lines = address(source, "copy_source")
+    lines.extend([
+        '    local copied = { exists = false }',
+        '    if copy_source_key ~= nil then',
+        '        copied = service_value(services.variables.resolve(',
+        '            context.data, copy_source_owner, copy_source_scope, copy_source_key))',
+        '    end',
+    ])
+    lines.extend(address(target, "copy_target"))
+    lines.extend([
+        '    if copy_target_key == nil then error("missing target variable") end',
+        '    service_value(services.variables.set_resolved(',
+        '        context.data, copy_target_owner, copy_target_scope, copy_target_key, copied.value))',
+    ])
     return lines
 
 
@@ -31645,7 +31626,8 @@ def render_eoc(
                     all_effects_converted = False
             elif isinstance(effect, dict) and "copy_var" in effect:
                 rendered = render_static_character_copy_var(
-                    effect, character_actor_proven, npc_event_character_actor_proven
+                    effect, character_actor_proven, npc_event_character_actor_proven,
+                    npc_actor_expression,
                 )
                 if rendered is not None:
                     lines.extend(rendered)

--- a/tools/migrate_lua_first.py
+++ b/tools/migrate_lua_first.py
@@ -24594,6 +24594,34 @@ def render_participant_string_expression(
             'services.martial_arts.technique_definition(services.types.id("martial_art_technique", '
             f'{identifier})).{field}'
         )
+    if isinstance(value, dict) and value.get("mutator") == "valid_technique":
+        if (set(value) - {"mutator", "blacklist", "crit", "dodge_counter", "block_counter"} or
+                avatar_expression is None or npc_expression is None):
+            return None
+        options = []
+        for source, name in (("crit", "critical"), ("dodge_counter", "dodge_counter"),
+                             ("block_counter", "block_counter")):
+            flag = value.get(source, False)
+            if not isinstance(flag, bool):
+                return None
+            if flag:
+                options.append(f"{name} = true")
+        blacklist = value.get("blacklist", [])
+        if not isinstance(blacklist, list) or len(blacklist) > 256:
+            return None
+        entries = [render_participant_string_expression(
+            entry, target_expression, avatar_expression, npc_expression) for entry in blacklist]
+        if any(entry is None for entry in entries):
+            return None
+        if entries:
+            options.append("blacklist = { " + ", ".join(entries) + " }")
+        rendered_options = "{ " + ", ".join(options) + " }"
+        # Native always selects for dialogue alpha against beta, regardless
+        # of the variable destination or the surrounding effect's target.
+        return (
+            'service_value(services.characters.choose_technique('
+            f'{avatar_expression}, {npc_expression}, {rendered_options})).technique.value'
+        )
     owner = target_expression
     if isinstance(value, dict):
         for key, expression in (("u_val", avatar_expression), ("npc_val", npc_expression)):
@@ -24993,40 +25021,11 @@ def render_static_character_string_var(
                     "actor" if avatar_actor_proven else None,
                     npc_actor_expression or ("actor" if npc_actor_proven else None),
                 )
-            elif mutator == "valid_technique" and set(value) <= {
-                "mutator", "blacklist", "crit", "dodge_counter",
-                "block_counter",
-            }:
-                option_values: list[str] = []
-                for source_name, target_name in (
-                    ("crit", "critical"),
-                    ("dodge_counter", "dodge_counter"),
-                    ("block_counter", "block_counter"),
-                ):
-                    flag = value.get(source_name, False)
-                    if not isinstance(flag, bool):
-                        return None
-                    if flag:
-                        option_values.append(f"{target_name} = true")
-                blacklist = value.get("blacklist", [])
-                if (
-                    not isinstance(blacklist, list) or len(blacklist) > 256 or
-                    not all(safe_platform_id(entry) for entry in blacklist)
-                ):
-                    return None
-                if blacklist:
-                    option_values.append(
-                        "blacklist = { " + ", ".join(
-                            lua_quote(entry) for entry in blacklist
-                        ) + " }"
-                    )
-                options = "{ " + ", ".join(option_values) + " }"
-                beta = npc_actor_expression or "(context.actors and context.actors.beta)"
-                rendered = (
-                    f"(({beta}) ~= nil and service_value("
-                    "services.characters.choose_technique("
-                    f"{actor_expression}, {beta}, {options})).technique.value or "
-                    f"{lua_quote('')})"
+            elif mutator == "valid_technique":
+                rendered = render_participant_string_expression(
+                    value, actor_expression,
+                    "actor" if avatar_actor_proven else None,
+                    npc_actor_expression or ("actor" if npc_actor_proven else None),
                 )
             elif mutator in {"ma_technique_name", "ma_technique_description", "mon_faction"}:
                 rendered = render_participant_string_expression(
@@ -25035,7 +25034,7 @@ def render_static_character_string_var(
                     npc_actor_expression or ("actor" if npc_actor_proven else None),
                 )
         if (isinstance(value, dict) and value.get("mutator") in {
-            "game_option", "ma_technique_name", "ma_technique_description", "mon_faction",
+            "game_option", "ma_technique_name", "ma_technique_description", "mon_faction", "valid_technique",
         } and rendered is None):
             return None
         if rendered is None:
@@ -25101,7 +25100,7 @@ def render_static_character_string_var(
     elif target[0] in {"u", "npc"}:
         lines.extend([
             "    services.variables.set(",
-            f"        actor, {lua_quote(target[1])}, {value_expression})",
+            f"        {actor_expression}, {lua_quote(target[1])}, {value_expression})",
         ])
     else:
         lines.extend([

--- a/tools/migrate_lua_first.py
+++ b/tools/migrate_lua_first.py
@@ -24558,6 +24558,21 @@ def render_participant_string_expression(
     avatar_expression: str | None, npc_expression: str | None,
 ) -> str | None:
     """Resolve a string independently of the character being queried or changed."""
+    if isinstance(value, dict) and value.get("mutator") == "game_option":
+        if set(value) != {"mutator", "option"}:
+            return None
+        option = render_participant_string_expression(
+            value["option"], target_expression, avatar_expression, npc_expression)
+        if option is None:
+            return None
+        # Native get_option<string> reads the stored string, not the formatted
+        # value of a numeric/bool option. Keep invalid types explicit.
+        return (
+            '(function(option) if option == nil then error("unknown game option") end; '
+            'if option.type ~= "string_select" and '
+            'option.type ~= "string_input" then error("string game option required") end; '
+            f'return option.value end)(services.gameplay.options.get({option}))'
+        )
     owner = target_expression
     if isinstance(value, dict):
         for key, expression in (("u_val", avatar_expression), ("npc_val", npc_expression)):
@@ -24952,11 +24967,11 @@ def render_static_character_string_var(
         if isinstance(value, dict) and isinstance(value.get("mutator"), str):
             mutator = value["mutator"]
             if mutator == "game_option" and set(value) == {"mutator", "option"}:
-                option = render_eoc_string_expression(
-                    value.get("option"), actor_expression
+                rendered = render_participant_string_expression(
+                    value, actor_expression,
+                    "actor" if avatar_actor_proven else None,
+                    npc_actor_expression or ("actor" if npc_actor_proven else None),
                 )
-                if option is not None:
-                    rendered = f"services.options.get({option})"
             elif mutator == "valid_technique" and set(value) <= {
                 "mutator", "blacklist", "crit", "dodge_counter",
                 "block_counter",

--- a/tools/migrate_lua_first.py
+++ b/tools/migrate_lua_first.py
@@ -25012,33 +25012,11 @@ def render_static_character_string_var(
             actor_expression = "actor"
 
     def render_value(value: Any) -> str | None:
-        rendered = None
-        if isinstance(value, dict) and isinstance(value.get("mutator"), str):
-            mutator = value["mutator"]
-            if mutator == "game_option" and set(value) == {"mutator", "option"}:
-                rendered = render_participant_string_expression(
-                    value, actor_expression,
-                    "actor" if avatar_actor_proven else None,
-                    npc_actor_expression or ("actor" if npc_actor_proven else None),
-                )
-            elif mutator == "valid_technique":
-                rendered = render_participant_string_expression(
-                    value, actor_expression,
-                    "actor" if avatar_actor_proven else None,
-                    npc_actor_expression or ("actor" if npc_actor_proven else None),
-                )
-            elif mutator in {"ma_technique_name", "ma_technique_description", "mon_faction"}:
-                rendered = render_participant_string_expression(
-                    value, actor_expression,
-                    "actor" if avatar_actor_proven else None,
-                    npc_actor_expression or ("actor" if npc_actor_proven else None),
-                )
-        if (isinstance(value, dict) and value.get("mutator") in {
-            "game_option", "ma_technique_name", "ma_technique_description", "mon_faction", "valid_technique",
-        } and rendered is None):
-            return None
-        if rendered is None:
-            rendered = render_eoc_string_expression(value, actor_expression)
+        rendered = render_participant_string_expression(
+            value, actor_expression,
+            "actor" if avatar_actor_proven else None,
+            npc_actor_expression or ("actor" if npc_actor_proven else None),
+        )
         if rendered is None and i18n and isinstance(value, dict):
             literal = value.get("str", value.get("str_sp"))
             if isinstance(literal, str) and bounded_utf8_string(

--- a/tools/migrate_lua_first.py
+++ b/tools/migrate_lua_first.py
@@ -24571,6 +24571,11 @@ def render_participant_string_expression(
     avatar_expression: str | None, npc_expression: str | None,
 ) -> str | None:
     """Resolve a string independently of the character being queried or changed."""
+    if isinstance(value, dict) and value.get("i18n") is True and "str" in value:
+        if set(value) - {"str", "i18n", "//~"} or not isinstance(value["str"], str):
+            return None
+        return render_participant_translation_expression(
+            value, target_expression, avatar_expression, npc_expression)
     if isinstance(value, dict) and value.get("mutator") == "game_option":
         if set(value) != {"mutator", "option"}:
             return None
@@ -26896,36 +26901,32 @@ def render_eoc_condition_expression(
             "services.gameplay.environment.dimension() == "
             f"{lua_quote(condition['current_dimension'])}"
         )
-    if set(condition) == {"is_season"} and isinstance(
-        condition["is_season"], str
+    for selector, current in (
+        ("is_season", "services.time_snapshot().season_id"),
+        ("is_weather", "services.weather.current().weather.value"),
     ):
-        return (
-            "services.time_snapshot().season_id == "
-            f"{lua_quote(condition['is_season'])}"
-        )
-    if set(condition) == {"is_weather"}:
-        weather_value = condition["is_weather"]
-        if isinstance(weather_value, str):
-            if not safe_platform_id(weather_value):
+        if set(condition) != {selector}:
+            continue
+        value = condition[selector]
+        if isinstance(value, dict) and "str" in value:
+            # str_or_var accepts this object through its explicit translation
+            # mutator only. A plain {str: ...} object is not a string literal.
+            if (set(value) - {"str", "i18n", "//~"} or
+                    value.get("i18n") is not True or
+                    not isinstance(value["str"], str)):
                 return None
-            weather_expression = lua_quote(weather_value)
-        elif isinstance(weather_value, dict) and len(weather_value) == 1:
-            variable_key = next(iter(weather_value))
-            if variable_key not in {"context_val", "u_val", "global_val"}:
-                return None
-            if variable_key == "u_val" and not avatar_actor_proven:
-                return None
-            weather_expression = render_eoc_string_expression(
-                weather_value, "actor"
-            )
-            if weather_expression is None:
-                return None
+            requested = render_participant_translation_expression(
+                value, "actor", "actor" if avatar_actor_proven else None,
+                npc_query_actor)
         else:
-            return None
-        return (
-            "services.weather.current().weather.value == "
-            f"{weather_expression}"
-        )
+            if isinstance(value, dict) and not set(value).intersection({
+                "u_val", "npc_val", "global_val", "context_val", "var_val", "mutator",
+            }):
+                return None
+            requested = render_participant_string_expression(
+                value, "actor", "actor" if avatar_actor_proven else None,
+                npc_query_actor)
+        return None if requested is None else f"{current} == {requested}"
     if (
         set(condition) == {"map_furniture_with_flag", "loc"} and
         bounded_utf8_string(condition.get("map_furniture_with_flag"), 256)

--- a/tools/migrate_lua_first.py
+++ b/tools/migrate_lua_first.py
@@ -4999,7 +4999,7 @@ def render_static_false_effect(
         return [line.replace("    ", "        ", 1) for line in rendered]
     if isinstance(effect, dict) and "set_string_var" in effect:
         rendered = render_static_character_string_var(
-            effect, avatar_actor_proven, npc_actor_proven
+            effect, avatar_actor_proven, npc_actor_proven, npc_actor_expression
         )
         if rendered is None:
             return None

--- a/tools/test_migrate_lua_first.py
+++ b/tools/test_migrate_lua_first.py
@@ -16,6 +16,42 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
 class LuaFirstMigrationTest(unittest.TestCase):
     @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_string_indirect_target_routes_native_prefixes(self) -> None:
+        lines = migrate_lua_first.render_static_character_string_var(
+            {"set_string_var": {"npc_val": "input"}, "target_var": {"var_val": "destination"}},
+            True, True, "partner")
+        self.assertIsNotNone(lines)
+        for reference, scope, owner in (("u_output", "u", "actor"), ("n_output", "npc", "partner"),
+                                        ("_output", "context", "nil"), ("output", "global", "nil")):
+            script = r"""
+local actor={input='alpha'}
+local partner={input='beta'}
+local context={data={destination='stale'}}
+local function service_value(r) assert(r.ok);return r.value end
+local writes=0
+local services={variables={
+ resolve=function(data,owner,scope,key)
+  assert(owner==partner and scope=='npc' and key=='input')
+  data.destination=REFERENCE
+  return {ok=true,value={value=owner[key]}}
+ end,
+ set_resolved=function(data,owner,scope,key,value)
+  assert(data==context.data and owner==OWNER and scope==SCOPE and key=='output' and value=='beta')
+  writes=writes+1;return {ok=true,value={}}
+ end
+}}
+BODY
+assert(writes==1)
+""".replace("REFERENCE", migrate_lua_first.lua_quote(reference))
+            script = script.replace("OWNER", owner).replace("SCOPE", migrate_lua_first.lua_quote(scope))
+            script = script.replace("BODY", "\n".join(lines))
+            result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+            self.assertEqual(result.returncode, 0, result.stderr)
+        for alpha, beta in ((True, False), (False, True), (False, False)):
+            self.assertIsNone(migrate_lua_first.render_static_character_string_var(
+                {"set_string_var": "value", "target_var": {"var_val": "destination"}}, alpha, beta))
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
     def test_string_assignment_reads_source_independently_of_destination(self) -> None:
         sources = [("u_val", "alpha"), ("npc_val", "beta"),
                    ("global_val", "global"), ("context_val", "context"),

--- a/tools/test_migrate_lua_first.py
+++ b/tools/test_migrate_lua_first.py
@@ -16,6 +16,68 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
 class LuaFirstMigrationTest(unittest.TestCase):
     @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_input_translated_variables_preserve_native_evaluation_order(self) -> None:
+        lines = migrate_lua_first.render_static_character_string_var(
+            {"set_string_var": "original", "target_var": {"context_val": "output"},
+             "string_input": {"title": {"npc_val": "title"}, "default_text": {"u_val": "initial"},
+                              "description": {"str": "Help", "ctxt": "input"},
+                              "identifier": {"context_val": "history"}}}, True, True, "partner")
+        self.assertIsNotNone(lines)
+        script = r"""
+local actor={initial='alpha initial'}
+local partner={title='beta title'}
+local context={data={history='input_history'}}
+local order={}
+local function service_value(r) assert(r.ok);return r.value end
+local services={
+ variables={resolve=function(data,owner,scope,key)
+  order[#order+1]=key;return {ok=true,value={value=owner[key]}}
+ end},
+ translate=function(text,ctxt)
+  assert(text=='Help' and ctxt=='input');order[#order+1]='description';return 'translated help'
+ end,
+ interaction={input_text=function(title,options)
+  assert(table.concat(order,',')=='title,initial,title,description')
+  assert(title=='beta title' and options.default=='alpha initial')
+  assert(options.description=='translated help' and options.identifier=='input_history')
+  assert(options.width==50);return {accepted=true,cancelled=false,value='entered'}
+ end}
+}
+BODY
+assert(context.data.output=='entered')
+""".replace("BODY", "\n".join(lines))
+        result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_translated_variable_default_is_lazy_and_preserves_empty_values(self) -> None:
+        expression = migrate_lua_first.render_participant_translation_expression(
+            {"npc_val": "input", "default": {"str": "Fallback", "ctxt": "default"}},
+            "actor", "actor", "partner")
+        self.assertIsNotNone(expression)
+        for present in (True, False):
+            script = r"""
+local actor={}
+local partner={}
+local context={data={}}
+local calls=0
+local function service_value(r) assert(r.ok);return r.value end
+local services={
+ variables={resolve=function(data,owner,scope,key)
+  assert(owner==partner);return {ok=true,value={value=PRESENT and '' or nil}}
+ end},
+ translate=function(text,ctxt)
+  assert(text=='Fallback' and ctxt=='default');calls=calls+1;return 'translated default'
+ end
+}
+local result=EXPRESSION
+assert(result==(PRESENT and '' or 'translated default'))
+assert(calls==(PRESENT and 0 or 1))
+""".replace("PRESENT", "true" if present else "false").replace("EXPRESSION", expression)
+            result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
     def test_string_i18n_translates_literals_but_not_stored_variables(self) -> None:
         cases = [("Hello", True, "translated", "nil"),
                  ({"str": "Hello", "ctxt": "greeting"}, True, "translated", '"greeting"'),
@@ -67,6 +129,7 @@ local context={data={}}
 local phase=0
 local function service_value(r) assert(r.ok);return r.value end
 local services={
+ translate=function(text) return text end,
  characters={avatar=function() return player end},
  interaction={input_text=function(title,options)
   assert(phase==0 and title=='Title' and options.default=='' and options.initial==nil);phase=1

--- a/tools/test_migrate_lua_first.py
+++ b/tools/test_migrate_lua_first.py
@@ -16,6 +16,31 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
 class LuaFirstMigrationTest(unittest.TestCase):
     @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_false_branch_string_assignment_preserves_beta_expression(self) -> None:
+        lines = migrate_lua_first.render_static_false_effect(
+            {"set_string_var": {"npc_val": "input"}, "target_var": {"npc_val": "output"}},
+            True, True, {}, npc_actor_expression="partner")
+        self.assertIsNotNone(lines)
+        script = r"""
+local actor={input='alpha'}
+local partner={input='beta'}
+local context={data={}}
+local function service_value(r) assert(r.ok);return r.value end
+local services={variables={
+ resolve=function(data,owner,scope,key)
+  assert(owner==partner and scope=='npc');return {ok=true,value={value=owner[key]}}
+ end,
+ set=function(owner,key,value) assert(owner==partner);owner[key]=value end
+}}
+if false then error('wrong branch') else
+BODY
+end
+assert(partner.output=='beta' and actor.output==nil)
+""".replace("BODY", "\n".join(lines))
+        result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
     def test_real_selector_example_string_setup_preserves_translation(self) -> None:
         source = json.loads((REPOSITORY_ROOT / "data/json/effects_on_condition/example_eocs.json").read_text())
         eoc = next(entry for entry in source if entry.get("id") == "EOC_selector_test")

--- a/tools/test_migrate_lua_first.py
+++ b/tools/test_migrate_lua_first.py
@@ -16,6 +16,36 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
 class LuaFirstMigrationTest(unittest.TestCase):
     @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_one_in_native_range_and_owner_are_not_clamped(self) -> None:
+        values = (2147483647.9, -2147483648.9,
+                  {"npc_val": "chance"}, [-2147483648, 2147483647])
+        for value in values:
+            expression = migrate_lua_first.render_eoc_condition_expression(
+                {"one_in_chance": value}, avatar_actor_proven=True,
+                npc_actor_expression="partner")
+            self.assertIsNotNone(expression)
+            expected = 2147483647 if isinstance(value, (dict, list)) else value
+            script = r"""
+local actor,partner={},{}
+local context={data={}}
+local reads=0
+local function service_value(r) assert(r.ok);return r.value end
+local services={variables={resolve=function(data,owner,scope,key)
+ assert(owner==partner and scope=='npc' and key=='chance')
+ reads=reads+1;return {ok=true,value={value=2147483647}}
+end},random={int=function(lo,hi)
+ assert(lo==-2147483648 and hi==2147483647);return hi
+end,one_in=function(n) assert(n==EXPECTED);return true end}}
+assert(EXPRESSION)
+assert(reads==READS)
+""".replace("EXPECTED", str(expected)).replace("EXPRESSION", expression)
+            script = script.replace("READS", "1" if isinstance(value, dict) else "0")
+            result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+            self.assertEqual(result.returncode, 0, result.stderr)
+        for invalid in (2147483648, -2147483649, [0, 2147483648]):
+            self.assertIsNone(migrate_lua_first.render_eoc_condition_expression({"one_in_chance": invalid}))
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
     def test_environment_nested_string_mutator_preserves_explicit_translation(self) -> None:
         expression = migrate_lua_first.render_eoc_condition_expression({
             "is_season": {"mutator": "mon_faction", "mtype_id": {"str": "original", "i18n": True}}})
@@ -852,7 +882,7 @@ assert(adds==1 and random_calls==2 and reads==READS)
                     self.assertEqual(result.returncode, 0, result.stderr)
 
     def test_effect_intensity_rejects_malformed_ranges(self) -> None:
-        for value in ([], [1], [1, 2, 3], [[1, 2], 3], [True, 2], [0, 1000000001]):
+        for value in ([], [1], [1, 2, 3], [[1, 2], 3], [True, 2], [0, 2147483648], [-2147483649, 0]):
             self.assertIsNone(migrate_lua_first.render_effect_condition(
                 {"u_has_effect": "bleed", "intensity": value}, "actor", None))
             self.assertIsNone(migrate_lua_first.render_dynamic_character_effect(

--- a/tools/test_migrate_lua_first.py
+++ b/tools/test_migrate_lua_first.py
@@ -16,6 +16,58 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
 class LuaFirstMigrationTest(unittest.TestCase):
     @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_string_assignment_reads_source_independently_of_destination(self) -> None:
+        sources = [("u_val", "alpha"), ("npc_val", "beta"),
+                   ("global_val", "global"), ("context_val", "context"),
+                   ("var_val", "alpha"), ("var_val", "beta"),
+                   ("var_val", "global"), ("var_val", "context")]
+        for source, expected in sources:
+            for destination in ("u_val", "npc_val", "global_val", "context_val"):
+                with self.subTest(source=source, expected=expected, destination=destination):
+                    lines = migrate_lua_first.render_static_character_string_var(
+                        {"set_string_var": {source: "input"}, "target_var": {destination: "output"}},
+                        True, True, "partner")
+                    self.assertIsNotNone(lines)
+                    reference = {"alpha": "u_input", "beta": "n_input",
+                                 "global": "input", "context": "_input"}[expected]
+                    # The reference and the referenced value need distinct context keys.
+                    if source == "var_val":
+                        lines = migrate_lua_first.render_static_character_string_var(
+                            {"set_string_var": {source: "reference"}, "target_var": {destination: "output"}},
+                            True, True, "partner")
+                    script = r"""
+local actor={input='alpha'}
+local partner={input='beta'}
+local globals={input='global'}
+local context={data={input='context',reference=REFERENCE}}
+local function service_value(r) assert(r.ok);return r.value end
+local services={variables={
+ get_global=function(key) return {ok=true,value={value=globals[key]}} end,
+ resolve=function(data,owner,scope,key)
+  local store=scope=='global' and globals or scope=='context' and data or owner
+  assert(store);return {ok=true,value={value=store[key]}}
+ end,
+ set=function(owner,key,value) owner[key]=value end,
+ set_global=function(key,value) globals[key]=value end
+}}
+BODY
+assert(DESTINATION.output==EXPECTED)
+assert(actor.input=='alpha' and partner.input=='beta')
+""".replace("REFERENCE", migrate_lua_first.lua_quote(reference))
+                    store = {"u_val": "actor", "npc_val": "partner",
+                             "global_val": "globals", "context_val": "context.data"}[destination]
+                    script = script.replace("BODY", "\n".join(lines)).replace("DESTINATION", store)
+                    script = script.replace("EXPECTED", migrate_lua_first.lua_quote(expected))
+                    result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+                    self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_string_assignment_does_not_invent_source_participants(self) -> None:
+        for source in ("u_val", "npc_val", "var_val"):
+            self.assertIsNone(migrate_lua_first.render_static_character_string_var(
+                {"set_string_var": {source: "input"}, "target_var": {"context_val": "output"}},
+                False, False))
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
     def test_technique_choice_keeps_alpha_beta_independent_of_string_destination(self) -> None:
         for selected in ("chosen_technique", ""):
             with self.subTest(selected=selected):

--- a/tools/test_migrate_lua_first.py
+++ b/tools/test_migrate_lua_first.py
@@ -16,6 +16,36 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
 class LuaFirstMigrationTest(unittest.TestCase):
     @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_string_random_choice_evaluates_only_selected_candidate_after_rng(self) -> None:
+        lines = migrate_lua_first.render_static_character_string_var(
+            {"set_string_var": [{"u_val": "first"}, {"npc_val": "second"}],
+             "target_var": {"context_val": "output"}}, True, True, "partner")
+        self.assertIsNotNone(lines)
+        for selected in (1, 2):
+            script = r"""
+local actor={first='alpha'}
+local partner={second='beta'}
+local context={data={}}
+local order={}
+local function service_value(r) assert(r.ok);return r.value end
+local services={
+ random={int=function(lo,hi)
+  assert(lo==1 and hi==2 and #order==0);order[1]='rng';return SELECTED
+ end},
+ variables={resolve=function(data,owner,scope,key)
+  assert(#order==1 and order[1]=='rng')
+  assert((SELECTED==1 and owner==actor and key=='first') or
+         (SELECTED==2 and owner==partner and key=='second'))
+  order[2]='value';return {ok=true,value={value=owner[key]}}
+ end}
+}
+BODY
+assert(#order==2 and context.data.output==(SELECTED==1 and 'alpha' or 'beta'))
+""".replace("SELECTED", str(selected)).replace("BODY", "\n".join(lines))
+            result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
     def test_string_indirect_target_routes_native_prefixes(self) -> None:
         lines = migrate_lua_first.render_static_character_string_var(
             {"set_string_var": {"npc_val": "input"}, "target_var": {"var_val": "destination"}},

--- a/tools/test_migrate_lua_first.py
+++ b/tools/test_migrate_lua_first.py
@@ -16,6 +16,111 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
 class LuaFirstMigrationTest(unittest.TestCase):
     @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_environment_nested_string_mutator_preserves_explicit_translation(self) -> None:
+        expression = migrate_lua_first.render_eoc_condition_expression({
+            "is_season": {"mutator": "mon_faction", "mtype_id": {"str": "original", "i18n": True}}})
+        self.assertIsNotNone(expression)
+        script = r"""
+local services={time_snapshot=function() return {season_id='spring'} end,
+ translate=function(text) assert(text=='original');return 'translated' end,
+ registry={get=function(kind,id)
+ assert(kind=='monster' and id=='translated');return {default_faction={value='spring'}}
+end}}
+assert(EXPRESSION)
+""".replace("EXPRESSION", expression)
+        result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_environment_explicit_translation_is_not_a_plain_string(self) -> None:
+        for selector in ("is_season", "is_weather"):
+            expression = migrate_lua_first.render_eoc_condition_expression(
+                {selector: {"str": "spring", "i18n": True}})
+            self.assertIsNotNone(expression)
+            script = r"""
+local translations=0
+local services={time_snapshot=function() return {season_id='spring'} end,
+ weather={current=function() return {weather={value='spring'}} end},
+ translate=function(text) assert(text=='spring');translations=translations+1;return 'printemps' end}
+assert(not (EXPRESSION))
+assert(translations==1)
+""".replace("EXPRESSION", expression)
+            result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            for invalid in ({"str": "spring"}, {"str": "spring", "i18n": False}, {"math": ["1"]}):
+                self.assertIsNone(migrate_lua_first.render_eoc_condition_expression({selector: invalid}))
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_real_environment_condition_literals_execute(self) -> None:
+        conditions = []
+
+        def collect(value):
+            if isinstance(value, dict):
+                for key in ("is_season", "is_weather"):
+                    if key in value:
+                        conditions.append({key: value[key]})
+                for child in value.values():
+                    collect(child)
+            elif isinstance(value, list):
+                for child in value:
+                    collect(child)
+
+        for relative in (
+            "data/json/effects_on_condition/mutation_eocs/mutation_effect_eocs.json",
+            "data/json/effects_on_condition/item_eocs.json",
+        ):
+            collect(json.loads((REPOSITORY_ROOT / relative).read_text()))
+        self.assertTrue(any("is_season" in value for value in conditions))
+        self.assertTrue(any("is_weather" in value for value in conditions))
+        lines = ["local services={time_snapshot=function() return {season_id='spring'} end,"
+                 "weather={current=function() return {weather={value='rain'}} end}}"]
+        for condition in conditions:
+            key, value = next(iter(condition.items()))
+            self.assertIsInstance(value, str)
+            expression = migrate_lua_first.render_eoc_condition_expression(condition)
+            self.assertIsNotNone(expression)
+            expected = value == ("spring" if key == "is_season" else "rain")
+            lines.append(f"assert(({expression})=={'true' if expected else 'false'})")
+        result = subprocess.run(["lua", "-"], input="\n".join(lines), text=True, capture_output=True, timeout=10)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_environment_string_queries_preserve_participant_and_fallback(self) -> None:
+        for selector, current in (("is_season", "spring"), ("is_weather", "rain")):
+            for key in ("u_val", "npc_val", "global_val", "context_val", "var_val"):
+                for present in (False, True):
+                    value = {key: "reference" if key == "var_val" else "wanted", "default": current}
+                    expression = migrate_lua_first.render_eoc_condition_expression(
+                        {selector: value}, avatar_actor_proven=True,
+                        npc_actor_expression="partner")
+                    self.assertIsNotNone(expression)
+                    script = r"""
+local actor,partner={},{}
+local context={data={reference='n_wanted'}}
+local reads=0
+local function service_value(r) assert(r.ok);return r.value end
+local services={time_snapshot=function() return {season_id=CURRENT} end,
+ weather={current=function() return {weather={value=CURRENT}} end},
+ variables={resolve=function(data,owner,scope,key)
+ assert(key=='wanted')
+ if SCOPE=='u_val' then assert(scope=='u' and owner==actor)
+ elseif SCOPE=='npc_val' or SCOPE=='var_val' then assert(scope=='npc' and owner==partner)
+ elseif SCOPE=='global_val' then assert(scope=='global')
+ else assert(scope=='context') end
+ reads=reads+1
+ return {ok=true,value={exists=PRESENT,value=nil}}
+end}}
+assert((EXPRESSION)==EXPECTED)
+assert(reads==1)
+""".replace("CURRENT", migrate_lua_first.lua_quote(current))
+                    script = script.replace("SCOPE", migrate_lua_first.lua_quote(key))
+                    script = script.replace("PRESENT", "true" if present else "false")
+                    script = script.replace("EXPECTED", "false" if present else "true")
+                    script = script.replace("EXPRESSION", expression)
+                    result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+                    self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
     def test_is_day_real_conditions_use_live_environment_without_actor(self) -> None:
         # Real content uses this parameterless predicate both directly and negated.
         source = json.loads((REPOSITORY_ROOT / "data/json/npcs/TALK_TEST.json").read_text())
@@ -3324,7 +3429,7 @@ assert(not ok and string.find(message, 'stale_world', 1, true))
                 1,
             )
 
-    def test_dynamic_or_unproven_is_season_shapes_stay_partial(self) -> None:
+    def test_dynamic_is_season_converts_but_numeric_shape_stays_partial(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             source = Path(temporary) / "source.json"
             source.write_text(
@@ -3356,12 +3461,12 @@ assert(not ok and string.find(message, 'stale_world', 1, true))
             main = result.files[Path("main.lua")]
             report = result.files[Path("MIGRATION_REPORT.md")]
 
-            self.assertEqual(result.converted, [])
-            self.assertEqual(len(result.partial), 2)
-            self.assertNotIn("services.time_snapshot", main)
+            self.assertEqual(len(result.converted), 1)
+            self.assertEqual(len(result.partial), 1)
+            self.assertIn("services.time_snapshot", main)
             self.assertEqual(
                 report.count("condition TODO: translate the legacy condition into a Lua predicate"),
-                2,
+                1,
             )
 
     def test_translates_literal_is_weather_through_current_snapshot(self) -> None:
@@ -3459,8 +3564,8 @@ assert(not ok and string.find(message, 'stale_world', 1, true))
             main = result.files[Path("main.lua")]
             report = result.files[Path("MIGRATION_REPORT.md")]
 
-            self.assertEqual(len(result.converted), 3)
-            self.assertEqual(len(result.partial), 3)
+            self.assertEqual(len(result.converted), 4)
+            self.assertEqual(len(result.partial), 2)
             self.assertIn(
                 'services.weather.current().weather.value == '
                 'tostring((context.data["context_weather"]) or "")',
@@ -3479,10 +3584,10 @@ assert(not ok and string.find(message, 'stale_world', 1, true))
                 main,
             )
             self.assertNotIn('weather.value == 5', main)
-            self.assertNotIn('weather.value == ""', main)
+            self.assertIn('weather.value == ""', main)
             self.assertEqual(
                 report.count("condition TODO: translate the legacy condition into a Lua predicate"),
-                3,
+                2,
             )
 
     def test_translates_proven_avatar_activity_cancellation(self) -> None:

--- a/tools/test_migrate_lua_first.py
+++ b/tools/test_migrate_lua_first.py
@@ -16,6 +16,37 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
 class LuaFirstMigrationTest(unittest.TestCase):
     @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_is_day_real_conditions_use_live_environment_without_actor(self) -> None:
+        # Real content uses this parameterless predicate both directly and negated.
+        source = json.loads((REPOSITORY_ROOT / "data/json/npcs/TALK_TEST.json").read_text())
+        predicates = []
+        for topic in source:
+            for response in topic.get("responses", []):
+                condition = response.get("condition")
+                if condition == "is_day" or condition == {"not": "is_day"}:
+                    predicates.append(condition)
+        self.assertEqual(len(predicates), 2)
+        for condition in predicates:
+            expression = migrate_lua_first.render_eoc_condition_expression(condition)
+            self.assertIsNotNone(expression)
+            expected = "night" if isinstance(condition, dict) else "not night"
+            script = """
+local night=false
+local reads=0
+local services={gameplay={environment={is_night=function()
+ reads=reads+1;return night
+end}}}
+local function predicate() return EXPRESSION end
+for _,value in ipairs({false,true,false}) do
+ night=value
+ assert(predicate()==(EXPECTED))
+end
+assert(reads==3)
+""".replace("EXPRESSION", expression).replace("EXPECTED", expected)
+            result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
     def test_probability_operands_preserve_large_values_and_single_owner_reads(self) -> None:
         for chance in ({"x": 1000000000000, "y": 2000000000000},
                        {"x": {"u_val": "x"}, "y": {"npc_val": "y"}}):
@@ -2065,7 +2096,6 @@ assert(not ok and string.find(message, 'stale_world', 1, true))
                 {"is_season": "spring"},
                 {"is_weather": "rain"},
                 "is_day",
-                "is_night",
                 {"u_has_trait": "SAMPLE_TRAIT"},
                 {"u_has_any_trait": ["SAMPLE_TRAIT", "TOUGH"]},
                 {"u_has_martial_art": "style_karate"},
@@ -3256,6 +3286,12 @@ assert(not ok and string.find(message, 'stale_world', 1, true))
                 ),
                 1,
             )
+
+    def test_unregistered_night_condition_is_not_invented_during_migration(self) -> None:
+        path = REPOSITORY_ROOT / "data/reference/json/ccb_eoc_conditions.json"
+        inventory = json.loads(path.read_text())
+        self.assertNotIn("is_night", {entry["key"] for entry in inventory["entries"]})
+        self.assertIsNone(migrate_lua_first.render_eoc_condition_expression("is_night"))
 
     def test_dynamic_or_unproven_is_day_shapes_stay_partial(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:

--- a/tools/test_migrate_lua_first.py
+++ b/tools/test_migrate_lua_first.py
@@ -35,8 +35,8 @@ local function service_value(r) assert(r.ok);return r.value end
 local services={
  characters={avatar=function() return player end},
  interaction={input_text=function(title,options)
-  assert(phase==0 and title=='Title');phase=1
-  if ACCEPTED then return 'entered <tag>' end
+  assert(phase==0 and title=='Title' and options.default=='' and options.initial==nil);phase=1
+  return {accepted=ACCEPTED,cancelled=not ACCEPTED,value=ACCEPTED and 'entered <tag>' or ''}
  end},
  text={expand_for=function(value,alpha,beta)
   assert(phase==1 and alpha==ALPHA and beta==BETA);phase=2

--- a/tools/test_migrate_lua_first.py
+++ b/tools/test_migrate_lua_first.py
@@ -16,6 +16,57 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
 class LuaFirstMigrationTest(unittest.TestCase):
     @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_real_mp3_dimension_comparison_executes_as_lua(self) -> None:
+        source = json.loads((REPOSITORY_ROOT / "data/json/effects_on_condition/anomalous_mp3_eocs.json").read_text())
+        eoc = next(entry for entry in source if entry.get("id") == "EOC_MP3_REVERBERATION_REVERBERATION_LISTENER")
+        expression = migrate_lua_first.render_eoc_condition_expression(eoc["effect"][1]["if"])
+        self.assertIsNotNone(expression)
+        for dimension, expected in (("radiosphere", True), ("cabins", False), ("", False)):
+            script = "local context={data={dim_name=" + migrate_lua_first.lua_quote(dimension) + "}}\n"
+            script += f"assert({expression} == {str(expected).lower()})"
+            result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_string_comparisons_preserve_owners_and_short_circuit(self) -> None:
+        for key, beta, expected in (("compare_string", "alpha", True),
+                                    ("compare_string_match_all", "different", False)):
+            condition = {key: [{"u_val": "input"}, {"npc_val": "input"},
+                               {"mutator": "game_option", "option": "unreached"}]}
+            expression = migrate_lua_first.render_eoc_condition_expression(
+                condition, avatar_actor_proven=True, npc_actor_proven=True, npc_actor_expression="partner")
+            self.assertIsNotNone(expression)
+            script = r"""
+local actor={input='alpha'}
+local partner={input=BETA}
+local context={data={}}
+local calls=0
+local function service_value(r) assert(r.ok);return r.value end
+local services={variables={resolve=function(data,owner,scope,key)
+ calls=calls+1;assert((calls==1 and owner==actor) or (calls==2 and owner==partner))
+ return {ok=true,value={value=owner[key]}}
+end},gameplay={options={get=function() error('must short circuit') end}}}
+assert(EXPRESSION==EXPECTED and calls==2)
+""".replace("BETA", migrate_lua_first.lua_quote(beta)).replace("EXPRESSION", expression)
+            script = script.replace("EXPECTED", "true" if expected else "false")
+            result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_string_comparisons_accept_native_empty_singleton_and_long_lists(self) -> None:
+        cases = [("compare_string", [], False), ("compare_string", ["a"], False),
+                 ("compare_string_match_all", ["a"], True),
+                 ("compare_string", [str(i) for i in range(300)], False),
+                 ("compare_string_match_all", ["same"] * 300, True)]
+        for key, values, expected in cases:
+            expression = migrate_lua_first.render_eoc_condition_expression({key: values})
+            self.assertIsNotNone(expression)
+            result = subprocess.run(["lua", "-"], input=f"assert({expression} == {str(expected).lower()})",
+                                    text=True, capture_output=True, timeout=10)
+            self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIsNone(migrate_lua_first.render_eoc_condition_expression({"compare_string_match_all": []}))
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
     def test_copy_variable_preserves_owners_types_and_empty_write(self) -> None:
         addresses = [("u_val", "actor", None), ("npc_val", "partner", None),
                      ("context_val", "context.data", None), ("global_val", "globals", None),
@@ -2000,8 +2051,8 @@ assert(not ok and string.find(message, 'stale_world', 1, true))
 
             self.assertEqual(len(result.converted), len(predicates))
             self.assertEqual(result.partial, [])
-            self.assertIn("services.gameplay.strings.any_equal", main)
-            self.assertIn("services.gameplay.strings.all_equal", main)
+            self.assertIn("if seen[value] then return true end", main)
+            self.assertIn("~= first then return false end", main)
             self.assertIn("services.random.one_in(3)", main)
             self.assertIn("services.random.probability(1.5, 4)", main)
             self.assertIn("services.random.contested(2, 5, 8)", main)
@@ -18632,8 +18683,8 @@ assert(not ok and string.find(message, 'stale_world', 1, true))
 
             self.assertEqual(result.partial, [])
             self.assertEqual(result.todos, [])
-            self.assertIn("services.gameplay.strings.any_equal", main)
-            self.assertIn("services.gameplay.strings.all_equal", main)
+            self.assertIn("if seen[value] then return true end", main)
+            self.assertIn("~= first then return false end", main)
             self.assertIn("services.gameplay.math.apply", main)
 
     def test_phase_move_and_global_overmap_point_keep_avatar_context(self) -> None:

--- a/tools/test_migrate_lua_first.py
+++ b/tools/test_migrate_lua_first.py
@@ -15,6 +15,52 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
 
 class LuaFirstMigrationTest(unittest.TestCase):
+    def test_definition_mutators_do_not_invent_missing_variable_owners(self) -> None:
+        for mutator, key in (("ma_technique_name", "matec_id"),
+                             ("ma_technique_description", "matec_id"), ("mon_faction", "mtype_id")):
+            value = {"mutator": mutator, key: {"npc_val": "selected"}}
+            self.assertIsNone(migrate_lua_first.render_static_character_string_var(
+                {"set_string_var": value, "target_var": {"context_val": "output"}}, False, False))
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_definition_string_mutators_preserve_owners_and_short_description(self) -> None:
+        for mutator, expected in (("ma_technique_name", "name"),
+                                  ("ma_technique_description", "short_description"),
+                                  ("mon_faction", "faction")):
+            for scope, owner in (("u_val", "actor"), ("npc_val", "partner")):
+                with self.subTest(mutator=mutator, scope=scope):
+                    key = "mtype_id" if mutator == "mon_faction" else "matec_id"
+                    value = {"mutator": mutator, key: {scope: "selected"}}
+                    expression = migrate_lua_first.render_participant_string_expression(value, "partner", "actor", "partner")
+                    lines = migrate_lua_first.render_static_character_string_var(
+                        {"set_string_var": value, "target_var": {"context_val": "output"}}, True, True, "partner")
+                    self.assertIsNotNone(expression)
+                    self.assertIsNotNone(lines)
+                    script = r"""
+local actor={selected='alpha_id'}
+local partner={selected='beta_id'}
+local context={data={}}
+local function service_value(r) assert(r.ok);return r.value end
+local services={
+ variables={resolve=function(data,owner,scope,key)
+  assert(owner==OWNER and key=='selected');return {ok=true,value={value=owner[key]}}
+ end},
+ types={id=function(kind,id) assert(kind=='martial_art_technique' and id==OWNER.selected);return id end},
+ martial_arts={technique_definition=function(id)
+  assert(id==OWNER.selected);return {name='name',flavor_description='short_description',description='full rules'}
+ end},
+ registry={get=function(kind,id)
+  assert(kind=='monster' and id==OWNER.selected);return {default_faction={value='faction'}}
+ end}
+}
+assert(EXPR==EXPECTED)
+BODY
+assert(context.data.output==EXPECTED)
+""".replace("OWNER", owner).replace("EXPECTED", migrate_lua_first.lua_quote(expected))
+                    script = script.replace("EXPR", expression).replace("BODY", "\n".join(lines))
+                    result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+                    self.assertEqual(result.returncode, 0, result.stderr)
+
     @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
     def test_string_option_mutator_uses_public_api_and_correct_variable_owner(self) -> None:
         for prefix, target in (("u_", "actor"), ("npc_", "partner")):

--- a/tools/test_migrate_lua_first.py
+++ b/tools/test_migrate_lua_first.py
@@ -16,6 +16,49 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
 class LuaFirstMigrationTest(unittest.TestCase):
     @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_probability_operands_preserve_large_values_and_single_owner_reads(self) -> None:
+        for chance in ({"x": 1000000000000, "y": 2000000000000},
+                       {"x": {"u_val": "x"}, "y": {"npc_val": "y"}}):
+            expression = migrate_lua_first.render_eoc_condition_expression(
+                {"x_in_y_chance": chance}, avatar_actor_proven=True,
+                npc_actor_proven=True, npc_actor_expression="partner")
+            self.assertIsNotNone(expression)
+            script = r"""
+local actor={x=1000000000000}
+local partner={y=2000000000000}
+local context={data={}}
+local reads={}
+local function service_value(r) assert(r.ok);return r.value end
+local services={variables={resolve=function(data,owner,scope,key)
+ assert((key=='x' and owner==actor) or (key=='y' and owner==partner))
+ reads[key]=(reads[key] or 0)+1;assert(reads[key]==1)
+ return {ok=true,value={exists=true,value=owner[key]}}
+end},random={probability=function(x,y)
+ assert(x==1000000000000 and y==2000000000000 and x/y==0.5);return true
+end}}
+assert(EXPRESSION)
+""".replace("EXPRESSION", expression)
+            result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_probability_ranges_preserve_integer_sampling(self) -> None:
+        expression = migrate_lua_first.render_eoc_condition_expression(
+            {"x_in_y_chance": {"x": [2.5, 2.5], "y": [4.9, 4.9]}})
+        self.assertIsNotNone(expression)
+        script = r"""
+local samples=0
+local services={random={int=function(lo,hi)
+ assert(lo==hi);samples=samples+1;return lo
+end,probability=function(x,y)
+ assert(samples==2 and x==2 and y==4);return true
+end}}
+assert(EXPRESSION)
+""".replace("EXPRESSION", expression)
+        result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
     def test_string_defaults_distinguish_stored_null_from_missing(self) -> None:
         for key in ("u_val", "npc_val", "global_val", "var_val"):
             for present in (True, False):

--- a/tools/test_migrate_lua_first.py
+++ b/tools/test_migrate_lua_first.py
@@ -16,6 +16,60 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
 class LuaFirstMigrationTest(unittest.TestCase):
     @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_string_option_mutator_uses_public_api_and_correct_variable_owner(self) -> None:
+        for prefix, target in (("u_", "actor"), ("npc_", "partner")):
+            for scope, owner in (("u_val", "actor"), ("npc_val", "partner")):
+                with self.subTest(prefix=prefix, scope=scope):
+                    value = {"mutator": "game_option", "option": {scope: "option_name"}}
+                    lines = migrate_lua_first.render_dynamic_simple_character_effect(
+                        {prefix + "add_bionic": value}, prefix + "add_bionic", target,
+                        avatar_expression="actor", npc_expression="partner")
+                    stored = migrate_lua_first.render_static_character_string_var(
+                        {"set_string_var": value, "target_var": {"context_val": "output"}},
+                        True, True, "partner")
+                    self.assertIsNotNone(lines)
+                    self.assertIsNotNone(stored)
+                    script = r"""
+local actor={option_name='ALPHA_OPTION'}
+local partner={option_name='BETA_OPTION'}
+local context={data={}}
+local calls=0
+local function service_value(r) assert(r.ok);return r.value end
+local services={
+ variables={resolve=function(data,character,scope,key)
+  assert(character==OWNER and key=='option_name');return {ok=true,value={value=character[key]}}
+ end},
+ gameplay={options={get=function(id)
+  assert(id==OWNER.option_name);return {type='string_select',value='bio_power_storage'}
+ end}},
+ types={id=function(kind,id) assert(kind=='bionic');return id end},
+ bionics={grant=function(character,id)
+  assert(character==TARGET and id=='bio_power_storage');calls=calls+1;return {ok=true}
+ end}
+}
+BODY
+STORE
+assert(calls==1 and context.data.output=='bio_power_storage')
+""".replace("TARGET", target).replace("OWNER", owner).replace("BODY", "\n".join(lines))
+                    script = script.replace("STORE", "\n".join(stored))
+                    result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+                    self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_string_option_mutator_does_not_use_numeric_display_value(self) -> None:
+        expression = migrate_lua_first.render_participant_string_expression(
+            {"mutator": "game_option", "option": "TEST_OPTION"}, "actor", "actor", None)
+        self.assertIsNotNone(expression)
+        script = r"""
+local services={gameplay={options={get=function() return {type='int',value='42'} end}}}
+assert(not pcall(function() return EXPR end))
+services.gameplay.options.get=function() return nil end
+assert(not pcall(function() return EXPR end))
+""".replace("EXPR", expression)
+        result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
     def test_effect_durations_preserve_signed_and_long_values(self) -> None:
         durations = [(-1.8, -1), ("-10 turns", -10), ("366 days", 31622400),
                      ({"npc_val": "duration"}, -1), ({"math": ["-1.8"]}, -1)]
@@ -19107,7 +19161,7 @@ assert(not ok and string.find(message, 'stale_world', 1, true))
             self.assertIn(
                 'context.data["raised_position"] = location', main
             )
-            self.assertIn('services.options.get("USE_LANG")', main)
+            self.assertIn('services.gameplay.options.get("USE_LANG")', main)
             self.assertIn(
                 "services.martial_arts.technique_definition(", main
             )

--- a/tools/test_migrate_lua_first.py
+++ b/tools/test_migrate_lua_first.py
@@ -16,6 +16,31 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
 class LuaFirstMigrationTest(unittest.TestCase):
     @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_real_gateway_copy_uses_native_copy_between_participants(self) -> None:
+        source = json.loads((REPOSITORY_ROOT / "data/mods/MindOverMatter/powers/teleportation_eoc.json").read_text())
+        effects = [effect for entry in source for effect in entry.get("effect", [])
+                   if isinstance(effect, dict) and effect.get("copy_var") == {"npc_val": "gateway_destination_1"}]
+        self.assertEqual(len(effects), 1)
+        lines = migrate_lua_first.render_static_character_copy_var(effects[0], True, True, "partner")
+        self.assertIsNotNone(lines)
+        script = r"""
+local actor={}
+local partner={}
+local context={data={}}
+local calls=0
+local function service_value(r) assert(r.ok);return r.value end
+local services={variables={copy=function(source,key,target,out)
+ assert(source==partner and key=='gateway_destination_1')
+ assert(target==actor and out=='dilated_gateway_location')
+ calls=calls+1;return {ok=true,value={source_exists=true,destination_existed=false}}
+end}}
+BODY
+assert(calls==1)
+""".replace("BODY", "\n".join(lines))
+        result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
     def test_copy_variable_preserves_owners_types_and_empty_write(self) -> None:
         addresses = [("u_val", "actor", None), ("npc_val", "partner", None),
                      ("context_val", "context.data", None), ("global_val", "globals", None),
@@ -38,6 +63,10 @@ SOURCE_STORE.input=VALUE
 local writes=0
 local function service_value(r) assert(r.ok);return r.value end
 local services={variables={
+ copy=function(source,key,target,out)
+  assert((source or globals)==SOURCE_STORE and (target or globals)==TARGET_STORE)
+  assert(key=='input' and out=='output');writes=writes+1;return {ok=true,value={}}
+ end,
  resolve=function(data,owner,scope,key)
   local store=scope=='global' and globals or scope=='context' and data or owner
   assert(store==SOURCE_STORE and key=='input')

--- a/tools/test_migrate_lua_first.py
+++ b/tools/test_migrate_lua_first.py
@@ -16,6 +16,41 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
 class LuaFirstMigrationTest(unittest.TestCase):
     @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_effect_durations_preserve_signed_and_long_values(self) -> None:
+        durations = [(-1.8, -1), ("-10 turns", -10), ("366 days", 31622400),
+                     ({"npc_val": "duration"}, -1), ({"math": ["-1.8"]}, -1)]
+        for value, expected in durations:
+            with self.subTest(value=value):
+                lines = migrate_lua_first.render_static_false_effect(
+                    {"u_add_effect": "bleed", "duration": value}, True, True, {},
+                    npc_actor_expression="partner")
+                self.assertIsNotNone(lines)
+                script = r"""
+local actor,partner={},{}
+local context={data={}}
+local called=false
+local function service_value(r) assert(r.ok);return r.value end
+local services={
+ types={id=function(kind,id) return id end},
+ variables={resolve=function(data,owner,scope,key)
+  assert(owner==partner and key=='duration');return {ok=true,value={value='-1.8'}}
+ end},
+ gameplay={math={evaluate=function(expression,character)
+  assert(character==actor);return {ok=true,value=-1.8}
+ end}},
+ time={duration=function(value,unit) assert(value==EXPECTED and unit=='turn');return value end},
+ effects={add=function(character,id,duration)
+  assert(character==actor and id=='bleed' and duration==EXPECTED)
+  called=true;return {ok=true}
+ end}
+}
+BODY
+assert(called)
+""".replace("EXPECTED", str(expected)).replace("BODY", "\n".join(lines))
+                result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
     def test_effect_intensity_ranges_preserve_integer_endpoints_and_lazy_reads(self) -> None:
         ranges = [([2.9, -1.9], -1, 2), ([-1.9, 2.9], -1, 2),
                   ([{"u_val": "lo"}, {"npc_val": "hi"}], -1, 2)]

--- a/tools/test_migrate_lua_first.py
+++ b/tools/test_migrate_lua_first.py
@@ -16,6 +16,40 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
 class LuaFirstMigrationTest(unittest.TestCase):
     @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_string_i18n_translates_literals_but_not_stored_variables(self) -> None:
+        cases = [("Hello", True, "translated", "nil"),
+                 ({"str": "Hello", "ctxt": "greeting"}, True, "translated", '"greeting"'),
+                 ({"str_sp": "Hello"}, True, "translated", "nil"),
+                 ({"npc_val": "input"}, True, "stored translation", "nil"),
+                 ("Hello", False, "Hello", "nil")]
+        for value, i18n, expected, translation_context in cases:
+            lines = migrate_lua_first.render_static_character_string_var(
+                {"set_string_var": value, "i18n": i18n, "target_var": {"context_val": "output"}},
+                True, True, "partner")
+            self.assertIsNotNone(lines)
+            script = r"""
+local actor={}
+local partner={input='stored translation'}
+local context={data={}}
+local calls=0
+local function service_value(r) assert(r.ok);return r.value end
+local services={
+ translate=function(text,ctxt)
+  assert(text=='Hello' and ctxt==CTXT);calls=calls+1;return 'translated'
+ end,
+ variables={resolve=function(data,owner,scope,key)
+  assert(owner==partner and scope=='npc');return {ok=true,value={value=owner[key]}}
+ end}
+}
+BODY
+assert(context.data.output==EXPECTED and calls==CALLS)
+""".replace("CTXT", translation_context).replace("BODY", "\n".join(lines))
+            script = script.replace("EXPECTED", migrate_lua_first.lua_quote(expected))
+            script = script.replace("CALLS", "1" if expected == "translated" else "0")
+            result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
     def test_string_tags_expand_after_input_with_dialogue_participants(self) -> None:
         for accepted in (True, False):
             for proven in (True, False):

--- a/tools/test_migrate_lua_first.py
+++ b/tools/test_migrate_lua_first.py
@@ -16,6 +16,29 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
 class LuaFirstMigrationTest(unittest.TestCase):
     @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_real_selector_example_string_setup_preserves_translation(self) -> None:
+        source = json.loads((REPOSITORY_ROOT / "data/json/effects_on_condition/example_eocs.json").read_text())
+        eoc = next(entry for entry in source if entry.get("id") == "EOC_selector_test")
+        effects = eoc["effect"][:3]
+        self.assertTrue(all("set_string_var" in effect for effect in effects))
+        bodies = [migrate_lua_first.render_static_character_string_var(effect, False, False) for effect in effects]
+        self.assertTrue(all(body is not None for body in bodies))
+        script = r"""
+local context={data={}}
+local translated={}
+local services={translate=function(text)
+ translated[#translated+1]=text;return 'localized:'..text
+end}
+BODY
+assert(context.data.title=='localized:EOC Selector Test')
+assert(context.data.name=='name_3')
+assert(context.data.description=='localized:option 3')
+assert(#translated==2)
+""".replace("BODY", "\n".join(line for body in bodies for line in body))
+        result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
     def test_input_translated_variables_preserve_native_evaluation_order(self) -> None:
         lines = migrate_lua_first.render_static_character_string_var(
             {"set_string_var": "original", "target_var": {"context_val": "output"},

--- a/tools/test_migrate_lua_first.py
+++ b/tools/test_migrate_lua_first.py
@@ -16,6 +16,47 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
 class LuaFirstMigrationTest(unittest.TestCase):
     @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_string_defaults_distinguish_stored_null_from_missing(self) -> None:
+        for key in ("u_val", "npc_val", "global_val", "var_val"):
+            for present in (True, False):
+                expression = migrate_lua_first.render_participant_string_expression(
+                    {key: "reference" if key == "var_val" else "input", "default": "fallback"},
+                    "actor", "actor", "partner")
+                self.assertIsNotNone(expression)
+                script = r"""
+local actor,partner={},{}
+local context={data={reference='n_input'}}
+local function service_value(r) assert(r.ok);return r.value end
+local services={variables={resolve=function(data,owner,scope,name)
+ assert(name=='input');return {ok=true,value={exists=PRESENT,value=nil}}
+end}}
+assert(EXPRESSION==(PRESENT and '' or 'fallback'))
+""".replace("PRESENT", "true" if present else "false").replace("EXPRESSION", expression)
+                result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_translated_defaults_do_not_translate_stored_null(self) -> None:
+        for key in ("u_val", "npc_val", "global_val"):
+            for present in (True, False):
+                expression = migrate_lua_first.render_participant_translation_expression(
+                    {key: "input", "default": "fallback"}, "actor", "actor", "partner")
+                self.assertIsNotNone(expression)
+                script = r"""
+local actor,partner={},{}
+local context={data={}}
+local calls=0
+local function service_value(r) assert(r.ok);return r.value end
+local services={variables={resolve=function(data,owner,scope,name)
+ return {ok=true,value={exists=PRESENT,value=nil}}
+end},translate=function(value) calls=calls+1;return 'translated:'..value end}
+assert(EXPRESSION==(PRESENT and '' or 'translated:fallback'))
+assert(calls==(PRESENT and 0 or 1))
+""".replace("PRESENT", "true" if present else "false").replace("EXPRESSION", expression)
+                result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
     def test_real_gateway_copy_uses_native_copy_between_participants(self) -> None:
         source = json.loads((REPOSITORY_ROOT / "data/mods/MindOverMatter/powers/teleportation_eoc.json").read_text())
         effects = [effect for entry in source for effect in entry.get("effect", [])
@@ -189,7 +230,7 @@ local calls=0
 local function service_value(r) assert(r.ok);return r.value end
 local services={
  variables={resolve=function(data,owner,scope,key)
-  assert(owner==partner);return {ok=true,value={value=PRESENT and '' or nil}}
+  assert(owner==partner);return {ok=true,value={exists=PRESENT,value=PRESENT and '' or nil}}
  end},
  translate=function(text,ctxt)
   assert(text=='Fallback' and ctxt=='default');calls=calls+1;return 'translated default'
@@ -1569,7 +1610,8 @@ local actor, partner = {}, {}
 local context = {data={}}
 local function service_value(r) assert(r.ok); return r.value end
 local services = {variables={resolve=function(data, character, scope, key)
- return {ok=true,value={value=character and character[key] or data[key]}}
+ local value = character and character[key] or data[key]
+ return {ok=true,value={exists=value~=nil,value=value}}
 end}}
 local function read() return EXPRESSION end
 assert(read() == 'fallback')

--- a/tools/test_migrate_lua_first.py
+++ b/tools/test_migrate_lua_first.py
@@ -15,6 +15,54 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
 
 class LuaFirstMigrationTest(unittest.TestCase):
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_technique_choice_keeps_alpha_beta_independent_of_string_destination(self) -> None:
+        for selected in ("chosen_technique", ""):
+            with self.subTest(selected=selected):
+                value = {"mutator": "valid_technique", "crit": True, "block_counter": True,
+                         "blacklist": [{"u_val": "excluded"}, {"npc_val": "excluded"}]}
+                expression = migrate_lua_first.render_participant_string_expression(value, "partner", "actor", "partner")
+                lines = migrate_lua_first.render_static_character_string_var(
+                    {"set_string_var": value, "target_var": {"npc_val": "output"}}, True, True, "partner")
+                self.assertIsNotNone(expression)
+                self.assertIsNotNone(lines)
+                script = r"""
+local actor={excluded='alpha_excluded'}
+local partner={excluded='beta_excluded'}
+local context={data={}}
+local calls=0
+local function service_value(r) assert(r.ok);return r.value end
+local services={
+ variables={resolve=function(data,owner,scope,key)
+  assert((owner==actor or owner==partner) and key=='excluded');return {ok=true,value={value=owner[key]}}
+ end,set=function(owner,key,value)
+  assert(owner==partner and key=='output');owner[key]=value;return {ok=true}
+ end},
+ characters={choose_technique=function(attacker,target,options)
+  assert(attacker==actor and target==partner)
+  assert(options.critical and options.block_counter and not options.dodge_counter)
+  assert(options.blacklist[1]=='alpha_excluded' and options.blacklist[2]=='beta_excluded')
+  calls=calls+1;return {ok=true,value={technique={value=SELECTED}}}
+ end}
+}
+assert(EXPR==SELECTED)
+BODY
+assert(calls==2 and partner.output==SELECTED)
+""".replace("SELECTED", migrate_lua_first.lua_quote(selected)).replace("EXPR", expression)
+                script = script.replace("BODY", "\n".join(lines))
+                result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_technique_choice_keeps_unproven_participants_and_invalid_options_partial(self) -> None:
+        value = {"mutator": "valid_technique"}
+        for alpha, beta in ((None, "partner"), ("actor", None)):
+            self.assertIsNone(migrate_lua_first.render_participant_string_expression(value, "actor", alpha, beta))
+        for options in ({"blacklist": ["x"] * 257}, {"crit": 1}, {"blacklist": {}}, {"unknown": True}):
+            self.assertIsNone(migrate_lua_first.render_participant_string_expression(
+                {**value, **options}, "actor", "actor", "partner"))
+        self.assertIsNone(migrate_lua_first.render_static_character_string_var(
+            {"set_string_var": value, "target_var": {"context_val": "output"}}, True, False))
+
     def test_definition_mutators_do_not_invent_missing_variable_owners(self) -> None:
         for mutator, key in (("ma_technique_name", "matec_id"),
                              ("ma_technique_description", "matec_id"), ("mon_faction", "mtype_id")):
@@ -19173,7 +19221,7 @@ assert(not ok and string.find(message, 'stale_world', 1, true))
             self.assertEqual(len(result.converted), 0)
             self.assertEqual(len(result.partial), 1)
             self.assertTrue(result.todos)
-            self.assertTrue(all(todo.category == "semantic_choice" for todo in result.todos))
+            self.assertEqual({todo.category for todo in result.todos}, {"semantic_choice", "manual_rewrite"})
             self.assertIn(
                 'services.messages.add("A translated message", "good")',
                 main,
@@ -19211,7 +19259,7 @@ assert(not ok and string.find(message, 'stale_world', 1, true))
             self.assertIn(
                 "services.martial_arts.technique_definition(", main
             )
-            self.assertIn("services.characters.choose_technique(", main)
+            self.assertNotIn("services.characters.choose_technique(", main)
             self.assertIn("services.text.expand_for(", main)
 
     def test_dialogue_item_popup_uses_native_hand_in_notice(self) -> None:

--- a/tools/test_migrate_lua_first.py
+++ b/tools/test_migrate_lua_first.py
@@ -16,6 +16,54 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
 class LuaFirstMigrationTest(unittest.TestCase):
     @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_copy_variable_preserves_owners_types_and_empty_write(self) -> None:
+        addresses = [("u_val", "actor", None), ("npc_val", "partner", None),
+                     ("context_val", "context.data", None), ("global_val", "globals", None),
+                     ("var_val", "actor", "u_"), ("var_val", "partner", "n_"),
+                     ("var_val", "context.data", "_"), ("var_val", "globals", "")]
+        for source, source_store, source_prefix in addresses:
+            for target, target_store, target_prefix in addresses:
+                for value in ('"text"', '0', 'nil'):
+                    lines = migrate_lua_first.render_static_character_copy_var(
+                        {"copy_var": {source: "source_ref" if source_prefix is not None else "input"},
+                         "target_var": {target: "target_ref" if target_prefix is not None else "output"}},
+                        True, True, "partner")
+                    self.assertIsNotNone(lines)
+                    script = r"""
+local actor={input='alpha'}
+local partner={input='beta'}
+local globals={input='global'}
+local context={data={input='context',source_ref=SOURCE_REF,target_ref=TARGET_REF}}
+SOURCE_STORE.input=VALUE
+local writes=0
+local function service_value(r) assert(r.ok);return r.value end
+local services={variables={
+ resolve=function(data,owner,scope,key)
+  local store=scope=='global' and globals or scope=='context' and data or owner
+  assert(store==SOURCE_STORE and key=='input')
+  return {ok=true,value={exists=store[key]~=nil,value=store[key]}}
+ end,
+ set_resolved=function(data,owner,scope,key,value)
+  local store=scope=='global' and globals or scope=='context' and data or owner
+  assert(store==TARGET_STORE and key=='output' and value==VALUE)
+  writes=writes+1;return {ok=true,value={}}
+ end
+}}
+BODY
+assert(writes==1)
+""".replace("SOURCE_REF", migrate_lua_first.lua_quote((source_prefix or '') + 'input'))
+                    script = script.replace("TARGET_REF", migrate_lua_first.lua_quote((target_prefix or '') + 'output'))
+                    script = script.replace("SOURCE_STORE", source_store).replace("TARGET_STORE", target_store)
+                    script = script.replace("VALUE", value).replace("BODY", "\n".join(lines))
+                    result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+                    self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_copy_variable_keeps_missing_participants_partial(self) -> None:
+        for source in ("u_val", "npc_val", "var_val"):
+            self.assertIsNone(migrate_lua_first.render_static_character_copy_var(
+                {"copy_var": {source: "input"}, "target_var": {"global_val": "output"}}, False, False))
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
     def test_false_branch_string_assignment_preserves_beta_expression(self) -> None:
         lines = migrate_lua_first.render_static_false_effect(
             {"set_string_var": {"npc_val": "input"}, "target_var": {"npc_val": "output"}},
@@ -2774,8 +2822,8 @@ assert(not ok and string.find(message, 'stale_world', 1, true))
             self.assertIn('tostring(services.turn())', main)
             self.assertIn('context.data["required"] ~= nil', main)
             self.assertIn("1 == 1", main)
-            self.assertIn('services.variables.get(actor, "source")', main)
-            self.assertIn('services.variables.remove(actor, "target")', main)
+            self.assertIn('copy_source_key = "u", actor, "source"', main)
+            self.assertNotIn('services.variables.remove(actor, "target")', main)
             self.assertIn(
                 'services.variables.set(\n        actor, "label"',
                 main,

--- a/tools/test_migrate_lua_first.py
+++ b/tools/test_migrate_lua_first.py
@@ -16,6 +16,48 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
 class LuaFirstMigrationTest(unittest.TestCase):
     @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_string_tags_expand_after_input_with_dialogue_participants(self) -> None:
+        for accepted in (True, False):
+            for proven in (True, False):
+                lines = migrate_lua_first.render_static_character_string_var(
+                    {"set_string_var": "original <tag>", "parse_tags": True,
+                     "string_input": {"title": "Title"},
+                     "target_var": {"npc_val": "output"} if proven else {"context_val": "output"}},
+                    proven, proven, "partner" if proven else None)
+                self.assertIsNotNone(lines)
+                script = r"""
+local actor={}
+local partner={}
+local player={}
+local context={data={}}
+local phase=0
+local function service_value(r) assert(r.ok);return r.value end
+local services={
+ characters={avatar=function() return player end},
+ interaction={input_text=function(title,options)
+  assert(phase==0 and title=='Title');phase=1
+  if ACCEPTED then return 'entered <tag>' end
+ end},
+ text={expand_for=function(value,alpha,beta)
+  assert(phase==1 and alpha==ALPHA and beta==BETA);phase=2
+  assert(value==(ACCEPTED and 'entered <tag>' or 'original <tag>'))
+  return {ok=true,value='expanded'}
+ end},
+ variables={set=function(owner,key,value)
+  assert(phase==2 and owner==partner);owner[key]=value
+ end}
+}
+BODY
+assert(phase==2 and DESTINATION.output=='expanded')
+""".replace("ACCEPTED", "true" if accepted else "false")
+                script = script.replace("ALPHA", "actor" if proven else "player")
+                script = script.replace("BETA", "partner" if proven else "player")
+                script = script.replace("DESTINATION", "partner" if proven else "context.data")
+                script = script.replace("BODY", "\n".join(lines))
+                result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
     def test_string_random_choice_evaluates_only_selected_candidate_after_rng(self) -> None:
         lines = migrate_lua_first.render_static_character_string_var(
             {"set_string_var": [{"u_val": "first"}, {"npc_val": "second"}],


### PR DESCRIPTION
Lua effects.add 原先拒绝负持续时间和超过 365 天的持续时间，迁移器还会把动态值夹取到该范围，改变原生 EOC 的行为。现在 effects.add 使用 TimeDuration 已验证的原生有符号回合范围，由 Creature/effect 处理定义上限和到期；迁移器保留符号和长时间，小数回合向零截断。其他时间接口约束保持原状。

验证：低优先级单线程原生测试构建通过；效果语义 10 个用例、2852 条断言通过（seed 20260910，254.311 秒），新增玩家/NPC 的 -10、-1 和 366 天实际 EOC 对照；迁移器 385 项、Lua 契约 80 项（含实际 LuaLS）通过；flake8、变更格式和 git diff --check 通过。生成器已运行，接口清单无差异。未重复全量游戏测试。

仍未验证全部效果领域及所有 586 项；区间继续受现有随机接口范围限制。本 PR 堆叠于 #783，保持草稿。

#### Responsible human
@LYHGLYTX

#### Documentation impact
effects.add 的持续时间说明改为原生有符号范围，并说明原生效果到期规则。

#### Related CCB-Docs PR
https://github.com/CrimsonCrossBunker/CCB-Docs/pull/49 （草稿，合并源码前不发布）

#### Affected documentation IDs
cpp.lua-bridge

#### Generated reference impact
集成收尾时本 PR 将纳入其依赖链上的 Lua API、LuaLS 声明及迁移修复；相关 Platform API／覆盖清单已由生成器刷新，配套说明统一由 CCB-Docs #49 承接。具体通过状态以当前提交的 CI 为准。
