### PR TITLE
fix(lua): 保留动态输入文本和按需翻译的默认值

### DIFF
--- a/ai/lua-first-replacement-ledger.yml
+++ b/ai/lua-first-replacement-ledger.yml
@@ -45,10 +45,10 @@ sources:
   entry_count: 311
 summary:
   total: 776
-  implemented_verified: 0
+  implemented_verified: 1
   implemented_unverified: 89
   bounded_implemented_verified: 0
-  bounded_implemented_unverified: 662
+  bounded_implemented_unverified: 661
   primitive_available_unverified: 8
   planned: 0
   private_adapter: 0
@@ -331,16 +331,16 @@ entries:
   selector: is_day
   target_kind: shared_service
   target: services.gameplay.environment
-  status: bounded_implemented_unverified
+  status: implemented_verified
   legacy_dependency: none
   evidence:
   - data/lua/types/ccb_platform_v1.d.lua
   - data/reference/json/ccb_eoc_conditions.json
-  - src/lua_platform_runtime.cpp
-  - tests/lua_platform_test.cpp
+  - src/lua_platform_runtime_services.cpp
+  - tests/lua_platform_day_semantic_test.cpp
   - tools/migrate_lua_first.py
   - tools/test_migrate_lua_first.py
-  verification: source_only
+  verification: final_semantic_gate
 - inventory: eoc-conditions
   selector: is_outside
   target_kind: shared_service

--- a/data/lua/reference/ccb_platform_api_v1.json
+++ b/data/lua/reference/ccb_platform_api_v1.json
@@ -7,7 +7,7 @@
     "root_class": "CcbPlatformV1"
   },
   "lua_luals": {
-    "class_count": 700,
+    "class_count": 702,
     "classes": [
       {
         "fields": [
@@ -1230,27 +1230,27 @@
       {
         "fields": [
           {
-            "line": 10603,
+            "line": 10620,
             "name": "items",
             "type": "table"
           },
           {
-            "line": 10606,
+            "line": 10623,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 10605,
+            "line": 10622,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 10604,
+            "line": 10621,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 10607,
+            "line": 10624,
             "name": "truncated",
             "type": "boolean"
           }
@@ -2450,67 +2450,67 @@
       {
         "fields": [
           {
-            "line": 10590,
+            "line": 10607,
             "name": "focus",
             "type": "integer"
           },
           {
-            "line": 10592,
+            "line": 10609,
             "name": "hunger",
             "type": "integer"
           },
           {
-            "line": 10586,
+            "line": 10603,
             "name": "moves",
             "type": "integer"
           },
           {
-            "line": 10582,
+            "line": 10599,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 10589,
+            "line": 10606,
             "name": "pain",
             "type": "integer"
           },
           {
-            "line": 10594,
+            "line": 10611,
             "name": "sleepiness",
             "type": "integer"
           },
           {
-            "line": 10591,
+            "line": 10608,
             "name": "speed",
             "type": "integer"
           },
           {
-            "line": 10587,
+            "line": 10604,
             "name": "stamina",
             "type": "integer"
           },
           {
-            "line": 10588,
+            "line": 10605,
             "name": "stamina_max",
             "type": "integer"
           },
           {
-            "line": 10593,
+            "line": 10610,
             "name": "thirst",
             "type": "integer"
           },
           {
-            "line": 10583,
+            "line": 10600,
             "name": "x",
             "type": "integer"
           },
           {
-            "line": 10584,
+            "line": 10601,
             "name": "y",
             "type": "integer"
           },
           {
-            "line": 10585,
+            "line": 10602,
             "name": "z",
             "type": "integer"
           }
@@ -2544,52 +2544,52 @@
       {
         "fields": [
           {
-            "line": 10616,
+            "line": 10633,
             "name": "attitude",
             "type": "string"
           },
           {
-            "line": 10617,
+            "line": 10634,
             "name": "dead",
             "type": "boolean"
           },
           {
-            "line": 10612,
+            "line": 10629,
             "name": "display_name",
             "type": "string"
           },
           {
-            "line": 10615,
+            "line": 10632,
             "name": "distance",
             "type": "integer"
           },
           {
-            "line": 10618,
+            "line": 10635,
             "name": "hp",
             "type": "integer"
           },
           {
-            "line": 10619,
+            "line": 10636,
             "name": "hp_max",
             "type": "integer"
           },
           {
-            "line": 10610,
+            "line": 10627,
             "name": "kind",
             "type": "'avatar'|'npc'|'monster'|'creature'"
           },
           {
-            "line": 10611,
+            "line": 10628,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 10613,
+            "line": 10630,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 10614,
+            "line": 10631,
             "name": "visible",
             "type": "boolean"
           }
@@ -2648,22 +2648,22 @@
       {
         "fields": [
           {
-            "line": 10063,
+            "line": 10080,
             "name": "items",
             "type": "GameId[]"
           },
           {
-            "line": 10065,
+            "line": 10082,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 10064,
+            "line": 10081,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 10066,
+            "line": 10083,
             "name": "truncated",
             "type": "boolean"
           }
@@ -2673,12 +2673,12 @@
       {
         "fields": [
           {
-            "line": 10070,
+            "line": 10087,
             "name": "effects",
             "type": "CcbEffectRelatedIdPage"
           },
           {
-            "line": 10069,
+            "line": 10086,
             "name": "mutations",
             "type": "CcbEffectRelatedIdPage"
           }
@@ -2688,112 +2688,112 @@
       {
         "fields": [
           {
-            "line": 10094,
+            "line": 10111,
             "name": "blocks_effects",
             "type": "CcbEffectRelatedIdPage"
           },
           {
-            "line": 10092,
+            "line": 10109,
             "name": "body_part",
             "type": "GameId"
           },
           {
-            "line": 10075,
+            "line": 10092,
             "name": "description",
             "type": "string"
           },
           {
-            "line": 10079,
+            "line": 10096,
             "name": "duration",
             "type": "TimeDuration"
           },
           {
-            "line": 10089,
+            "line": 10106,
             "name": "duration_add_percent",
             "type": "integer"
           },
           {
-            "line": 10085,
+            "line": 10102,
             "name": "effective_intensity",
             "type": "integer"
           },
           {
-            "line": 10088,
+            "line": 10105,
             "name": "harmful_cough",
             "type": "boolean"
           },
           {
-            "line": 10073,
+            "line": 10090,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 10087,
+            "line": 10104,
             "name": "impairs_movement",
             "type": "boolean"
           },
           {
-            "line": 10082,
+            "line": 10099,
             "name": "intensity",
             "type": "integer"
           },
           {
-            "line": 10090,
+            "line": 10107,
             "name": "intensity_add",
             "type": "integer"
           },
           {
-            "line": 10091,
+            "line": 10108,
             "name": "intensity_duration",
             "type": "TimeDuration"
           },
           {
-            "line": 10080,
+            "line": 10097,
             "name": "maximum_duration",
             "type": "TimeDuration"
           },
           {
-            "line": 10084,
+            "line": 10101,
             "name": "maximum_effective_intensity",
             "type": "integer"
           },
           {
-            "line": 10083,
+            "line": 10100,
             "name": "maximum_intensity",
             "type": "integer"
           },
           {
-            "line": 10077,
+            "line": 10094,
             "name": "mod_source",
             "type": "string"
           },
           {
-            "line": 10074,
+            "line": 10091,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 10086,
+            "line": 10103,
             "name": "permanent",
             "type": "boolean"
           },
           {
-            "line": 10093,
+            "line": 10110,
             "name": "resisted_by",
             "type": "CcbEffectResistanceIds"
           },
           {
-            "line": 10076,
+            "line": 10093,
             "name": "short_description",
             "type": "string"
           },
           {
-            "line": 10081,
+            "line": 10098,
             "name": "start_time",
             "type": "TimePoint"
           },
           {
-            "line": 10078,
+            "line": 10095,
             "name": "uses_body_part_description",
             "type": "boolean"
           }
@@ -2803,7 +2803,7 @@
       {
         "fields": [
           {
-            "line": 10097,
+            "line": 10114,
             "name": "value",
             "type": "CcbEffectSnapshot"
           }
@@ -5211,22 +5211,22 @@
       {
         "fields": [
           {
-            "line": 10598,
+            "line": 10615,
             "name": "count",
             "type": "integer"
           },
           {
-            "line": 10599,
+            "line": 10616,
             "name": "current_id",
             "type": "string"
           },
           {
-            "line": 10600,
+            "line": 10617,
             "name": "desired_id",
             "type": "string"
           },
           {
-            "line": 10597,
+            "line": 10614,
             "name": "items",
             "type": "table"
           }
@@ -6182,22 +6182,22 @@
       {
         "fields": [
           {
-            "line": 10217,
+            "line": 10234,
             "name": "has_capacity",
             "type": "boolean"
           },
           {
-            "line": 10214,
+            "line": 10231,
             "name": "installed_count",
             "type": "integer"
           },
           {
-            "line": 10216,
+            "line": 10233,
             "name": "maximum_power",
             "type": "UnitValue"
           },
           {
-            "line": 10215,
+            "line": 10232,
             "name": "power",
             "type": "UnitValue"
           }
@@ -6493,27 +6493,27 @@
       {
         "fields": [
           {
-            "line": 10557,
+            "line": 10574,
             "name": "environment",
             "type": "CcbPlatformEnvironmentQueries"
           },
           {
-            "line": 10556,
+            "line": 10573,
             "name": "math",
             "type": "CcbPlatformMathApi"
           },
           {
-            "line": 10555,
+            "line": 10572,
             "name": "mods",
             "type": "CcbPlatformModQueries"
           },
           {
-            "line": 10558,
+            "line": 10575,
             "name": "options",
             "type": "CcbPlatformGameplayOptionsApi"
           },
           {
-            "line": 10554,
+            "line": 10571,
             "name": "strings",
             "type": "CcbPlatformStringPredicates"
           }
@@ -6654,17 +6654,17 @@
       {
         "fields": [
           {
-            "line": 10421,
+            "line": 10438,
             "name": "capped",
             "type": "boolean"
           },
           {
-            "line": 10420,
+            "line": 10437,
             "name": "decay_start",
             "type": "TimeDuration"
           },
           {
-            "line": 10419,
+            "line": 10436,
             "name": "duration",
             "type": "TimeDuration"
           }
@@ -6746,32 +6746,32 @@
       {
         "fields": [
           {
-            "line": 10337,
+            "line": 10354,
             "name": "category",
             "type": "GameId"
           },
           {
-            "line": 10333,
+            "line": 10350,
             "name": "changed",
             "type": "boolean"
           },
           {
-            "line": 10334,
+            "line": 10351,
             "name": "forgotten_count",
             "type": "integer"
           },
           {
-            "line": 10336,
+            "line": 10353,
             "name": "known_after",
             "type": "integer"
           },
           {
-            "line": 10335,
+            "line": 10352,
             "name": "known_before",
             "type": "integer"
           },
           {
-            "line": 10338,
+            "line": 10355,
             "name": "subcategory",
             "type": "string"
           }
@@ -7377,47 +7377,47 @@
       {
         "fields": [
           {
-            "line": 10747,
+            "line": 10764,
             "name": "ModDefinition",
             "type": "fun(options:"
           },
           {
-            "line": 10748,
+            "line": 10765,
             "name": "content",
             "type": "CcbPlatformContent"
           },
           {
-            "line": 10750,
+            "line": 10767,
             "name": "dialogue",
             "type": "CcbPlatformDialogueApi"
           },
           {
-            "line": 10746,
+            "line": 10763,
             "name": "platform_version",
             "type": "1"
           },
           {
-            "line": 10753,
+            "line": 10770,
             "name": "presentation",
             "type": "CcbPlatformPresentation"
           },
           {
-            "line": 10749,
+            "line": 10766,
             "name": "runtime",
             "type": "CcbPlatformRuntime"
           },
           {
-            "line": 10754,
+            "line": 10771,
             "name": "services",
             "type": "CcbPlatformServices"
           },
           {
-            "line": 10751,
+            "line": 10768,
             "name": "state",
             "type": "CcbPlatformState"
           },
           {
-            "line": 10752,
+            "line": 10769,
             "name": "tasks",
             "type": "CcbPlatformTasks"
           }
@@ -7486,37 +7486,37 @@
       {
         "fields": [
           {
-            "line": 10254,
+            "line": 10271,
             "name": "batch",
             "type": "integer"
           },
           {
-            "line": 10253,
+            "line": 10270,
             "name": "has_more",
             "type": "boolean"
           },
           {
-            "line": 10248,
+            "line": 10265,
             "name": "items",
             "type": "table"
           },
           {
-            "line": 10251,
+            "line": 10268,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 10250,
+            "line": 10267,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 10252,
+            "line": 10269,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 10249,
+            "line": 10266,
             "name": "total",
             "type": "integer"
           }
@@ -7526,47 +7526,47 @@
       {
         "fields": [
           {
-            "line": 10239,
+            "line": 10256,
             "name": "batch",
             "type": "integer"
           },
           {
-            "line": 10242,
+            "line": 10259,
             "name": "craftable",
             "type": "boolean"
           },
           {
-            "line": 10245,
+            "line": 10262,
             "name": "flag",
             "type": "string"
           },
           {
-            "line": 10240,
+            "line": 10257,
             "name": "include_obsolete",
             "type": "boolean"
           },
           {
-            "line": 10241,
+            "line": 10258,
             "name": "known",
             "type": "boolean"
           },
           {
-            "line": 10238,
+            "line": 10255,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 10237,
+            "line": 10254,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 10244,
+            "line": 10261,
             "name": "result",
             "type": "GameId"
           },
           {
-            "line": 10243,
+            "line": 10260,
             "name": "skill",
             "type": "GameId"
           }
@@ -7639,17 +7639,17 @@
       {
         "fields": [
           {
-            "line": 10259,
+            "line": 10276,
             "name": "batch",
             "type": "integer"
           },
           {
-            "line": 10258,
+            "line": 10275,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 10257,
+            "line": 10274,
             "name": "offset",
             "type": "integer"
           }
@@ -7762,172 +7762,172 @@
       {
         "fields": [
           {
-            "line": 10392,
+            "line": 10409,
             "name": "area",
             "type": "string"
           },
           {
-            "line": 10394,
+            "line": 10411,
             "name": "attack_vectors",
             "type": "CcbTechniqueIdPage"
           },
           {
-            "line": 10367,
+            "line": 10384,
             "name": "avatar_message",
             "type": "string"
           },
           {
-            "line": 10377,
+            "line": 10394,
             "name": "block_counter",
             "type": "boolean"
           },
           {
-            "line": 10373,
+            "line": 10390,
             "name": "critical_compatible",
             "type": "boolean"
           },
           {
-            "line": 10372,
+            "line": 10389,
             "name": "critical_only",
             "type": "boolean"
           },
           {
-            "line": 10369,
+            "line": 10386,
             "name": "defensive",
             "type": "boolean"
           },
           {
-            "line": 10364,
+            "line": 10381,
             "name": "description",
             "type": "string"
           },
           {
-            "line": 10380,
+            "line": 10397,
             "name": "disarms",
             "type": "boolean"
           },
           {
-            "line": 10376,
+            "line": 10393,
             "name": "dodge_counter",
             "type": "boolean"
           },
           {
-            "line": 10387,
+            "line": 10404,
             "name": "down_duration",
             "type": "integer"
           },
           {
-            "line": 10371,
+            "line": 10388,
             "name": "dummy",
             "type": "boolean"
           },
           {
-            "line": 10395,
+            "line": 10412,
             "name": "eocs",
             "type": "CcbTechniqueIdPage"
           },
           {
-            "line": 10393,
+            "line": 10410,
             "name": "flags",
             "type": "CcbTechniqueFlagPage"
           },
           {
-            "line": 10365,
+            "line": 10382,
             "name": "flavor_description",
             "type": "string"
           },
           {
-            "line": 10366,
+            "line": 10383,
             "name": "goal",
             "type": "string"
           },
           {
-            "line": 10379,
+            "line": 10396,
             "name": "grab_break",
             "type": "boolean"
           },
           {
-            "line": 10362,
+            "line": 10379,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 10389,
+            "line": 10406,
             "name": "knockback_distance",
             "type": "integer"
           },
           {
-            "line": 10391,
+            "line": 10408,
             "name": "knockback_follow",
             "type": "boolean"
           },
           {
-            "line": 10390,
+            "line": 10407,
             "name": "knockback_spread",
             "type": "number"
           },
           {
-            "line": 10378,
+            "line": 10395,
             "name": "miss_recovery",
             "type": "boolean"
           },
           {
-            "line": 10363,
+            "line": 10380,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 10382,
+            "line": 10399,
             "name": "needs_ammo",
             "type": "boolean"
           },
           {
-            "line": 10368,
+            "line": 10385,
             "name": "npc_message",
             "type": "string"
           },
           {
-            "line": 10375,
+            "line": 10392,
             "name": "reach_compatible",
             "type": "boolean"
           },
           {
-            "line": 10374,
+            "line": 10391,
             "name": "reach_only",
             "type": "boolean"
           },
           {
-            "line": 10386,
+            "line": 10403,
             "name": "repeat_max",
             "type": "integer"
           },
           {
-            "line": 10385,
+            "line": 10402,
             "name": "repeat_min",
             "type": "integer"
           },
           {
-            "line": 10370,
+            "line": 10387,
             "name": "side_switch",
             "type": "boolean"
           },
           {
-            "line": 10388,
+            "line": 10405,
             "name": "stun_duration",
             "type": "integer"
           },
           {
-            "line": 10381,
+            "line": 10398,
             "name": "take_weapon",
             "type": "boolean"
           },
           {
-            "line": 10383,
+            "line": 10400,
             "name": "wall_adjacent",
             "type": "boolean"
           },
           {
-            "line": 10384,
+            "line": 10401,
             "name": "weight",
             "type": "integer"
           }
@@ -7937,22 +7937,22 @@
       {
         "fields": [
           {
-            "line": 10356,
+            "line": 10373,
             "name": "items",
             "type": "string[]"
           },
           {
-            "line": 10358,
+            "line": 10375,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 10357,
+            "line": 10374,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 10359,
+            "line": 10376,
             "name": "truncated",
             "type": "boolean"
           }
@@ -7962,22 +7962,22 @@
       {
         "fields": [
           {
-            "line": 10350,
+            "line": 10367,
             "name": "items",
             "type": "GameId[]"
           },
           {
-            "line": 10352,
+            "line": 10369,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 10351,
+            "line": 10368,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 10353,
+            "line": 10370,
             "name": "truncated",
             "type": "boolean"
           }
@@ -7987,22 +7987,22 @@
       {
         "fields": [
           {
-            "line": 10641,
+            "line": 10658,
             "name": "season_id",
             "type": "string"
           },
           {
-            "line": 10642,
+            "line": 10659,
             "name": "season_name",
             "type": "string"
           },
           {
-            "line": 10639,
+            "line": 10656,
             "name": "turn",
             "type": "integer"
           },
           {
-            "line": 10640,
+            "line": 10657,
             "name": "year",
             "type": "integer"
           }
@@ -8506,6 +8506,31 @@
       {
         "fields": [],
         "name": "CcbTypesApi"
+      },
+      {
+        "fields": [
+          {
+            "line": 10018,
+            "name": "value",
+            "type": "CcbVariableCopyValue"
+          }
+        ],
+        "name": "CcbVariableCopyResult"
+      },
+      {
+        "fields": [
+          {
+            "line": 10015,
+            "name": "destination_existed",
+            "type": "boolean"
+          },
+          {
+            "line": 10014,
+            "name": "source_exists",
+            "type": "boolean"
+          }
+        ],
+        "name": "CcbVariableCopyValue"
       },
       {
         "fields": [
@@ -9407,22 +9432,22 @@
       {
         "fields": [
           {
-            "line": 10645,
+            "line": 10662,
             "name": "id",
             "type": "string"
           },
           {
-            "line": 10646,
+            "line": 10663,
             "name": "temperature_c",
             "type": "number"
           },
           {
-            "line": 10648,
+            "line": 10665,
             "name": "wind_direction",
             "type": "number"
           },
           {
-            "line": 10647,
+            "line": 10664,
             "name": "wind_speed",
             "type": "number"
           }
@@ -20078,7 +20103,7 @@
         "name": "ZoneTypeDefinitionOptions"
       }
     ],
-    "function_count": 1278,
+    "function_count": 1279,
     "functions": [
       {
         "line": "2713",
@@ -20621,43 +20646,43 @@
         "parameters": "character, body_part_limit"
       },
       {
-        "line": "10631",
+        "line": "10648",
         "name": "nearby",
         "owner": "CcbCreaturesApi",
         "parameters": "observer, options"
       },
       {
-        "line": "10626",
+        "line": "10643",
         "name": "snapshot",
         "owner": "CcbCreaturesApi",
         "parameters": "handle"
       },
       {
-        "line": "10636",
+        "line": "10653",
         "name": "visible_monsters",
         "owner": "CcbCreaturesApi",
         "parameters": "observer, direction"
       },
       {
-        "line": "10109",
+        "line": "10126",
         "name": "add",
         "owner": "CcbEffectsApi",
         "parameters": "character, effect, duration, options"
       },
       {
-        "line": "10124",
+        "line": "10141",
         "name": "get",
         "owner": "CcbEffectsApi",
         "parameters": "character, effect, body_part"
       },
       {
-        "line": "10117",
+        "line": "10134",
         "name": "has",
         "owner": "CcbEffectsApi",
         "parameters": "character, effect, body_part, intensity"
       },
       {
-        "line": "10131",
+        "line": "10148",
         "name": "remove",
         "owner": "CcbEffectsApi",
         "parameters": "character, effect, body_part"
@@ -21329,61 +21354,61 @@
         "parameters": "character, morale"
       },
       {
-        "line": "10170",
+        "line": "10187",
         "name": "grant",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation, variant"
       },
       {
-        "line": "10140",
+        "line": "10157",
         "name": "has",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation"
       },
       {
-        "line": "10154",
+        "line": "10171",
         "name": "is_purifiable",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation"
       },
       {
-        "line": "10147",
+        "line": "10164",
         "name": "is_visible_to",
         "owner": "CcbMutationsApi",
         "parameters": "observed, observer, mutation"
       },
       {
-        "line": "10199",
+        "line": "10216",
         "name": "mutate_category",
         "owner": "CcbMutationsApi",
         "parameters": "character, category, use_vitamins, true_random"
       },
       {
-        "line": "10177",
+        "line": "10194",
         "name": "remove",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation"
       },
       {
-        "line": "10191",
+        "line": "10208",
         "name": "remove_category",
         "owner": "CcbMutationsApi",
         "parameters": "character, category"
       },
       {
-        "line": "10208",
+        "line": "10225",
         "name": "remove_type",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation_type"
       },
       {
-        "line": "10185",
+        "line": "10202",
         "name": "set_active",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation, active"
       },
       {
-        "line": "10162",
+        "line": "10179",
         "name": "set_purifiable",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation, purifiable"
@@ -21935,19 +21960,19 @@
         "parameters": "character_handle, npc_handle, duration"
       },
       {
-        "line": "10228",
+        "line": "10245",
         "name": "grant",
         "owner": "CcbPlatformBionicsApi",
         "parameters": "character, id"
       },
       {
-        "line": "10234",
+        "line": "10251",
         "name": "remove_type",
         "owner": "CcbPlatformBionicsApi",
         "parameters": "character, id"
       },
       {
-        "line": "10222",
+        "line": "10239",
         "name": "summary",
         "owner": "CcbPlatformBionicsApi",
         "parameters": "character"
@@ -23687,67 +23712,67 @@
         "parameters": "dimension"
       },
       {
-        "line": "10498",
+        "line": "10515",
         "name": "dimension",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": ""
       },
       {
-        "line": "10536",
+        "line": "10553",
         "name": "field_exists",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position, field_id"
       },
       {
-        "line": "10519",
+        "line": "10536",
         "name": "furniture_has_flag",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position, flag"
       },
       {
-        "line": "10531",
+        "line": "10548",
         "name": "furniture_id",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position"
       },
       {
-        "line": "10546",
+        "line": "10563",
         "name": "is_indoor_tile",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position"
       },
       {
-        "line": "10502",
+        "line": "10519",
         "name": "is_night",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": ""
       },
       {
-        "line": "10506",
+        "line": "10523",
         "name": "is_outside",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position"
       },
       {
-        "line": "10513",
+        "line": "10530",
         "name": "line_of_sight",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "from, to, range, with_fields"
       },
       {
-        "line": "10551",
+        "line": "10568",
         "name": "safe_mode_dangerous",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "direction"
       },
       {
-        "line": "10541",
+        "line": "10558",
         "name": "terrain_has_flag",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position, flag"
       },
       {
-        "line": "10525",
+        "line": "10542",
         "name": "terrain_id",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position"
@@ -23825,31 +23850,31 @@
         "parameters": "id"
       },
       {
-        "line": "10416",
+        "line": "10433",
         "name": "forget",
         "owner": "CcbPlatformMartialArtsApi",
         "parameters": "character, id"
       },
       {
-        "line": "10410",
+        "line": "10427",
         "name": "learn",
         "owner": "CcbPlatformMartialArtsApi",
         "parameters": "character, id"
       },
       {
-        "line": "10403",
+        "line": "10420",
         "name": "technique_definition",
         "owner": "CcbPlatformMartialArtsApi",
         "parameters": "id"
       },
       {
-        "line": "10578",
+        "line": "10595",
         "name": "apply",
         "owner": "CcbPlatformMathApi",
         "parameters": "expression, actor, context"
       },
       {
-        "line": "10571",
+        "line": "10588",
         "name": "evaluate",
         "owner": "CcbPlatformMathApi",
         "parameters": "expression, actor, context"
@@ -23873,7 +23898,7 @@
         "parameters": "message, type"
       },
       {
-        "line": "10492",
+        "line": "10509",
         "name": "is_loaded",
         "owner": "CcbPlatformModQueries",
         "parameters": "mod_id"
@@ -23885,13 +23910,13 @@
         "parameters": "id"
       },
       {
-        "line": "10433",
+        "line": "10450",
         "name": "add",
         "owner": "CcbPlatformMoraleApi",
         "parameters": "character, id, bonus, max_bonus, options"
       },
       {
-        "line": "10439",
+        "line": "10456",
         "name": "remove",
         "owner": "CcbPlatformMoraleApi",
         "parameters": "character, id"
@@ -23957,97 +23982,97 @@
         "parameters": "file, volume"
       },
       {
-        "line": "10452",
+        "line": "10469",
         "name": "chance",
         "owner": "CcbPlatformRandomApi",
         "parameters": "numerator, denominator"
       },
       {
-        "line": "10474",
+        "line": "10491",
         "name": "contested",
         "owner": "CcbPlatformRandomApi",
         "parameters": "check, difficulty, die_size"
       },
       {
-        "line": "10447",
+        "line": "10464",
         "name": "int",
         "owner": "CcbPlatformRandomApi",
         "parameters": "minimum, maximum"
       },
       {
-        "line": "10456",
+        "line": "10473",
         "name": "one_in",
         "owner": "CcbPlatformRandomApi",
         "parameters": "denominator"
       },
       {
-        "line": "10461",
+        "line": "10478",
         "name": "probability",
         "owner": "CcbPlatformRandomApi",
         "parameters": "numerator, denominator"
       },
       {
-        "line": "10468",
+        "line": "10485",
         "name": "sample_integers",
         "owner": "CcbPlatformRandomApi",
         "parameters": "minimum, maximum, count, with_replacement"
       },
       {
-        "line": "10278",
+        "line": "10295",
         "name": "all",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, options"
       },
       {
-        "line": "10288",
+        "line": "10305",
         "name": "by_flag",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "flag, character, options"
       },
       {
-        "line": "10283",
+        "line": "10300",
         "name": "by_skill",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "skill, character, options"
       },
       {
-        "line": "10330",
+        "line": "10347",
         "name": "forget",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, id"
       },
       {
-        "line": "10347",
+        "line": "10364",
         "name": "forget_category",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, category, subcategory"
       },
       {
-        "line": "10293",
+        "line": "10310",
         "name": "get",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, id, batch"
       },
       {
-        "line": "10297",
+        "line": "10314",
         "name": "has_flag",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "id, flag"
       },
       {
-        "line": "10318",
+        "line": "10335",
         "name": "knows",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, id"
       },
       {
-        "line": "10324",
+        "line": "10341",
         "name": "learn",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, id"
       },
       {
-        "line": "10274",
+        "line": "10291",
         "name": "list",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, options"
@@ -24089,115 +24114,115 @@
         "parameters": "event_name, handler_id"
       },
       {
-        "line": "10737",
+        "line": "10754",
         "name": "activity_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10727",
+        "line": "10744",
         "name": "bionics_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10674",
+        "line": "10691",
         "name": "character_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character"
       },
       {
-        "line": "10717",
+        "line": "10734",
         "name": "current_tile_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, field_limit"
       },
       {
-        "line": "10695",
+        "line": "10712",
         "name": "effects_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10705",
+        "line": "10722",
         "name": "equipment_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10690",
+        "line": "10707",
         "name": "inventory_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10712",
+        "line": "10729",
         "name": "item_contents_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, item_handle, offset, limit"
       },
       {
-        "line": "10650",
+        "line": "10667",
         "name": "message",
         "owner": "CcbPlatformServices",
         "parameters": "text"
       },
       {
-        "line": "10732",
+        "line": "10749",
         "name": "missions_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10678",
+        "line": "10695",
         "name": "movement_modes_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character"
       },
       {
-        "line": "10722",
+        "line": "10739",
         "name": "mutations_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10743",
+        "line": "10760",
         "name": "nearby_creatures_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, radius, limit"
       },
       {
-        "line": "10700",
+        "line": "10717",
         "name": "skills_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10681",
+        "line": "10698",
         "name": "time_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": ""
       },
       {
-        "line": "10657",
+        "line": "10674",
         "name": "translate",
         "owner": "CcbPlatformServices",
         "parameters": "text, context"
       },
       {
-        "line": "10667",
+        "line": "10684",
         "name": "translate_plural",
         "owner": "CcbPlatformServices",
         "parameters": "singular, plural, count, context"
       },
       {
-        "line": "10670",
+        "line": "10687",
         "name": "turn",
         "owner": "CcbPlatformServices",
         "parameters": ""
       },
       {
-        "line": "10684",
+        "line": "10701",
         "name": "weather_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": ""
@@ -24269,13 +24294,13 @@
         "parameters": "key, value"
       },
       {
-        "line": "10485",
+        "line": "10502",
         "name": "all_equal",
         "owner": "CcbPlatformStringPredicates",
         "parameters": "values"
       },
       {
-        "line": "10481",
+        "line": "10498",
         "name": "any_equal",
         "owner": "CcbPlatformStringPredicates",
         "parameters": "values"
@@ -24365,19 +24390,19 @@
         "parameters": "avatar, target, options"
       },
       {
-        "line": "10312",
+        "line": "10329",
         "name": "for_recipe",
         "owner": "CcbRequirementsApi",
         "parameters": "character, id, batch"
       },
       {
-        "line": "10307",
+        "line": "10324",
         "name": "get",
         "owner": "CcbRequirementsApi",
         "parameters": "character, id, batch"
       },
       {
-        "line": "10302",
+        "line": "10319",
         "name": "list",
         "owner": "CcbRequirementsApi",
         "parameters": "character, options"
@@ -24437,49 +24462,55 @@
         "parameters": ""
       },
       {
-        "line": "10016",
+        "line": "10028",
+        "name": "copy",
+        "owner": "CcbVariablesApi",
+        "parameters": "source_owner, source_key, destination_owner, destination_key"
+      },
+      {
+        "line": "10033",
         "name": "get",
         "owner": "CcbVariablesApi",
         "parameters": "character, key"
       },
       {
-        "line": "10033",
+        "line": "10050",
         "name": "get_global",
         "owner": "CcbVariablesApi",
         "parameters": "key"
       },
       {
-        "line": "10029",
+        "line": "10046",
         "name": "remove",
         "owner": "CcbVariablesApi",
         "parameters": "character, key"
       },
       {
-        "line": "10042",
+        "line": "10059",
         "name": "remove_global",
         "owner": "CcbVariablesApi",
         "parameters": "key"
       },
       {
-        "line": "10051",
+        "line": "10068",
         "name": "resolve",
         "owner": "CcbVariablesApi",
         "parameters": "context, actor, scope, key"
       },
       {
-        "line": "10024",
+        "line": "10041",
         "name": "set",
         "owner": "CcbVariablesApi",
         "parameters": "character, key, value"
       },
       {
-        "line": "10038",
+        "line": "10055",
         "name": "set_global",
         "owner": "CcbVariablesApi",
         "parameters": "key, value"
       },
       {
-        "line": "10060",
+        "line": "10077",
         "name": "set_resolved",
         "owner": "CcbVariablesApi",
         "parameters": "context, actor, scope, key, value"
@@ -30385,47 +30416,47 @@
   "public_root": {
     "fields": [
       {
-        "line": 10747,
+        "line": 10764,
         "name": "ModDefinition",
         "type": "fun(options:"
       },
       {
-        "line": 10748,
+        "line": 10765,
         "name": "content",
         "type": "CcbPlatformContent"
       },
       {
-        "line": 10750,
+        "line": 10767,
         "name": "dialogue",
         "type": "CcbPlatformDialogueApi"
       },
       {
-        "line": 10746,
+        "line": 10763,
         "name": "platform_version",
         "type": "1"
       },
       {
-        "line": 10753,
+        "line": 10770,
         "name": "presentation",
         "type": "CcbPlatformPresentation"
       },
       {
-        "line": 10749,
+        "line": 10766,
         "name": "runtime",
         "type": "CcbPlatformRuntime"
       },
       {
-        "line": 10754,
+        "line": 10771,
         "name": "services",
         "type": "CcbPlatformServices"
       },
       {
-        "line": 10751,
+        "line": 10768,
         "name": "state",
         "type": "CcbPlatformState"
       },
       {
-        "line": 10752,
+        "line": 10769,
         "name": "tasks",
         "type": "CcbPlatformTasks"
       }

--- a/data/lua/reference/ccb_platform_api_v1.json
+++ b/data/lua/reference/ccb_platform_api_v1.json
@@ -1230,27 +1230,27 @@
       {
         "fields": [
           {
-            "line": 10601,
+            "line": 10603,
             "name": "items",
             "type": "table"
           },
           {
-            "line": 10604,
+            "line": 10606,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 10603,
+            "line": 10605,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 10602,
+            "line": 10604,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 10605,
+            "line": 10607,
             "name": "truncated",
             "type": "boolean"
           }
@@ -2450,67 +2450,67 @@
       {
         "fields": [
           {
-            "line": 10588,
+            "line": 10590,
             "name": "focus",
             "type": "integer"
           },
           {
-            "line": 10590,
+            "line": 10592,
             "name": "hunger",
             "type": "integer"
           },
           {
-            "line": 10584,
+            "line": 10586,
             "name": "moves",
             "type": "integer"
           },
           {
-            "line": 10580,
+            "line": 10582,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 10587,
+            "line": 10589,
             "name": "pain",
             "type": "integer"
           },
           {
-            "line": 10592,
+            "line": 10594,
             "name": "sleepiness",
             "type": "integer"
           },
           {
-            "line": 10589,
+            "line": 10591,
             "name": "speed",
             "type": "integer"
           },
           {
-            "line": 10585,
+            "line": 10587,
             "name": "stamina",
             "type": "integer"
           },
           {
-            "line": 10586,
+            "line": 10588,
             "name": "stamina_max",
             "type": "integer"
           },
           {
-            "line": 10591,
+            "line": 10593,
             "name": "thirst",
             "type": "integer"
           },
           {
-            "line": 10581,
+            "line": 10583,
             "name": "x",
             "type": "integer"
           },
           {
-            "line": 10582,
+            "line": 10584,
             "name": "y",
             "type": "integer"
           },
           {
-            "line": 10583,
+            "line": 10585,
             "name": "z",
             "type": "integer"
           }
@@ -2544,52 +2544,52 @@
       {
         "fields": [
           {
-            "line": 10614,
+            "line": 10616,
             "name": "attitude",
             "type": "string"
           },
           {
-            "line": 10615,
+            "line": 10617,
             "name": "dead",
             "type": "boolean"
           },
           {
-            "line": 10610,
+            "line": 10612,
             "name": "display_name",
             "type": "string"
           },
           {
-            "line": 10613,
+            "line": 10615,
             "name": "distance",
             "type": "integer"
           },
           {
-            "line": 10616,
+            "line": 10618,
             "name": "hp",
             "type": "integer"
           },
           {
-            "line": 10617,
+            "line": 10619,
             "name": "hp_max",
             "type": "integer"
           },
           {
-            "line": 10608,
+            "line": 10610,
             "name": "kind",
             "type": "'avatar'|'npc'|'monster'|'creature'"
           },
           {
-            "line": 10609,
+            "line": 10611,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 10611,
+            "line": 10613,
             "name": "position",
             "type": "TripointCoord"
           },
           {
-            "line": 10612,
+            "line": 10614,
             "name": "visible",
             "type": "boolean"
           }
@@ -2648,22 +2648,22 @@
       {
         "fields": [
           {
-            "line": 10061,
+            "line": 10063,
             "name": "items",
             "type": "GameId[]"
           },
           {
-            "line": 10063,
+            "line": 10065,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 10062,
+            "line": 10064,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 10064,
+            "line": 10066,
             "name": "truncated",
             "type": "boolean"
           }
@@ -2673,12 +2673,12 @@
       {
         "fields": [
           {
-            "line": 10068,
+            "line": 10070,
             "name": "effects",
             "type": "CcbEffectRelatedIdPage"
           },
           {
-            "line": 10067,
+            "line": 10069,
             "name": "mutations",
             "type": "CcbEffectRelatedIdPage"
           }
@@ -2688,112 +2688,112 @@
       {
         "fields": [
           {
-            "line": 10092,
+            "line": 10094,
             "name": "blocks_effects",
             "type": "CcbEffectRelatedIdPage"
           },
           {
-            "line": 10090,
+            "line": 10092,
             "name": "body_part",
             "type": "GameId"
           },
           {
-            "line": 10073,
+            "line": 10075,
             "name": "description",
             "type": "string"
           },
           {
-            "line": 10077,
+            "line": 10079,
             "name": "duration",
             "type": "TimeDuration"
           },
           {
-            "line": 10087,
+            "line": 10089,
             "name": "duration_add_percent",
             "type": "integer"
           },
           {
-            "line": 10083,
+            "line": 10085,
             "name": "effective_intensity",
             "type": "integer"
           },
           {
-            "line": 10086,
+            "line": 10088,
             "name": "harmful_cough",
             "type": "boolean"
           },
           {
-            "line": 10071,
+            "line": 10073,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 10085,
+            "line": 10087,
             "name": "impairs_movement",
             "type": "boolean"
           },
           {
-            "line": 10080,
+            "line": 10082,
             "name": "intensity",
             "type": "integer"
           },
           {
-            "line": 10088,
+            "line": 10090,
             "name": "intensity_add",
             "type": "integer"
           },
           {
-            "line": 10089,
+            "line": 10091,
             "name": "intensity_duration",
             "type": "TimeDuration"
           },
           {
-            "line": 10078,
+            "line": 10080,
             "name": "maximum_duration",
             "type": "TimeDuration"
           },
           {
-            "line": 10082,
+            "line": 10084,
             "name": "maximum_effective_intensity",
             "type": "integer"
           },
           {
-            "line": 10081,
+            "line": 10083,
             "name": "maximum_intensity",
             "type": "integer"
           },
           {
-            "line": 10075,
+            "line": 10077,
             "name": "mod_source",
             "type": "string"
           },
           {
-            "line": 10072,
+            "line": 10074,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 10084,
+            "line": 10086,
             "name": "permanent",
             "type": "boolean"
           },
           {
-            "line": 10091,
+            "line": 10093,
             "name": "resisted_by",
             "type": "CcbEffectResistanceIds"
           },
           {
-            "line": 10074,
+            "line": 10076,
             "name": "short_description",
             "type": "string"
           },
           {
-            "line": 10079,
+            "line": 10081,
             "name": "start_time",
             "type": "TimePoint"
           },
           {
-            "line": 10076,
+            "line": 10078,
             "name": "uses_body_part_description",
             "type": "boolean"
           }
@@ -2803,7 +2803,7 @@
       {
         "fields": [
           {
-            "line": 10095,
+            "line": 10097,
             "name": "value",
             "type": "CcbEffectSnapshot"
           }
@@ -5211,22 +5211,22 @@
       {
         "fields": [
           {
-            "line": 10596,
+            "line": 10598,
             "name": "count",
             "type": "integer"
           },
           {
-            "line": 10597,
+            "line": 10599,
             "name": "current_id",
             "type": "string"
           },
           {
-            "line": 10598,
+            "line": 10600,
             "name": "desired_id",
             "type": "string"
           },
           {
-            "line": 10595,
+            "line": 10597,
             "name": "items",
             "type": "table"
           }
@@ -6182,22 +6182,22 @@
       {
         "fields": [
           {
-            "line": 10215,
+            "line": 10217,
             "name": "has_capacity",
             "type": "boolean"
           },
           {
-            "line": 10212,
+            "line": 10214,
             "name": "installed_count",
             "type": "integer"
           },
           {
-            "line": 10214,
+            "line": 10216,
             "name": "maximum_power",
             "type": "UnitValue"
           },
           {
-            "line": 10213,
+            "line": 10215,
             "name": "power",
             "type": "UnitValue"
           }
@@ -6493,27 +6493,27 @@
       {
         "fields": [
           {
-            "line": 10555,
+            "line": 10557,
             "name": "environment",
             "type": "CcbPlatformEnvironmentQueries"
           },
           {
-            "line": 10554,
+            "line": 10556,
             "name": "math",
             "type": "CcbPlatformMathApi"
           },
           {
-            "line": 10553,
+            "line": 10555,
             "name": "mods",
             "type": "CcbPlatformModQueries"
           },
           {
-            "line": 10556,
+            "line": 10558,
             "name": "options",
             "type": "CcbPlatformGameplayOptionsApi"
           },
           {
-            "line": 10552,
+            "line": 10554,
             "name": "strings",
             "type": "CcbPlatformStringPredicates"
           }
@@ -6654,17 +6654,17 @@
       {
         "fields": [
           {
-            "line": 10419,
+            "line": 10421,
             "name": "capped",
             "type": "boolean"
           },
           {
-            "line": 10418,
+            "line": 10420,
             "name": "decay_start",
             "type": "TimeDuration"
           },
           {
-            "line": 10417,
+            "line": 10419,
             "name": "duration",
             "type": "TimeDuration"
           }
@@ -6746,32 +6746,32 @@
       {
         "fields": [
           {
-            "line": 10335,
+            "line": 10337,
             "name": "category",
             "type": "GameId"
           },
           {
-            "line": 10331,
+            "line": 10333,
             "name": "changed",
             "type": "boolean"
           },
           {
-            "line": 10332,
+            "line": 10334,
             "name": "forgotten_count",
             "type": "integer"
           },
           {
-            "line": 10334,
+            "line": 10336,
             "name": "known_after",
             "type": "integer"
           },
           {
-            "line": 10333,
+            "line": 10335,
             "name": "known_before",
             "type": "integer"
           },
           {
-            "line": 10336,
+            "line": 10338,
             "name": "subcategory",
             "type": "string"
           }
@@ -7377,47 +7377,47 @@
       {
         "fields": [
           {
-            "line": 10745,
+            "line": 10747,
             "name": "ModDefinition",
             "type": "fun(options:"
           },
           {
-            "line": 10746,
+            "line": 10748,
             "name": "content",
             "type": "CcbPlatformContent"
           },
           {
-            "line": 10748,
+            "line": 10750,
             "name": "dialogue",
             "type": "CcbPlatformDialogueApi"
           },
           {
-            "line": 10744,
+            "line": 10746,
             "name": "platform_version",
             "type": "1"
           },
           {
-            "line": 10751,
+            "line": 10753,
             "name": "presentation",
             "type": "CcbPlatformPresentation"
           },
           {
-            "line": 10747,
+            "line": 10749,
             "name": "runtime",
             "type": "CcbPlatformRuntime"
           },
           {
-            "line": 10752,
+            "line": 10754,
             "name": "services",
             "type": "CcbPlatformServices"
           },
           {
-            "line": 10749,
+            "line": 10751,
             "name": "state",
             "type": "CcbPlatformState"
           },
           {
-            "line": 10750,
+            "line": 10752,
             "name": "tasks",
             "type": "CcbPlatformTasks"
           }
@@ -7486,37 +7486,37 @@
       {
         "fields": [
           {
-            "line": 10252,
+            "line": 10254,
             "name": "batch",
             "type": "integer"
           },
           {
-            "line": 10251,
+            "line": 10253,
             "name": "has_more",
             "type": "boolean"
           },
           {
-            "line": 10246,
+            "line": 10248,
             "name": "items",
             "type": "table"
           },
           {
-            "line": 10249,
+            "line": 10251,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 10248,
+            "line": 10250,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 10250,
+            "line": 10252,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 10247,
+            "line": 10249,
             "name": "total",
             "type": "integer"
           }
@@ -7526,47 +7526,47 @@
       {
         "fields": [
           {
-            "line": 10237,
+            "line": 10239,
             "name": "batch",
             "type": "integer"
           },
           {
-            "line": 10240,
+            "line": 10242,
             "name": "craftable",
             "type": "boolean"
           },
           {
-            "line": 10243,
+            "line": 10245,
             "name": "flag",
             "type": "string"
           },
           {
-            "line": 10238,
+            "line": 10240,
             "name": "include_obsolete",
             "type": "boolean"
           },
           {
-            "line": 10239,
+            "line": 10241,
             "name": "known",
             "type": "boolean"
           },
           {
-            "line": 10236,
+            "line": 10238,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 10235,
+            "line": 10237,
             "name": "offset",
             "type": "integer"
           },
           {
-            "line": 10242,
+            "line": 10244,
             "name": "result",
             "type": "GameId"
           },
           {
-            "line": 10241,
+            "line": 10243,
             "name": "skill",
             "type": "GameId"
           }
@@ -7639,17 +7639,17 @@
       {
         "fields": [
           {
-            "line": 10257,
+            "line": 10259,
             "name": "batch",
             "type": "integer"
           },
           {
-            "line": 10256,
+            "line": 10258,
             "name": "limit",
             "type": "integer"
           },
           {
-            "line": 10255,
+            "line": 10257,
             "name": "offset",
             "type": "integer"
           }
@@ -7762,172 +7762,172 @@
       {
         "fields": [
           {
-            "line": 10390,
+            "line": 10392,
             "name": "area",
             "type": "string"
           },
           {
-            "line": 10392,
+            "line": 10394,
             "name": "attack_vectors",
             "type": "CcbTechniqueIdPage"
           },
           {
-            "line": 10365,
+            "line": 10367,
             "name": "avatar_message",
             "type": "string"
           },
           {
-            "line": 10375,
+            "line": 10377,
             "name": "block_counter",
             "type": "boolean"
           },
           {
-            "line": 10371,
+            "line": 10373,
             "name": "critical_compatible",
             "type": "boolean"
           },
           {
-            "line": 10370,
+            "line": 10372,
             "name": "critical_only",
             "type": "boolean"
           },
           {
-            "line": 10367,
+            "line": 10369,
             "name": "defensive",
             "type": "boolean"
           },
           {
-            "line": 10362,
+            "line": 10364,
             "name": "description",
             "type": "string"
           },
           {
-            "line": 10378,
+            "line": 10380,
             "name": "disarms",
             "type": "boolean"
           },
           {
-            "line": 10374,
+            "line": 10376,
             "name": "dodge_counter",
             "type": "boolean"
           },
           {
-            "line": 10385,
+            "line": 10387,
             "name": "down_duration",
             "type": "integer"
           },
           {
-            "line": 10369,
+            "line": 10371,
             "name": "dummy",
             "type": "boolean"
           },
           {
-            "line": 10393,
+            "line": 10395,
             "name": "eocs",
             "type": "CcbTechniqueIdPage"
           },
           {
-            "line": 10391,
+            "line": 10393,
             "name": "flags",
             "type": "CcbTechniqueFlagPage"
           },
           {
-            "line": 10363,
+            "line": 10365,
             "name": "flavor_description",
             "type": "string"
           },
           {
-            "line": 10364,
+            "line": 10366,
             "name": "goal",
             "type": "string"
           },
           {
-            "line": 10377,
+            "line": 10379,
             "name": "grab_break",
             "type": "boolean"
           },
           {
-            "line": 10360,
+            "line": 10362,
             "name": "id",
             "type": "GameId"
           },
           {
-            "line": 10387,
+            "line": 10389,
             "name": "knockback_distance",
             "type": "integer"
           },
           {
-            "line": 10389,
+            "line": 10391,
             "name": "knockback_follow",
             "type": "boolean"
           },
           {
-            "line": 10388,
+            "line": 10390,
             "name": "knockback_spread",
             "type": "number"
           },
           {
-            "line": 10376,
+            "line": 10378,
             "name": "miss_recovery",
             "type": "boolean"
           },
           {
-            "line": 10361,
+            "line": 10363,
             "name": "name",
             "type": "string"
           },
           {
-            "line": 10380,
+            "line": 10382,
             "name": "needs_ammo",
             "type": "boolean"
           },
           {
-            "line": 10366,
+            "line": 10368,
             "name": "npc_message",
             "type": "string"
           },
           {
-            "line": 10373,
+            "line": 10375,
             "name": "reach_compatible",
             "type": "boolean"
           },
           {
-            "line": 10372,
+            "line": 10374,
             "name": "reach_only",
             "type": "boolean"
           },
           {
-            "line": 10384,
+            "line": 10386,
             "name": "repeat_max",
             "type": "integer"
           },
           {
-            "line": 10383,
+            "line": 10385,
             "name": "repeat_min",
             "type": "integer"
           },
           {
-            "line": 10368,
+            "line": 10370,
             "name": "side_switch",
             "type": "boolean"
           },
           {
-            "line": 10386,
+            "line": 10388,
             "name": "stun_duration",
             "type": "integer"
           },
           {
-            "line": 10379,
+            "line": 10381,
             "name": "take_weapon",
             "type": "boolean"
           },
           {
-            "line": 10381,
+            "line": 10383,
             "name": "wall_adjacent",
             "type": "boolean"
           },
           {
-            "line": 10382,
+            "line": 10384,
             "name": "weight",
             "type": "integer"
           }
@@ -7937,22 +7937,22 @@
       {
         "fields": [
           {
-            "line": 10354,
+            "line": 10356,
             "name": "items",
             "type": "string[]"
           },
           {
-            "line": 10356,
+            "line": 10358,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 10355,
+            "line": 10357,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 10357,
+            "line": 10359,
             "name": "truncated",
             "type": "boolean"
           }
@@ -7962,22 +7962,22 @@
       {
         "fields": [
           {
-            "line": 10348,
+            "line": 10350,
             "name": "items",
             "type": "GameId[]"
           },
           {
-            "line": 10350,
+            "line": 10352,
             "name": "returned",
             "type": "integer"
           },
           {
-            "line": 10349,
+            "line": 10351,
             "name": "total",
             "type": "integer"
           },
           {
-            "line": 10351,
+            "line": 10353,
             "name": "truncated",
             "type": "boolean"
           }
@@ -7987,22 +7987,22 @@
       {
         "fields": [
           {
-            "line": 10639,
+            "line": 10641,
             "name": "season_id",
             "type": "string"
           },
           {
-            "line": 10640,
+            "line": 10642,
             "name": "season_name",
             "type": "string"
           },
           {
-            "line": 10637,
+            "line": 10639,
             "name": "turn",
             "type": "integer"
           },
           {
-            "line": 10638,
+            "line": 10640,
             "name": "year",
             "type": "integer"
           }
@@ -9407,22 +9407,22 @@
       {
         "fields": [
           {
-            "line": 10643,
+            "line": 10645,
             "name": "id",
             "type": "string"
           },
           {
-            "line": 10644,
+            "line": 10646,
             "name": "temperature_c",
             "type": "number"
           },
           {
-            "line": 10646,
+            "line": 10648,
             "name": "wind_direction",
             "type": "number"
           },
           {
-            "line": 10645,
+            "line": 10647,
             "name": "wind_speed",
             "type": "number"
           }
@@ -20621,43 +20621,43 @@
         "parameters": "character, body_part_limit"
       },
       {
-        "line": "10629",
+        "line": "10631",
         "name": "nearby",
         "owner": "CcbCreaturesApi",
         "parameters": "observer, options"
       },
       {
-        "line": "10624",
+        "line": "10626",
         "name": "snapshot",
         "owner": "CcbCreaturesApi",
         "parameters": "handle"
       },
       {
-        "line": "10634",
+        "line": "10636",
         "name": "visible_monsters",
         "owner": "CcbCreaturesApi",
         "parameters": "observer, direction"
       },
       {
-        "line": "10107",
+        "line": "10109",
         "name": "add",
         "owner": "CcbEffectsApi",
         "parameters": "character, effect, duration, options"
       },
       {
-        "line": "10122",
+        "line": "10124",
         "name": "get",
         "owner": "CcbEffectsApi",
         "parameters": "character, effect, body_part"
       },
       {
-        "line": "10115",
+        "line": "10117",
         "name": "has",
         "owner": "CcbEffectsApi",
         "parameters": "character, effect, body_part, intensity"
       },
       {
-        "line": "10129",
+        "line": "10131",
         "name": "remove",
         "owner": "CcbEffectsApi",
         "parameters": "character, effect, body_part"
@@ -21329,61 +21329,61 @@
         "parameters": "character, morale"
       },
       {
-        "line": "10168",
+        "line": "10170",
         "name": "grant",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation, variant"
       },
       {
-        "line": "10138",
+        "line": "10140",
         "name": "has",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation"
       },
       {
-        "line": "10152",
+        "line": "10154",
         "name": "is_purifiable",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation"
       },
       {
-        "line": "10145",
+        "line": "10147",
         "name": "is_visible_to",
         "owner": "CcbMutationsApi",
         "parameters": "observed, observer, mutation"
       },
       {
-        "line": "10197",
+        "line": "10199",
         "name": "mutate_category",
         "owner": "CcbMutationsApi",
         "parameters": "character, category, use_vitamins, true_random"
       },
       {
-        "line": "10175",
+        "line": "10177",
         "name": "remove",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation"
       },
       {
-        "line": "10189",
+        "line": "10191",
         "name": "remove_category",
         "owner": "CcbMutationsApi",
         "parameters": "character, category"
       },
       {
-        "line": "10206",
+        "line": "10208",
         "name": "remove_type",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation_type"
       },
       {
-        "line": "10183",
+        "line": "10185",
         "name": "set_active",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation, active"
       },
       {
-        "line": "10160",
+        "line": "10162",
         "name": "set_purifiable",
         "owner": "CcbMutationsApi",
         "parameters": "character, mutation, purifiable"
@@ -21935,19 +21935,19 @@
         "parameters": "character_handle, npc_handle, duration"
       },
       {
-        "line": "10226",
+        "line": "10228",
         "name": "grant",
         "owner": "CcbPlatformBionicsApi",
         "parameters": "character, id"
       },
       {
-        "line": "10232",
+        "line": "10234",
         "name": "remove_type",
         "owner": "CcbPlatformBionicsApi",
         "parameters": "character, id"
       },
       {
-        "line": "10220",
+        "line": "10222",
         "name": "summary",
         "owner": "CcbPlatformBionicsApi",
         "parameters": "character"
@@ -23687,67 +23687,67 @@
         "parameters": "dimension"
       },
       {
-        "line": "10496",
+        "line": "10498",
         "name": "dimension",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": ""
       },
       {
-        "line": "10534",
+        "line": "10536",
         "name": "field_exists",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position, field_id"
       },
       {
-        "line": "10517",
+        "line": "10519",
         "name": "furniture_has_flag",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position, flag"
       },
       {
-        "line": "10529",
+        "line": "10531",
         "name": "furniture_id",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position"
       },
       {
-        "line": "10544",
+        "line": "10546",
         "name": "is_indoor_tile",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position"
       },
       {
-        "line": "10500",
+        "line": "10502",
         "name": "is_night",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": ""
       },
       {
-        "line": "10504",
+        "line": "10506",
         "name": "is_outside",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position"
       },
       {
-        "line": "10511",
+        "line": "10513",
         "name": "line_of_sight",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "from, to, range, with_fields"
       },
       {
-        "line": "10549",
+        "line": "10551",
         "name": "safe_mode_dangerous",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "direction"
       },
       {
-        "line": "10539",
+        "line": "10541",
         "name": "terrain_has_flag",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position, flag"
       },
       {
-        "line": "10523",
+        "line": "10525",
         "name": "terrain_id",
         "owner": "CcbPlatformEnvironmentQueries",
         "parameters": "position"
@@ -23825,31 +23825,31 @@
         "parameters": "id"
       },
       {
-        "line": "10414",
+        "line": "10416",
         "name": "forget",
         "owner": "CcbPlatformMartialArtsApi",
         "parameters": "character, id"
       },
       {
-        "line": "10408",
+        "line": "10410",
         "name": "learn",
         "owner": "CcbPlatformMartialArtsApi",
         "parameters": "character, id"
       },
       {
-        "line": "10401",
+        "line": "10403",
         "name": "technique_definition",
         "owner": "CcbPlatformMartialArtsApi",
         "parameters": "id"
       },
       {
-        "line": "10576",
+        "line": "10578",
         "name": "apply",
         "owner": "CcbPlatformMathApi",
         "parameters": "expression, actor, context"
       },
       {
-        "line": "10569",
+        "line": "10571",
         "name": "evaluate",
         "owner": "CcbPlatformMathApi",
         "parameters": "expression, actor, context"
@@ -23873,7 +23873,7 @@
         "parameters": "message, type"
       },
       {
-        "line": "10490",
+        "line": "10492",
         "name": "is_loaded",
         "owner": "CcbPlatformModQueries",
         "parameters": "mod_id"
@@ -23885,13 +23885,13 @@
         "parameters": "id"
       },
       {
-        "line": "10431",
+        "line": "10433",
         "name": "add",
         "owner": "CcbPlatformMoraleApi",
         "parameters": "character, id, bonus, max_bonus, options"
       },
       {
-        "line": "10437",
+        "line": "10439",
         "name": "remove",
         "owner": "CcbPlatformMoraleApi",
         "parameters": "character, id"
@@ -23957,97 +23957,97 @@
         "parameters": "file, volume"
       },
       {
-        "line": "10450",
+        "line": "10452",
         "name": "chance",
         "owner": "CcbPlatformRandomApi",
         "parameters": "numerator, denominator"
       },
       {
-        "line": "10472",
+        "line": "10474",
         "name": "contested",
         "owner": "CcbPlatformRandomApi",
         "parameters": "check, difficulty, die_size"
       },
       {
-        "line": "10445",
+        "line": "10447",
         "name": "int",
         "owner": "CcbPlatformRandomApi",
         "parameters": "minimum, maximum"
       },
       {
-        "line": "10454",
+        "line": "10456",
         "name": "one_in",
         "owner": "CcbPlatformRandomApi",
         "parameters": "denominator"
       },
       {
-        "line": "10459",
+        "line": "10461",
         "name": "probability",
         "owner": "CcbPlatformRandomApi",
         "parameters": "numerator, denominator"
       },
       {
-        "line": "10466",
+        "line": "10468",
         "name": "sample_integers",
         "owner": "CcbPlatformRandomApi",
         "parameters": "minimum, maximum, count, with_replacement"
       },
       {
-        "line": "10276",
+        "line": "10278",
         "name": "all",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, options"
       },
       {
-        "line": "10286",
+        "line": "10288",
         "name": "by_flag",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "flag, character, options"
       },
       {
-        "line": "10281",
+        "line": "10283",
         "name": "by_skill",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "skill, character, options"
       },
       {
-        "line": "10328",
+        "line": "10330",
         "name": "forget",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, id"
       },
       {
-        "line": "10345",
+        "line": "10347",
         "name": "forget_category",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, category, subcategory"
       },
       {
-        "line": "10291",
+        "line": "10293",
         "name": "get",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, id, batch"
       },
       {
-        "line": "10295",
+        "line": "10297",
         "name": "has_flag",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "id, flag"
       },
       {
-        "line": "10316",
+        "line": "10318",
         "name": "knows",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, id"
       },
       {
-        "line": "10322",
+        "line": "10324",
         "name": "learn",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, id"
       },
       {
-        "line": "10272",
+        "line": "10274",
         "name": "list",
         "owner": "CcbPlatformRecipesApi",
         "parameters": "character, options"
@@ -24089,115 +24089,115 @@
         "parameters": "event_name, handler_id"
       },
       {
-        "line": "10735",
+        "line": "10737",
         "name": "activity_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10725",
+        "line": "10727",
         "name": "bionics_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10672",
+        "line": "10674",
         "name": "character_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character"
       },
       {
-        "line": "10715",
+        "line": "10717",
         "name": "current_tile_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, field_limit"
       },
       {
-        "line": "10693",
+        "line": "10695",
         "name": "effects_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10703",
+        "line": "10705",
         "name": "equipment_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10688",
+        "line": "10690",
         "name": "inventory_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10710",
+        "line": "10712",
         "name": "item_contents_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, item_handle, offset, limit"
       },
       {
-        "line": "10648",
+        "line": "10650",
         "name": "message",
         "owner": "CcbPlatformServices",
         "parameters": "text"
       },
       {
-        "line": "10730",
+        "line": "10732",
         "name": "missions_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10676",
+        "line": "10678",
         "name": "movement_modes_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character"
       },
       {
-        "line": "10720",
+        "line": "10722",
         "name": "mutations_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10741",
+        "line": "10743",
         "name": "nearby_creatures_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, radius, limit"
       },
       {
-        "line": "10698",
+        "line": "10700",
         "name": "skills_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": "character, limit"
       },
       {
-        "line": "10679",
+        "line": "10681",
         "name": "time_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": ""
       },
       {
-        "line": "10655",
+        "line": "10657",
         "name": "translate",
         "owner": "CcbPlatformServices",
         "parameters": "text, context"
       },
       {
-        "line": "10665",
+        "line": "10667",
         "name": "translate_plural",
         "owner": "CcbPlatformServices",
         "parameters": "singular, plural, count, context"
       },
       {
-        "line": "10668",
+        "line": "10670",
         "name": "turn",
         "owner": "CcbPlatformServices",
         "parameters": ""
       },
       {
-        "line": "10682",
+        "line": "10684",
         "name": "weather_snapshot",
         "owner": "CcbPlatformServices",
         "parameters": ""
@@ -24269,13 +24269,13 @@
         "parameters": "key, value"
       },
       {
-        "line": "10483",
+        "line": "10485",
         "name": "all_equal",
         "owner": "CcbPlatformStringPredicates",
         "parameters": "values"
       },
       {
-        "line": "10479",
+        "line": "10481",
         "name": "any_equal",
         "owner": "CcbPlatformStringPredicates",
         "parameters": "values"
@@ -24365,19 +24365,19 @@
         "parameters": "avatar, target, options"
       },
       {
-        "line": "10310",
+        "line": "10312",
         "name": "for_recipe",
         "owner": "CcbRequirementsApi",
         "parameters": "character, id, batch"
       },
       {
-        "line": "10305",
+        "line": "10307",
         "name": "get",
         "owner": "CcbRequirementsApi",
         "parameters": "character, id, batch"
       },
       {
-        "line": "10300",
+        "line": "10302",
         "name": "list",
         "owner": "CcbRequirementsApi",
         "parameters": "character, options"
@@ -24443,43 +24443,43 @@
         "parameters": "character, key"
       },
       {
-        "line": "10032",
+        "line": "10033",
         "name": "get_global",
         "owner": "CcbVariablesApi",
         "parameters": "key"
       },
       {
-        "line": "10028",
+        "line": "10029",
         "name": "remove",
         "owner": "CcbVariablesApi",
         "parameters": "character, key"
       },
       {
-        "line": "10041",
+        "line": "10042",
         "name": "remove_global",
         "owner": "CcbVariablesApi",
         "parameters": "key"
       },
       {
-        "line": "10050",
+        "line": "10051",
         "name": "resolve",
         "owner": "CcbVariablesApi",
         "parameters": "context, actor, scope, key"
       },
       {
-        "line": "10023",
+        "line": "10024",
         "name": "set",
         "owner": "CcbVariablesApi",
         "parameters": "character, key, value"
       },
       {
-        "line": "10037",
+        "line": "10038",
         "name": "set_global",
         "owner": "CcbVariablesApi",
         "parameters": "key, value"
       },
       {
-        "line": "10058",
+        "line": "10060",
         "name": "set_resolved",
         "owner": "CcbVariablesApi",
         "parameters": "context, actor, scope, key, value"
@@ -30385,47 +30385,47 @@
   "public_root": {
     "fields": [
       {
-        "line": 10745,
+        "line": 10747,
         "name": "ModDefinition",
         "type": "fun(options:"
       },
       {
-        "line": 10746,
+        "line": 10748,
         "name": "content",
         "type": "CcbPlatformContent"
       },
       {
-        "line": 10748,
+        "line": 10750,
         "name": "dialogue",
         "type": "CcbPlatformDialogueApi"
       },
       {
-        "line": 10744,
+        "line": 10746,
         "name": "platform_version",
         "type": "1"
       },
       {
-        "line": 10751,
+        "line": 10753,
         "name": "presentation",
         "type": "CcbPlatformPresentation"
       },
       {
-        "line": 10747,
+        "line": 10749,
         "name": "runtime",
         "type": "CcbPlatformRuntime"
       },
       {
-        "line": 10752,
+        "line": 10754,
         "name": "services",
         "type": "CcbPlatformServices"
       },
       {
-        "line": 10749,
+        "line": 10751,
         "name": "state",
         "type": "CcbPlatformState"
       },
       {
-        "line": 10750,
+        "line": 10752,
         "name": "tasks",
         "type": "CcbPlatformTasks"
       }

--- a/data/lua/reference/ccb_platform_api_v1_coverage.json
+++ b/data/lua/reference/ccb_platform_api_v1_coverage.json
@@ -1079,8 +1079,8 @@
   ],
   "platform_sync": {
     "contract_export_roots_missing_from_inventory": [],
-    "luals_class_count": 700,
-    "luals_function_count": 1278,
+    "luals_class_count": 702,
+    "luals_function_count": 1279,
     "native_export_root_count": 179,
     "native_export_roots_declared": 179,
     "native_export_roots_in_public_contract": 179,

--- a/data/lua/types/ccb_platform_v1.d.lua
+++ b/data/lua/types/ccb_platform_v1.d.lua
@@ -10458,8 +10458,8 @@ function CcbPlatformMoraleApi.remove(character, id) end
 ---@class CcbPlatformRandomApi: CcbRandomApi
 local CcbPlatformRandomApi = {}
 
----@param minimum integer Inclusive lower bound in -1000000000..1000000000.
----@param maximum integer Inclusive upper bound in -1000000000..1000000000.
+---@param minimum integer Inclusive lower bound in native signed integer range -2147483648..2147483647.
+---@param maximum integer Inclusive upper bound in native signed integer range -2147483648..2147483647.
 ---@return integer
 function CcbPlatformRandomApi.int(minimum, maximum) end
 
@@ -10468,7 +10468,7 @@ function CcbPlatformRandomApi.int(minimum, maximum) end
 ---@return boolean
 function CcbPlatformRandomApi.chance(numerator, denominator) end
 
----@param denominator number Converted to a native integer; values at or below one always succeed.
+---@param denominator number Truncated toward zero into -2147483648..2147483647; values at or below one always succeed.
 ---@return boolean
 function CcbPlatformRandomApi.one_in(denominator) end
 

--- a/data/lua/types/ccb_platform_v1.d.lua
+++ b/data/lua/types/ccb_platform_v1.d.lua
@@ -10010,6 +10010,23 @@ function CcbTypesApi.id_kinds() end
 ---@class CcbVariablesApi
 local CcbVariablesApi = {}
 
+---@class CcbVariableCopyValue
+---@field source_exists boolean
+---@field destination_existed boolean
+
+---@class CcbVariableCopyResult: CcbResult
+---@field value? CcbVariableCopyValue
+
+---Copy native values without converting arrays, nulls, or coordinates through Lua.
+---Both owners are validated before mutation; missing sources write a stored empty value.
+---An active write callback is required. Use nil owners for the global variable store.
+---@param source_owner GameHandle|nil
+---@param source_key string Variable key, 1..128 bytes without ASCII controls or NUL.
+---@param destination_owner GameHandle|nil
+---@param destination_key string
+---@return CcbVariableCopyResult
+function CcbVariablesApi.copy(source_owner, source_key, destination_owner, destination_key) end
+
 ---@param character GameHandle Explicit live variable-owning actor.
 ---@param key string Variable name containing 1..128 bytes, without ASCII controls or NUL.
 ---@return CcbVariableReadResult

--- a/data/lua/types/ccb_platform_v1.d.lua
+++ b/data/lua/types/ccb_platform_v1.d.lua
@@ -10016,6 +10016,7 @@ local CcbVariablesApi = {}
 function CcbVariablesApi.get(character, key) end
 
 ---Write phases and an active callback are required for variable mutations.
+---Actor/global nil writes store an empty native value with exists=true; remove deletes the key.
 ---@param character GameHandle Explicit live variable-owning actor.
 ---@param key string
 ---@param value boolean|number|string|TripointCoord|nil Finite numbers, bounded strings, absolute map-square coordinates, or nil.
@@ -10049,6 +10050,7 @@ function CcbVariablesApi.remove_global(key) end
 ---@return CcbVariableReadResult
 function CcbVariablesApi.resolve(context, actor, scope, key) end
 
+---For context scope, nil clears the Lua table entry; Lua tables cannot retain a stored nil.
 ---@param context table<string, any>|nil
 ---@param actor GameHandle|nil Explicit owner, including indirect actor references.
 ---@param scope 'u'|'npc'|'global'|'context'|'var'

--- a/src/lua_platform_runtime_services.cpp
+++ b/src/lua_platform_runtime_services.cpp
@@ -2843,9 +2843,10 @@ void install_runtime_api( const std::shared_ptr<runtime> &value,
     };
     const auto random_integer = [require_random_runtime]( const std::int64_t minimum,
     const std::int64_t maximum ) {
-        if( minimum < -1000000000LL || maximum > 1000000000LL || minimum > maximum ) {
+        if( minimum < std::numeric_limits<int>::min() ||
+            maximum > std::numeric_limits<int>::max() || minimum > maximum ) {
             throw std::invalid_argument(
-                "services.random.int requires an ordered range within -1000000000..1000000000" );
+                "services.random.int requires an ordered range within native integer bounds" );
         }
         const std::shared_ptr<runtime> owner = require_random_runtime();
         std::uniform_int_distribution<std::int64_t> distribution( minimum, maximum );
@@ -2871,12 +2872,13 @@ void install_runtime_api( const std::shared_ptr<runtime> &value,
     } );
     random.set_function( "one_in", [require_random_runtime]( const double raw_denominator ) {
         const std::shared_ptr<runtime> owner = require_random_runtime();
-        if( !std::isfinite( raw_denominator ) || raw_denominator < -1000000000.0 ||
-            raw_denominator > 1000000000.0 ) {
+        const double truncated = std::trunc( raw_denominator );
+        if( !std::isfinite( truncated ) || truncated < std::numeric_limits<int>::min() ||
+            truncated > std::numeric_limits<int>::max() ) {
             throw std::invalid_argument(
                 "services.random.one_in requires a finite denominator within native bounds" );
         }
-        const std::int64_t denominator = static_cast<std::int64_t>( raw_denominator );
+        const std::int64_t denominator = static_cast<std::int64_t>( truncated );
         if( denominator <= 1 ) {
             return true;
         }

--- a/src/lua_platform_variables.cpp
+++ b/src/lua_platform_variables.cpp
@@ -569,6 +569,46 @@ sol::table set_resolved_variable(
                runtime_generation, world_generation );
 }
 
+sol::table copy_variable(
+    sol::this_state lua, const sol::optional<game_handle> &source_owner,
+    const std::string &source_key, const sol::optional<game_handle> &target_owner,
+    const std::string &target_key, const game_handle_runtime &runtime_generation,
+    const std::size_t world_generation )
+{
+    validate_context_key( source_key );
+    validate_context_key( target_key );
+    sol::state_view state( lua );
+    resolved_variable_talker source;
+    resolved_variable_talker target;
+    if( source_owner ) {
+        source = resolve_variable_talker( *source_owner, runtime_generation, world_generation );
+        if( source.error ) {
+            return make_game_error_result( state, *source.error );
+        }
+    }
+    if( target_owner ) {
+        target = resolve_variable_talker( *target_owner, runtime_generation, world_generation );
+        if( target.error ) {
+            return make_game_error_result( state, *target.error );
+        }
+    }
+    const diag_value *stored = source_owner ? resolved_variable_get( source, source_key ) :
+                               get_globals().maybe_get_global_value( source_key );
+    // Snapshot before writing: source and destination may name the same value.
+    const diag_value copied = stored == nullptr ? diag_value() : *stored;
+    const bool existed = ( target_owner ? resolved_variable_get( target, target_key ) :
+                           get_globals().maybe_get_global_value( target_key ) ) != nullptr;
+    sol::table result = state.create_table();
+    result["source_exists"] = stored != nullptr;
+    result["destination_existed"] = existed;
+    if( target_owner ) {
+        resolved_variable_set( target, target_key, copied );
+    } else {
+        get_globals().set_global_value( target_key, copied );
+    }
+    return make_game_value_result( state, sol::make_object( state, std::move( result ) ) );
+}
+
 } // namespace
 
 void install_variable_api(
@@ -582,6 +622,19 @@ void install_variable_api(
     sol::state_view lua( services.lua_state() );
 
     sol::table variables = lua.create_table();
+    variables.set_function(
+        "copy",
+        [current_runtime_generation, current_world_generation,
+         require_read, require_write, has_active_callback](
+            sol::this_state lua_state, const sol::optional<game_handle> &source_owner,
+            const std::string & source_key, const sol::optional<game_handle> &target_owner,
+    const std::string & target_key ) {
+        require_read();
+        require_write();
+        require_active_callback( has_active_callback, "services.variables.copy" );
+        return copy_variable( lua_state, source_owner, source_key, target_owner, target_key,
+                              current_runtime_generation(), current_world_generation() );
+    } );
     variables.set_function(
         "get",
         [current_runtime_generation, current_world_generation,

--- a/src/lua_platform_variables.cpp
+++ b/src/lua_platform_variables.cpp
@@ -61,6 +61,9 @@ void validate_context_key( const std::string &key )
 diag_value context_value_from_lua(
     const sol::object &value, const std::string &key )
 {
+    if( value.get_type() == sol::type::nil ) {
+        return diag_value();
+    }
     if( value.get_type() == sol::type::boolean ) {
         return diag_value( value.as<bool>() ? 1.0 : 0.0 );
     }
@@ -95,7 +98,7 @@ diag_value context_value_from_lua(
     }
     throw std::invalid_argument(
         "services.variables context value '" + key +
-        "' must be boolean, number, string, or TripointCoord" );
+        "' must be nil, boolean, number, string, or TripointCoord" );
 }
 
 sol::object context_value_to_lua(
@@ -459,7 +462,7 @@ sol::table resolve_variable(
                        state, sol::make_object( state, std::move( result ) ) );
         }
         const resolved_variable_talker resolved = resolve_variable_talker(
-                    *actor, runtime_generation, world_generation );
+                *actor, runtime_generation, world_generation );
         if( resolved.error ) {
             return make_game_error_result( state, *resolved.error );
         }
@@ -582,7 +585,7 @@ void install_variable_api(
     variables.set_function(
         "get",
         [current_runtime_generation, current_world_generation,
-                                     require_read](
+         require_read](
             sol::this_state lua_state, const game_handle & handle,
     const std::string & key ) {
         require_read();
@@ -594,7 +597,7 @@ void install_variable_api(
     variables.set_function(
         "set",
         [current_runtime_generation, current_world_generation,
-                                     require_write, has_active_callback](
+         require_write, has_active_callback](
             sol::this_state lua_state, const game_handle & handle,
     const std::string & key, const sol::object & value ) {
         require_write();
@@ -608,7 +611,7 @@ void install_variable_api(
     variables.set_function(
         "remove",
         [current_runtime_generation, current_world_generation,
-                                     require_write, has_active_callback](
+         require_write, has_active_callback](
             sol::this_state lua_state, const game_handle & handle,
     const std::string & key ) {
         require_write();
@@ -655,7 +658,7 @@ void install_variable_api(
     variables.set_function(
         "set_resolved",
         [current_runtime_generation, current_world_generation,
-                                     require_write, has_active_callback](
+         require_write, has_active_callback](
             sol::this_state lua_state, const sol::optional<sol::table> &context,
             const sol::optional<game_handle> &actor, const std::string & scope,
     const std::string & key, const sol::object & value ) {

--- a/tests/lua_platform_day_semantic_test.cpp
+++ b/tests/lua_platform_day_semantic_test.cpp
@@ -1,0 +1,70 @@
+#if defined(CATA_ENABLE_LUA_PLATFORM) && CATA_ENABLE_LUA_PLATFORM
+
+#include <array>
+#include <memory>
+
+#include "calendar.h"
+#include "cata_catch.h"
+#include "cata_scope_helpers.h"
+#include "condition.h"
+#include "dialogue.h"
+#include "lua_platform_runtime.h"
+#include "lua_platform_sol.h"
+
+TEST_CASE( "lua_platform_is_day_matches_legacy_calendar_boundaries",
+           "[lua][platform][day][semantic]" )
+{
+    using namespace cata::lua_platform;
+    clear_active_runtimes();
+    restore_on_out_of_scope restore_turn( calendar::turn );
+    const bool old_day = calendar::eternal_day();
+    const bool old_night = calendar::eternal_night();
+    sol::state lua;
+    sol::table ccb = lua.create_table();
+    const std::shared_ptr<runtime> owner = make_runtime( "day_semantics", 4901, lua );
+    on_out_of_scope cleanup( [old_day, old_night]() {
+        clear_active_runtimes();
+        calendar::set_eternal_day( old_day );
+        calendar::set_eternal_night( old_night );
+    } );
+    install_runtime_api( owner, lua, ccb );
+    set_active_runtimes( { owner } );
+    runtime_world_ready( true );
+    lua["services"] = ccb["services"];
+    // This is the migrator's ordinary Lua expression, using the real service.
+    sol::protected_function predicate = lua.load(
+                                            "return not services.gameplay.environment.is_night()" );
+    conditional_t legacy( "is_day" );
+    dialogue context;
+    for( const bool eternal_day : {
+             false, true
+         } ) {
+        for( const bool eternal_night : {
+                 false, true
+             } ) {
+            calendar::set_eternal_day( eternal_day );
+            calendar::set_eternal_night( eternal_night );
+            for( int season = 0; season < 4; ++season ) {
+                const time_point date = calendar::turn_zero + calendar::season_length() * season;
+                const std::array<time_point, 6> boundaries = {{
+                        date, sunrise( date ), daylight_time( date ), noon( date ),
+                        sunset( date ), night_time( date )
+                    }
+                };
+                for( const time_point boundary : boundaries ) {
+                    for( const int offset : {
+                             -1, 0, 1
+                         } ) {
+                        calendar::turn = boundary + time_duration::from_seconds( offset );
+                        CAPTURE( eternal_day, eternal_night, season, offset );
+                        const sol::protected_function_result actual = predicate();
+                        REQUIRE( actual.valid() );
+                        CHECK( actual.get<bool>() == legacy( context ) );
+                    }
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/tests/lua_platform_environment_predicate_test.cpp
+++ b/tests/lua_platform_environment_predicate_test.cpp
@@ -1,0 +1,78 @@
+#if defined(CATA_ENABLE_LUA_PLATFORM) && CATA_ENABLE_LUA_PLATFORM
+
+#include <memory>
+#include <string>
+
+#include "calendar.h"
+#include "cata_catch.h"
+#include "cata_scope_helpers.h"
+#include "condition.h"
+#include "dialogue.h"
+#include "flexbuffer_json.h"
+#include "json_loader.h"
+#include "lua_platform_runtime.h"
+#include "lua_platform_sol.h"
+#include "weather.h"
+
+TEST_CASE( "lua_platform_environment_strings_match_native_predicates",
+           "[lua][platform][environment_predicate][semantic]" )
+{
+    using namespace cata::lua_platform;
+    clear_active_runtimes();
+    restore_on_out_of_scope restore_turn( calendar::turn );
+    restore_on_out_of_scope restore_weather( get_weather().weather_id );
+    const bool old_eternal = calendar::eternal_season();
+    sol::state lua;
+    sol::table ccb = lua.create_table();
+    const std::shared_ptr<runtime> owner = make_runtime( "environment_strings", 4902, lua );
+    on_out_of_scope cleanup( [old_eternal]() {
+        clear_active_runtimes();
+        calendar::set_eternal_season( old_eternal );
+    } );
+    install_runtime_api( owner, lua, ccb );
+    set_active_runtimes( { owner } );
+    runtime_world_ready( true );
+    lua["services"] = ccb["services"];
+    dialogue context;
+    sol::protected_function season_query = lua.load(
+            "return services.time_snapshot().season_id == wanted" );
+    for( const bool eternal : {
+             false, true
+         } ) {
+        calendar::set_eternal_season( eternal );
+        for( int season = 0; season < 4; ++season ) {
+            calendar::turn = calendar::turn_zero + calendar::season_length() * season;
+            for( const std::string wanted : {
+                     "spring", "summer", "autumn", "winter", "", "unknown"
+                 } ) {
+                CAPTURE( eternal, season, wanted );
+                lua["wanted"] = wanted;
+                conditional_t legacy( json_loader::from_string(
+                                          "{\"is_season\":\"" + wanted + "\"}" ).get_object() );
+                const sol::protected_function_result actual = season_query();
+                REQUIRE( actual.valid() );
+                CHECK( actual.get<bool>() == legacy( context ) );
+            }
+        }
+    }
+    sol::protected_function weather_query = lua.load(
+            "return services.weather.current().weather.value == wanted" );
+    for( const std::string current : {
+             "sunny", "rain", "snowing"
+         } ) {
+        get_weather().weather_id = weather_type_id( current );
+        for( const std::string wanted : {
+                 "sunny", "rain", "snowing", "", "unknown"
+             } ) {
+            CAPTURE( current, wanted );
+            lua["wanted"] = wanted;
+            conditional_t legacy( json_loader::from_string(
+                                      "{\"is_weather\":\"" + wanted + "\"}" ).get_object() );
+            const sol::protected_function_result actual = weather_query();
+            REQUIRE( actual.valid() );
+            CHECK( actual.get<bool>() == legacy( context ) );
+        }
+    }
+}
+
+#endif

--- a/tests/lua_platform_random_range_test.cpp
+++ b/tests/lua_platform_random_range_test.cpp
@@ -1,0 +1,66 @@
+#if defined(CATA_ENABLE_LUA_PLATFORM) && CATA_ENABLE_LUA_PLATFORM
+
+#include <memory>
+
+#include "cata_catch.h"
+#include "cata_scope_helpers.h"
+#include "lua_platform_runtime.h"
+#include "lua_platform_sol.h"
+#include "rng.h"
+
+TEST_CASE( "lua_platform_random_accepts_native_integer_boundaries",
+           "[lua][platform][random_range][semantic]" )
+{
+    using namespace cata::lua_platform;
+    clear_active_runtimes();
+    sol::state lua;
+    lua.open_libraries( sol::lib::base, sol::lib::math );
+    sol::table ccb = lua.create_table();
+    const std::shared_ptr<runtime> owner = make_runtime( "random_range", 4903, lua );
+    on_out_of_scope cleanup( []() {
+        clear_active_runtimes();
+    } );
+    install_runtime_api( owner, lua, ccb );
+    set_active_runtimes( { owner } );
+    lua["ccb"] = ccb;
+    lua.set_function( "check", []( const bool value ) {
+        CHECK( value );
+    } );
+    lua.set_function( "native_one_in", []( const double value ) {
+        return one_in( static_cast<int>( value ) );
+    } );
+    const sol::protected_function_result installed = lua.safe_script( R"(
+local random = ccb.services.random
+ccb.runtime.handler("check_ranges", function()
+    local lo, hi = -2147483648, 2147483647
+    check(random.int(lo, lo) == lo)
+    check(random.int(hi, hi) == hi)
+    for i = 1, 8 do
+        local value = random.int(lo, hi)
+        check(value >= lo and value <= hi and value == math.floor(value))
+    end
+    for _, denominator in ipairs({lo - 0.9, lo, -1.9, 0, 1, 1.9}) do
+        check(random.one_in(denominator) == native_one_in(denominator))
+    end
+    check(type(random.one_in(hi)) == "boolean")
+    check(type(random.one_in(hi + 0.9)) == "boolean")
+    check(not pcall(random.int, lo - 1, hi))
+    check(not pcall(random.int, lo, hi + 1))
+    check(not pcall(random.int, 1, 0))
+    for _, denominator in ipairs({lo - 1, hi + 1, math.huge, -math.huge, 0/0}) do
+        check(not pcall(random.one_in, denominator))
+    end
+    done = true
+end)
+ccb.runtime.on("world_ready", "check_ranges")
+)" );
+    REQUIRE( installed.valid() );
+    runtime_world_ready( true );
+    CHECK( lua["done"].get_or( false ) );
+    const sol::protected_function_result outside_callback = lua.safe_script(
+            "return pcall(ccb.services.random.int, 0, 1)" );
+    REQUIRE( outside_callback.valid() );
+    CHECK_FALSE( outside_callback.get<bool>() );
+}
+
+#endif

--- a/tests/lua_platform_string_comparison_test.cpp
+++ b/tests/lua_platform_string_comparison_test.cpp
@@ -1,0 +1,41 @@
+#if defined(CATA_ENABLE_LUA_PLATFORM) && CATA_ENABLE_LUA_PLATFORM
+
+#include <string>
+
+#include "avatar.h"
+#include "cata_catch.h"
+#include "condition.h"
+#include "dialogue.h"
+#include "flexbuffer_json.h"
+#include "json_loader.h"
+#include "npc.h"
+
+TEST_CASE( "lua_platform_string_comparison_native_short_circuit_contract",
+           "[lua][platform][string_comparison][semantic]" )
+{
+    avatar player;
+    npc partner;
+    player.normalize();
+    partner.normalize();
+    player.set_value( "comparison", "alpha" );
+    partner.set_value( "comparison", "alpha" );
+    dialogue context( get_talker_for( player ), get_talker_for( partner ) );
+    const auto evaluate = [&context]( const std::string & input ) {
+        const conditional_t condition( json_loader::from_string( input ).get_object() );
+        return condition( context );
+    };
+    // Evaluating the final mutator would request an invalid game option.
+    // A decisive pair must prevent that evaluation entirely.
+    CHECK( evaluate(
+               R"({"compare_string":[{"u_val":"comparison"},{"npc_val":"comparison"},{"mutator":"game_option","option":"INVALID_UNREACHED_OPTION"}]})" ) );
+    partner.set_value( "comparison", "beta" );
+    CHECK_FALSE( evaluate(
+                     R"({"compare_string_match_all":[{"u_val":"comparison"},{"npc_val":"comparison"},{"mutator":"game_option","option":"INVALID_UNREACHED_OPTION"}]})" ) );
+    CHECK_FALSE( evaluate( R"({"compare_string":[]})" ) );
+    CHECK_FALSE( evaluate( R"({"compare_string":["only"]})" ) );
+    CHECK( evaluate( R"({"compare_string_match_all":["only"]})" ) );
+    CHECK_FALSE( evaluate( R"({"compare_string":["a","b","c"]})" ) );
+    CHECK( evaluate( R"({"compare_string_match_all":["a","a","a"]})" ) );
+}
+
+#endif

--- a/tests/lua_platform_string_variables_test.cpp
+++ b/tests/lua_platform_string_variables_test.cpp
@@ -6,6 +6,7 @@
 #include "avatar.h"
 #include "cata_catch.h"
 #include "character_id.h"
+#include "character.h"
 #include "condition.h"
 #include "dialogue.h"
 #include "flexbuffer_json.h"
@@ -111,6 +112,30 @@ TEST_CASE( "lua_platform_string_variable_owners_match_native_assignment",
     CHECK( null_snapshot["exists"].get<bool>() );
     CHECK( null_snapshot["value"].get<sol::object>().get_type() == sol::type::nil );
 
+    diag_value nested;
+    nested._deserialize( json_loader::from_string( "[null,[1,null,\"tail\"],{\"tripoint\":[1,2,3]}]" ),
+                         false );
+    Character &copy_source = source_npc ? static_cast<Character &>( partner ) : player;
+    copy_source.set_value( "nested_source", nested );
+    sol::protected_function copy = services["variables"]["copy"];
+    sol::protected_function_result copied = copy(
+            source_npc ? partner_handle : player_handle, "nested_source",
+            target_npc ? partner_handle : player_handle, "nested_target" );
+    REQUIRE( copied.valid() );
+    sol::table copy_result = copied;
+    REQUIRE( copy_result["ok"].get<bool>() );
+    CHECK( target.get_value( "nested_target" ) == nested );
+    copy_source.set_value( "nested_source", "changed after copy" );
+    CHECK( target.get_value( "nested_target" ) == nested );
+    const auto stale_target = cata::lua_platform::game_handle::from_creature(
+                                  player, { "avatar", 4801, 0, 0, 0, {} }, runtime, 2 );
+    sol::protected_function_result rejected = copy(
+            partner_handle, "string_input", stale_target, "nested_target" );
+    REQUIRE( rejected.valid() );
+    sol::table error_result = rejected;
+    CHECK_FALSE( error_result["ok"].get<bool>() );
+    CHECK( target.get_value( "nested_target" ) == nested );
+
 }
 
 TEST_CASE( "lua_platform_global_null_is_distinct_from_removal",
@@ -142,6 +167,23 @@ TEST_CASE( "lua_platform_global_null_is_distinct_from_removal",
     REQUIRE( result["ok"].get<bool>() );
     REQUIRE( get_globals().maybe_get_global_value( key ) != nullptr );
     CHECK( get_globals().get_global_value( key ).is_empty() );
+    sol::protected_function copy = services["variables"]["copy"];
+    sol::protected_function_result self_copy = copy( sol::nil, key, sol::nil, key );
+    REQUIRE( self_copy.valid() );
+    sol::table self_result = self_copy;
+    REQUIRE( self_result["ok"].get<bool>() );
+    sol::table self_metadata = self_result["value"];
+    CHECK( self_metadata["source_exists"].get<bool>() );
+    CHECK( self_metadata["destination_existed"].get<bool>() );
+    CHECK( get_globals().get_global_value( key ).is_empty() );
+    sol::protected_function_result missing_copy = copy(
+            sol::nil, "lua_semantic_missing_copy_source", sol::nil, key );
+    REQUIRE( missing_copy.valid() );
+    sol::table missing_result = missing_copy;
+    REQUIRE( missing_result["ok"].get<bool>() );
+    sol::table missing_metadata = missing_result["value"];
+    CHECK_FALSE( missing_metadata["source_exists"].get<bool>() );
+    CHECK( get_globals().maybe_get_global_value( key ) != nullptr );
     sol::protected_function remove = services["variables"]["remove_global"];
     sol::protected_function_result erased = remove( key );
     REQUIRE( erased.valid() );

--- a/tests/lua_platform_string_variables_test.cpp
+++ b/tests/lua_platform_string_variables_test.cpp
@@ -9,6 +9,7 @@
 #include "condition.h"
 #include "dialogue.h"
 #include "flexbuffer_json.h"
+#include "global_vars.h"
 #include "json_loader.h"
 #include "lua_platform_bindings_values.h"
 #include "lua_platform_handle.h"
@@ -92,6 +93,59 @@ TEST_CASE( "lua_platform_string_variable_owners_match_native_assignment",
     REQUIRE( write_result["ok"].get<bool>() );
     const Character &target = target_npc ? static_cast<const Character &>( partner ) : player;
     CHECK( target.get_value( "platform_output" ).str() == target.get_value( "legacy_output" ).str() );
+    sol::protected_function_result null_write = set(
+            data, target_npc ? partner_handle : player_handle,
+            target_npc ? "npc" : "u", "platform_output", sol::nil );
+    REQUIRE( null_write.valid() );
+    sol::table null_result = null_write;
+    REQUIRE( null_result["ok"].get<bool>() );
+    REQUIRE( target.maybe_get_value( "platform_output" ) != nullptr );
+    CHECK( target.get_value( "platform_output" ).is_empty() );
+    sol::protected_function_result null_read = resolve(
+            data, target_npc ? partner_handle : player_handle,
+            target_npc ? "npc" : "u", "platform_output" );
+    REQUIRE( null_read.valid() );
+    sol::table null_read_result = null_read;
+    REQUIRE( null_read_result["ok"].get<bool>() );
+    sol::table null_snapshot = null_read_result["value"];
+    CHECK( null_snapshot["exists"].get<bool>() );
+    CHECK( null_snapshot["value"].get<sol::object>().get_type() == sol::type::nil );
+
+}
+
+TEST_CASE( "lua_platform_global_null_is_distinct_from_removal",
+           "[lua][platform][strings][semantic]" )
+{
+    const std::string key = "lua_semantic_null_global";
+    struct global_cleanup {
+        const std::string &key;
+        ~global_cleanup() {
+            get_globals().remove_global_value( key );
+        }
+    } cleanup{ key };
+    REQUIRE( get_globals().maybe_get_global_value( key ) == nullptr );
+    const auto owner = cata::lua_platform::make_game_handle_runtime_owner();
+    const cata::lua_platform::game_handle_runtime runtime{ owner, 1 };
+    sol::state lua;
+    sol::table services = lua.create_table();
+    cata::lua_platform::install_variable_api( services, [runtime]() {
+        return runtime;
+    }, []() {
+        return std::size_t( 1 );
+    }, []() {}, []() {}, []() {
+        return true;
+    } );
+    sol::protected_function set = services["variables"]["set_global"];
+    sol::protected_function_result write = set( key, sol::nil );
+    REQUIRE( write.valid() );
+    sol::table result = write;
+    REQUIRE( result["ok"].get<bool>() );
+    REQUIRE( get_globals().maybe_get_global_value( key ) != nullptr );
+    CHECK( get_globals().get_global_value( key ).is_empty() );
+    sol::protected_function remove = services["variables"]["remove_global"];
+    sol::protected_function_result erased = remove( key );
+    REQUIRE( erased.valid() );
+    CHECK( get_globals().maybe_get_global_value( key ) == nullptr );
 }
 
 #endif

--- a/tests/lua_platform_string_variables_test.cpp
+++ b/tests/lua_platform_string_variables_test.cpp
@@ -1,0 +1,97 @@
+#if defined(CATA_ENABLE_LUA_PLATFORM) && CATA_ENABLE_LUA_PLATFORM
+
+#include <cstddef>
+#include <string>
+
+#include "avatar.h"
+#include "cata_catch.h"
+#include "character_id.h"
+#include "condition.h"
+#include "dialogue.h"
+#include "flexbuffer_json.h"
+#include "json_loader.h"
+#include "lua_platform_bindings_values.h"
+#include "lua_platform_handle.h"
+#include "lua_platform_variables.h"
+#include "math_parser_diag_value.h"
+#include "npc.h"
+
+TEST_CASE( "lua_platform_string_variable_owners_match_native_assignment",
+           "[lua][platform][strings][semantic]" )
+{
+    avatar player;
+    npc partner;
+    player.normalize();
+    partner.normalize();
+    player.setID( character_id( 4801 ), true );
+    partner.setID( character_id( 4802 ), true );
+    cata::lua_platform::register_npc_handle_identity( partner );
+    struct identity_cleanup {
+        npc &value;
+        ~identity_cleanup() {
+            cata::lua_platform::retire_npc_handle_identity( value );
+        }
+    } cleanup{ partner };
+    player.set_value( "string_input", "alpha value" );
+    partner.set_value( "string_input", "beta value" );
+    const bool source_npc = GENERATE( false, true );
+    const bool target_npc = GENERATE( false, true );
+    const bool indirect = GENERATE( false, true );
+    const std::string source_key = source_npc ? "npc_val" : "u_val";
+    const std::string target_key = target_npc ? "npc_val" : "u_val";
+    dialogue context( get_talker_for( player ), get_talker_for( partner ) );
+    context.set_value( "destination", target_npc ? "n_legacy_output" : "u_legacy_output" );
+    talk_effect_t legacy;
+    const std::string input = "{\"set_string_var\":{\"" + source_key +
+                              "\":\"string_input\"},\"target_var\":{\"" +
+                              ( indirect ? "var_val" : target_key ) + "\":\"" +
+                              ( indirect ? "destination" : "legacy_output" ) + "\"}}";
+    legacy.parse_sub_effect( json_loader::from_string( input ).get_object(), "string_acceptance" );
+    for( const talk_effect_fun_t &effect : legacy.effects ) {
+        effect( context );
+    }
+    const auto owner = cata::lua_platform::make_game_handle_runtime_owner();
+    const cata::lua_platform::game_handle_runtime runtime{ owner, 1 };
+    sol::state lua;
+    sol::table services = lua.create_table();
+    cata::lua_platform::install_value_type_api( lua, services, []() {} );
+    cata::lua_platform::install_game_handle_api( lua, services, [runtime]() {
+        return runtime;
+    }, []() {
+        return std::size_t( 1 );
+    }, []() {} );
+    cata::lua_platform::install_variable_api( services, [runtime]() {
+        return runtime;
+    }, []() {
+        return std::size_t( 1 );
+    }, []() {}, []() {}, []() {
+        return true;
+    } );
+    const auto player_handle = cata::lua_platform::game_handle::from_creature(
+                                   player, { "avatar", 4801, 0, 0, 0, {} }, runtime, 1 );
+    const auto partner_handle = cata::lua_platform::game_handle::from_creature(
+                                    partner, { "npc", 4802, 0, 0, 0, {} }, runtime, 1 );
+    sol::table data = lua.create_table();
+    sol::protected_function resolve = services["variables"]["resolve"];
+    sol::protected_function_result read = resolve(
+            data, source_npc ? partner_handle : player_handle,
+            source_npc ? "npc" : "u", "string_input" );
+    REQUIRE( read.valid() );
+    sol::table read_result = read;
+    REQUIRE( read_result["ok"].get<bool>() );
+    sol::table snapshot = read_result["value"];
+    const std::string value = snapshot["value"];
+    CHECK( value == ( source_npc ? "beta value" : "alpha value" ) );
+    // Generated Lua resolves indirect prefixes before this single-owner API.
+    sol::protected_function set = services["variables"]["set_resolved"];
+    sol::protected_function_result write = set(
+            data, target_npc ? partner_handle : player_handle,
+            target_npc ? "npc" : "u", "platform_output", value );
+    REQUIRE( write.valid() );
+    sol::table write_result = write;
+    REQUIRE( write_result["ok"].get<bool>() );
+    const Character &target = target_npc ? static_cast<const Character &>( partner ) : player;
+    CHECK( target.get_value( "platform_output" ).str() == target.get_value( "legacy_output" ).str() );
+}
+
+#endif

--- a/tools/agent/generate_lua_first_replacement_ledger.py
+++ b/tools/agent/generate_lua_first_replacement_ledger.py
@@ -85,12 +85,30 @@ CONTROL_FLOW = {
     "weighted_list_eocs",
 }
 
-# No disposition is verified during the source-only implementation sprint.
-# These sets are intentionally empty. A future final semantic-gate batch may
-# add exact selectors after recording native behavior and real inventory
-# evidence; source presence or a previous local run is not enough.
+# JSON object types remain unverified. Promote exact selectors only after
+# recording native behavior and real inventory evidence; source presence or
+# a previous local run is not enough. EOC acceptance is recorded separately.
 IMPLEMENTED_VERIFIED = frozenset()
 BOUNDED_IMPLEMENTED_VERIFIED = frozenset()
+
+# Exact, complete EOC selector scopes accepted against native behavior and real
+# content. is_day is parameterless: f_is_day and the public environment query
+# both use is_night(calendar::turn), including twilight. The native gate
+# compares the installed Lua service at calendar boundaries; migration uses
+# direct and negated conditions from TALK_TEST.json. This is not a promotion of
+# other environment predicates or of the surrounding content's migration.
+VERIFIED_EOC = {
+    ("eoc-conditions", "is_day"): {
+        "target": "services.gameplay.environment",
+        "evidence": [
+            "src/lua_platform_runtime_services.cpp",
+            "tests/lua_platform_day_semantic_test.cpp",
+            "tools/migrate_lua_first.py",
+            "tools/test_migrate_lua_first.py",
+            "data/lua/types/ccb_platform_v1.d.lua",
+        ],
+    },
+}
 
 IMPLEMENTED_JSON = {
     "monster_adjustment": {
@@ -4581,6 +4599,17 @@ def disposition(inventory: str, selector: str, entry: dict) -> dict:
             "evidence": legacy_evidence(inventory, entry),
         }
 
+    verified = VERIFIED_EOC.get((inventory, selector))
+    if verified:
+        return {
+            "inventory": inventory,
+            "selector": selector,
+            "target_kind": "shared_service",
+            "target": verified["target"],
+            "status": "implemented_verified",
+            "legacy_dependency": "none",
+            "evidence": verified["evidence"],
+        }
     bounded_target = BOUNDED_IMPLEMENTED_EOC.get((inventory, selector))
     if (
         bounded_target and

--- a/tools/agent/test_lua_first_replacement_ledger.py
+++ b/tools/agent/test_lua_first_replacement_ledger.py
@@ -95,9 +95,24 @@ class LuaFirstReplacementLedgerTest(unittest.TestCase):
         ):
             classify_migration_todo("selector_todo")
 
-    def test_verified_promotions_are_disabled_until_the_final_gate(self):
+    def test_json_promotions_remain_disabled_until_their_final_gate(self):
         self.assertEqual(IMPLEMENTED_VERIFIED, frozenset())
         self.assertEqual(BOUNDED_IMPLEMENTED_VERIFIED, frozenset())
+
+    def test_only_accepted_day_predicate_is_promoted(self):
+        verified = [entry for entry in build_ledger()["entries"]
+                    if entry["status"] == "implemented_verified"]
+        self.assertEqual(
+            [(entry["inventory"], entry["selector"]) for entry in verified],
+            [("eoc-conditions", "is_day")],
+        )
+        self.assertEqual(verified[0]["verification"], "final_semantic_gate")
+        self.assertIn(
+            "tests/lua_platform_day_semantic_test.cpp", verified[0]["evidence"]
+        )
+        self.assertIn(
+            "tools/test_migrate_lua_first.py", verified[0]["evidence"]
+        )
 
     def test_generator_uses_the_three_real_inventories(self):
         generated = build_ledger()

--- a/tools/lua_api/test_mod_sdk.py
+++ b/tools/lua_api/test_mod_sdk.py
@@ -305,6 +305,19 @@ return inspect
             self.assertEqual(
                 mod_sdk.check_mod(mod, os.environ["CCB_LUALS"]), [])
 
+    def test_day_predicate_has_boolean_editor_type(self):
+        with tempfile.TemporaryDirectory() as directory:
+            mod = self.scaffold(Path(directory), "minimal")
+            (mod / "day.lua").write_text('''local ccb = require("ccb")
+---@return boolean
+return function()
+    local services = ccb.services
+    return not services.gameplay.environment.is_night()
+end
+''', encoding="utf-8")
+            self.assertEqual(
+                mod_sdk.check_mod(mod, os.environ["CCB_LUALS"]), [])
+
     def test_native_variable_copy_has_editor_types(self):
         with tempfile.TemporaryDirectory() as directory:
             mod = self.scaffold(Path(directory), "minimal")

--- a/tools/lua_api/test_mod_sdk.py
+++ b/tools/lua_api/test_mod_sdk.py
@@ -305,6 +305,23 @@ return inspect
             self.assertEqual(
                 mod_sdk.check_mod(mod, os.environ["CCB_LUALS"]), [])
 
+    def test_native_variable_copy_has_editor_types(self):
+        with tempfile.TemporaryDirectory() as directory:
+            mod = self.scaffold(Path(directory), "minimal")
+            source = mod / "copy.lua"
+            source.write_text('''local ccb = require("ccb")
+---@param owner GameHandle
+return function(owner)
+    local result = ccb.services.variables.copy(nil, "global", owner, "local")
+    if result.ok then
+        local metadata = assert(result.value)
+        return metadata.source_exists, metadata.destination_existed
+    end
+end
+''', encoding="utf-8")
+            self.assertEqual(
+                mod_sdk.check_mod(mod, os.environ["CCB_LUALS"]), [])
+
     def test_interaction_input_uses_native_options_and_result(self):
         with tempfile.TemporaryDirectory() as directory:
             mod = self.scaffold(Path(directory), "minimal")

--- a/tools/migrate_lua_first.py
+++ b/tools/migrate_lua_first.py
@@ -26829,55 +26829,22 @@ def render_eoc_condition_expression(
             return None
         numerator = finite_number_literal(chance["x"])
         denominator = finite_number_literal(chance["y"])
-        if numerator is None:
-            numerator_expression = render_eoc_numeric_expression(
-                chance["x"], "0", "actor"
-            )
-            if numerator_expression is None:
-                return None
-            numerator_expression = (
-                "math.max(0, math.min(1000000000, (" +
-                numerator_expression + ")))"
-            )
-        else:
-            if numerator < 0 or numerator > 1000000000:
-                return None
-            numerator_expression = lua_number(numerator)
-        if denominator is None:
-            denominator_expression = render_eoc_numeric_expression(
-                chance["y"], "1", "actor"
-            )
-            if denominator_expression is None:
-                return None
-            denominator_expression = (
-                "math.max(1, math.min(1000000000, (" +
-                denominator_expression + ")))"
-            )
-        else:
-            if denominator <= 0 or denominator > 1000000000:
-                return None
-            denominator_expression = lua_number(denominator)
+        if numerator is not None and numerator < 0:
+            return None
+        if denominator is not None and denominator <= 0:
+            return None
         if numerator is not None and denominator is not None and numerator > denominator:
             return None
-        if numerator is not None and denominator is None:
-            numerator_expression = (
-                "math.min(" + denominator_expression + ", " +
-                numerator_expression + ")"
-            )
-        elif numerator is None and denominator is not None:
-            numerator_expression = (
-                "math.min(" + denominator_expression + ", " +
-                numerator_expression + ")"
-            )
-        elif numerator is None and denominator is None:
-            numerator_expression = (
-                "math.min(" + denominator_expression + ", " +
-                numerator_expression + ")"
-            )
-        return (
-            "services.random.probability("
-            f"{numerator_expression}, {denominator_expression})"
-        )
+        expressions = [_effect_numeric_expression(
+            chance[key], "actor", "actor" if character_actor_proven else None, npc_query_actor)
+            for key in ("x", "y")]
+        if any(expression is None for expression in expressions):
+            return None
+        # Each operand is evaluated once. The public service accepts finite
+        # fractional values without the integer random service's range bound.
+        # Invalid ratios remain explicit errors instead of being clamped to a
+        # different probability.
+        return f"services.random.probability({expressions[0]}, {expressions[1]})"
 
     if set(condition) <= {"roll_contested", "difficulty", "die_size"} and {
         "roll_contested", "difficulty"

--- a/tools/migrate_lua_first.py
+++ b/tools/migrate_lua_first.py
@@ -24553,6 +24553,19 @@ def render_dynamic_character_wound(
     return lines
 
 
+def render_direct_variable_snapshot(value: Any, owner: str) -> str | None:
+    """Retain presence separately from the Lua representation of a stored null."""
+    if not isinstance(value, dict) or len(value) != 1:
+        return None
+    key, name = next(iter(value.items()))
+    scopes = {"u_val": "u", "npc_val": "npc", "global_val": "global", "context_val": "context"}
+    if key not in scopes or render_eoc_value_expression(value, "nil", owner) is None:
+        return None
+    actual_owner = owner if key in {"u_val", "npc_val"} else "nil"
+    return ('service_value(services.variables.resolve(context.data, '
+            f'{actual_owner}, {lua_quote(scopes[key])}, {lua_quote(name)}))')
+
+
 def render_participant_string_expression(
     value: Any, target_expression: str,
     avatar_expression: str | None, npc_expression: str | None,
@@ -24651,9 +24664,19 @@ def render_participant_string_expression(
                 'elseif name:sub(1, 2) == "n_" then scope, owner, name = "npc", ' +
                 npc_expression + ', name:sub(3) '
                 'elseif name:sub(1, 1) == "_" then scope, name = "context", name:sub(2) end; '
-                'return tostring(service_value(services.variables.resolve('
-                'context.data, owner, scope, name)).value or ' + fallback + ') end)()'
+                'local result = service_value(services.variables.resolve('
+                'context.data, owner, scope, name)); '
+                'if result.exists == false then return ' + fallback + ' end; '
+                'return tostring(result.value or "") end)()'
             )
+        if "default" in value:
+            variable = {key: item for key, item in value.items() if key != "default"}
+            snapshot = render_direct_variable_snapshot(variable, owner)
+            fallback = value["default"]
+            if snapshot is None or not bounded_utf8_string(fallback, 8192, allow_empty=True):
+                return None
+            return ('(function(result) if result.exists == false then return '
+                    f'{lua_quote(fallback)} end; return tostring(result.value or "") end)({snapshot})')
     return render_eoc_string_expression(value, owner)
 
 
@@ -24981,10 +25004,10 @@ def render_participant_translation_expression(
             return None
         fallback = render_participant_translation_expression(
             value["default"], target_expression, avatar_expression, npc_expression)
-        raw = render_eoc_value_expression({key: value[key]}, "nil", owner or target_expression)
+        raw = render_direct_variable_snapshot({key: value[key]}, owner or target_expression)
         if fallback is None or raw is None:
             return None
-        return ('(function(value) if value ~= nil then return tostring(value) end; '
+        return ('(function(result) if result.exists ~= false then return tostring(result.value or \"\") end; '
                 f'return {fallback} end)({raw})')
     return render_participant_string_expression(
         value, target_expression, avatar_expression, npc_expression)

--- a/tools/migrate_lua_first.py
+++ b/tools/migrate_lua_first.py
@@ -24927,18 +24927,21 @@ def render_static_character_copy_var(
         ]
 
     lines = address(source, "copy_source")
-    lines.extend([
-        '    local copied = { exists = false }',
-        '    if copy_source_key ~= nil then',
-        '        copied = service_value(services.variables.resolve(',
-        '            context.data, copy_source_owner, copy_source_scope, copy_source_key))',
-        '    end',
-    ])
     lines.extend(address(target, "copy_target"))
     lines.extend([
         '    if copy_target_key == nil then error("missing target variable") end',
-        '    service_value(services.variables.set_resolved(',
-        '        context.data, copy_target_owner, copy_target_scope, copy_target_key, copied.value))',
+        '    if copy_source_key ~= nil and copy_source_scope ~= "context" and copy_target_scope ~= "context" then',
+        '        service_value(services.variables.copy(',
+        '            copy_source_owner, copy_source_key, copy_target_owner, copy_target_key))',
+        '    else',
+        '        local copied = { exists = false }',
+        '        if copy_source_key ~= nil then',
+        '            copied = service_value(services.variables.resolve(',
+        '                context.data, copy_source_owner, copy_source_scope, copy_source_key))',
+        '        end',
+        '        service_value(services.variables.set_resolved(',
+        '            context.data, copy_target_owner, copy_target_scope, copy_target_key, copied.value))',
+        '    end',
     ])
     return lines
 

--- a/tools/migrate_lua_first.py
+++ b/tools/migrate_lua_first.py
@@ -26055,8 +26055,6 @@ def render_eoc_condition_expression(
             )
         if condition == "is_day":
             return "not services.gameplay.environment.is_night()"
-        if condition == "is_night":
-            return "services.gameplay.environment.is_night()"
         if npc_query_actor is not None:
             if condition == "npc_is_alive":
                 return (

--- a/tools/migrate_lua_first.py
+++ b/tools/migrate_lua_first.py
@@ -19137,7 +19137,7 @@ def _effect_numeric_expression(
             return None
         for endpoint in value:
             literal = finite_number_literal(endpoint)
-            if literal is not None and abs(math.trunc(literal)) > 1000000000:
+            if literal is not None and not -2147483648 <= math.trunc(literal) <= 2147483647:
                 return None
         endpoints = [_effect_numeric_expression(endpoint, target, alpha, beta) for endpoint in value]
         if any(endpoint is None for endpoint in endpoints):
@@ -26812,19 +26812,14 @@ def render_eoc_condition_expression(
 
     if set(condition) == {"one_in_chance"}:
         value = finite_number_literal(condition["one_in_chance"])
-        if value is not None:
-            if value < -1000000000 or value > 1000000000:
-                return None
-            return f"services.random.one_in({lua_number(value)})"
-        dynamic = render_eoc_numeric_expression(
-            condition["one_in_chance"], "0", "actor"
-        )
-        if dynamic is None:
+        if value is not None and not -2147483648 <= math.trunc(value) <= 2147483647:
             return None
-        return (
-            "services.random.one_in(math.max(-1000000000, math.min("
-            f"1000000000, ({dynamic}))))"
-        )
+        denominator = _effect_numeric_expression(
+            condition["one_in_chance"], "actor",
+            "actor" if character_actor_proven else None, npc_query_actor)
+        if denominator is None:
+            return None
+        return f"services.random.one_in({denominator})"
 
     if set(condition) == {"x_in_y_chance"}:
         chance = condition["x_in_y_chance"]

--- a/tools/migrate_lua_first.py
+++ b/tools/migrate_lua_first.py
@@ -24962,6 +24962,50 @@ def render_static_character_copy_var(
     return lines
 
 
+def render_participant_translation_expression(
+    value: Any, target_expression: str,
+    avatar_expression: str | None, npc_expression: str | None,
+) -> str | None:
+    """Translate authored literals; stored dialogue values are already translated."""
+    if isinstance(value, str) or (
+            isinstance(value, dict) and ("str" in value or "str_sp" in value)):
+        literal = value if isinstance(value, str) else value.get("str_sp", value.get("str"))
+        translation_context = value.get("ctxt") if isinstance(value, dict) else None
+        if not bounded_utf8_string(literal, 8192, allow_empty=True):
+            return None
+        if translation_context is not None and not bounded_utf8_string(
+                translation_context, 8192, allow_empty=True):
+            return None
+        arguments = lua_quote(literal)
+        if translation_context is not None:
+            arguments += ", " + lua_quote(translation_context)
+        return f"services.translate({arguments})"
+    if isinstance(value, dict) and "default" in value:
+        # A translated fallback must run only when the variable is absent.
+        # Keep unsupported indirect fallback shapes explicit for now.
+        keys = set(value) - {"default"}
+        if len(keys) != 1:
+            return None
+        key = next(iter(keys))
+        owner = {"u_val": avatar_expression, "npc_val": npc_expression}.get(key)
+        if key not in {"u_val", "npc_val", "context_val", "global_val"} or (
+                key in {"u_val", "npc_val"} and owner is None):
+            return None
+        default = value["default"]
+        if not (isinstance(default, str) or isinstance(default, dict) and (
+                "str" in default or "str_sp" in default)):
+            return None
+        fallback = render_participant_translation_expression(
+            value["default"], target_expression, avatar_expression, npc_expression)
+        raw = render_eoc_value_expression({key: value[key]}, "nil", owner or target_expression)
+        if fallback is None or raw is None:
+            return None
+        return ('(function(value) if value ~= nil then return tostring(value) end; '
+                f'return {fallback} end)({raw})')
+    return render_participant_string_expression(
+        value, target_expression, avatar_expression, npc_expression)
+
+
 def render_static_character_string_var(
     effect: dict[str, Any],
     avatar_actor_proven: bool,
@@ -25014,27 +25058,12 @@ def render_static_character_string_var(
             actor_expression = "actor"
 
     def render_value(value: Any) -> str | None:
-        if i18n and (isinstance(value, str) or (
-                isinstance(value, dict) and ("str" in value or "str_sp" in value))):
-            literal = value if isinstance(value, str) else value.get("str_sp", value.get("str"))
-            translation_context = value.get("ctxt") if isinstance(value, dict) else None
-            if not bounded_utf8_string(literal, 8192, allow_empty=True):
-                return None
-            if translation_context is not None and not bounded_utf8_string(
-                    translation_context, 8192, allow_empty=True):
-                return None
-            arguments = lua_quote(literal)
-            if translation_context is not None:
-                arguments += ", " + lua_quote(translation_context)
-            return f"services.translate({arguments})"
-        rendered = render_participant_string_expression(
+        renderer = render_participant_translation_expression if i18n else render_participant_string_expression
+        return renderer(
             value, actor_expression,
             "actor" if avatar_actor_proven else None,
             npc_actor_expression or ("actor" if npc_actor_proven else None),
         )
-        if rendered is None:
-            return None
-        return rendered
 
     rendered_values = [render_value(value) for value in values]
     if any(value is None for value in rendered_values):
@@ -25054,19 +25083,26 @@ def render_static_character_string_var(
             "title", "description", "default_text", "identifier",
         }:
             return None
-        title = display_text(input_options.get("title"), "")
-        description = display_text(input_options.get("description"), "")
-        initial = display_text(input_options.get("default_text"), "")
-        if not all(isinstance(value, str) for value in (title, description, initial)):
+        alpha = "actor" if avatar_actor_proven else None
+        beta = npc_actor_expression or ("actor" if npc_actor_proven else None)
+        translated_options = [render_participant_translation_expression(
+            input_options[key], actor_expression, alpha, beta) if key in input_options else '""'
+            for key in ("title", "default_text", "description")]
+        identifier = render_participant_string_expression(
+            input_options["identifier"], actor_expression, alpha, beta) if "identifier" in input_options else '""'
+        if any(option is None for option in translated_options) or identifier is None:
             return None
-        identifier = input_options.get("identifier", "")
-        if not bounded_utf8_string(identifier, 128, allow_empty=True):
-            return None
+        title, initial, description = translated_options
         lines.extend([
             f"    local value = {value_expression}",
+            f"    local input_label_width = #{title}",
+            f"    local input_default = {initial}",
+            f"    local input_title = {title}",
+            f"    local input_description = {description}",
+            f"    local input_identifier = {identifier}",
             "    local input = services.interaction.input_text(",
-            f"        {lua_quote(title)}, {{ default = {lua_quote(initial)}, "
-            f"description = {lua_quote(description)}, identifier = {lua_quote(identifier)} }})",
+            "        input_title, { default = input_default, description = input_description,",
+            "        identifier = input_identifier, width = 40 + input_label_width })",
             "    if input.accepted then",
             "        value = input.value",
             "    end",

--- a/tools/migrate_lua_first.py
+++ b/tools/migrate_lua_first.py
@@ -26761,25 +26761,26 @@ def render_eoc_condition_expression(
                 f"services.types.id(\"{kind}\", {lua_quote(condition[item_key])})))"
             )
 
-    for key, function_name, minimum in (
-        ("compare_string", "any_equal", 2),
-        ("compare_string_match_all", "all_equal", 1),
-    ):
+    for key, all_equal in (("compare_string", False), ("compare_string_match_all", True)):
         if set(condition) == {key}:
             values = condition[key]
-            if not isinstance(values, list) or len(values) < minimum:
+            if not isinstance(values, list) or all_equal and not values:
                 return None
-            rendered = [
-                render_eoc_string_expression(value)
-                for value in values
-            ]
+            rendered = [render_participant_string_expression(
+                value, "actor", "actor" if character_actor_proven else None, npc_query_actor)
+                for value in values]
             if any(value is None for value in rendered):
                 return None
-            rendered_values = ", ".join(rendered)
-            return (
-                f"services.gameplay.strings.{function_name}"
-                f"({{{rendered_values}}})"
-            )
+            if all_equal:
+                statements = [f"local first = {rendered[0]};"]
+                statements.extend(f"if {value} ~= first then return false end;" for value in rendered[1:])
+                statements.append("return true")
+            else:
+                statements = ["local seen = {}; local value;"]
+                statements.extend(f"value = {value}; if seen[value] then return true end; seen[value] = true;"
+                                  for value in rendered)
+                statements.append("return false")
+            return "(function() " + " ".join(statements) + " end)()"
 
     if set(condition) == {"one_in_chance"}:
         value = finite_number_literal(condition["one_in_chance"])

--- a/tools/migrate_lua_first.py
+++ b/tools/migrate_lua_first.py
@@ -4992,7 +4992,7 @@ def render_static_false_effect(
         ]
     if isinstance(effect, dict) and "copy_var" in effect:
         rendered = render_static_character_copy_var(
-            effect, avatar_actor_proven, npc_actor_proven
+            effect, avatar_actor_proven, npc_actor_proven, npc_actor_expression
         )
         if rendered is None:
             return None
@@ -24891,6 +24891,7 @@ def render_static_character_copy_var(
     effect: dict[str, Any],
     avatar_actor_proven: bool,
     npc_actor_proven: bool,
+    npc_actor_expression: str | None = None,
 ) -> list[str] | None:
     if set(effect) != {"copy_var", "target_var"}:
         return None
@@ -24898,67 +24899,47 @@ def render_static_character_copy_var(
     target = _static_string_variable_descriptor(effect["target_var"])
     if source is None or target is None:
         return None
-    if source[0] == "npc" and not npc_actor_proven:
-        return None
-    if target[0] == "npc" and not npc_actor_proven:
-        return None
-    actor_expression = (
-        "actor" if (avatar_actor_proven or npc_actor_proven)
-        else "services.characters.avatar()"
-    )
+    alpha = "actor" if avatar_actor_proven else None
+    beta = npc_actor_expression or ("actor" if npc_actor_proven else None)
+    for scope, _ in (source, target):
+        if (scope == "u" and alpha is None or scope == "npc" and beta is None or
+                scope == "var" and (alpha is None or beta is None)):
+            return None
 
-    def resolved(scope: str, name: str) -> str:
-        if scope in {"u", "npc"}:
-            return (
-                "service_value(services.variables.get("
-                f"{actor_expression}, {lua_quote(name)}))"
-            )
-        return (
-            "service_value(services.variables.resolve(context.data, "
-            f"{actor_expression}, {lua_quote(scope)}, {lua_quote(name)}))"
-        )
+    def address(descriptor: tuple[str, str], prefix: str) -> list[str]:
+        scope, key = descriptor
+        owner = {"u": alpha, "npc": beta}.get(scope) or "nil"
+        if scope != "var":
+            return [f"    local {prefix}_scope, {prefix}_owner, {prefix}_key = "
+                    f"{lua_quote(scope)}, {owner}, {lua_quote(key)}"]
+        return [
+            f"    local {prefix}_scope, {prefix}_owner = \"global\", nil",
+            f"    local {prefix}_key = context.data[{lua_quote(key)}]",
+            f"    if {prefix}_key ~= nil then",
+            f'        if {prefix}_key:sub(1, 2) == "u_" then',
+            f'            {prefix}_scope, {prefix}_owner, {prefix}_key = "u", {alpha}, {prefix}_key:sub(3)',
+            f'        elseif {prefix}_key:sub(1, 2) == "n_" then',
+            f'            {prefix}_scope, {prefix}_owner, {prefix}_key = "npc", {beta}, {prefix}_key:sub(3)',
+            f'        elseif {prefix}_key:sub(1, 1) == "_" then',
+            f'            {prefix}_scope, {prefix}_key = "context", {prefix}_key:sub(2)',
+            '        end',
+            '    end',
+        ]
 
-    lines = [
-        f"    local copied = {resolved(source[0], source[1])}",
-        "    if copied.exists then",
-    ]
-    if target[0] == "context":
-        lines.append(
-            f"        context.data[{lua_quote(target[1])}] = copied.value"
-        )
-    elif target[0] == "global":
-        lines.append(
-            "        services.variables.set_global("
-            f"{lua_quote(target[1])}, copied.value)"
-        )
-    elif target[0] in {"u", "npc"}:
-        lines.append(
-            "        services.variables.set("
-            f"{actor_expression}, {lua_quote(target[1])}, copied.value)"
-        )
-    else:
-        lines.append(
-            "        service_value(services.variables.set_resolved("
-            f"context.data, {actor_expression}, \"var\", "
-            f"{lua_quote(target[1])}, copied.value))"
-        )
-    lines.append("    else")
-    if target[0] == "context":
-        lines.append(f"        context.data[{lua_quote(target[1])}] = nil")
-    elif target[0] == "global":
-        lines.append(
-            f"        services.variables.remove_global({lua_quote(target[1])})"
-        )
-    elif target[0] in {"u", "npc"}:
-        lines.append(
-            f"        services.variables.remove({actor_expression}, {lua_quote(target[1])})"
-        )
-    else:
-        # The v5 contract has no remove_resolved operation; leaving an
-        # indirect destination untouched is safer than writing a fabricated
-        # nil value into the native variable store.
-        lines.append("        -- missing source leaves an indirect target unchanged")
-    lines.append("    end")
+    lines = address(source, "copy_source")
+    lines.extend([
+        '    local copied = { exists = false }',
+        '    if copy_source_key ~= nil then',
+        '        copied = service_value(services.variables.resolve(',
+        '            context.data, copy_source_owner, copy_source_scope, copy_source_key))',
+        '    end',
+    ])
+    lines.extend(address(target, "copy_target"))
+    lines.extend([
+        '    if copy_target_key == nil then error("missing target variable") end',
+        '    service_value(services.variables.set_resolved(',
+        '        context.data, copy_target_owner, copy_target_scope, copy_target_key, copied.value))',
+    ])
     return lines
 
 
@@ -31645,7 +31626,8 @@ def render_eoc(
                     all_effects_converted = False
             elif isinstance(effect, dict) and "copy_var" in effect:
                 rendered = render_static_character_copy_var(
-                    effect, character_actor_proven, npc_event_character_actor_proven
+                    effect, character_actor_proven, npc_event_character_actor_proven,
+                    npc_actor_expression,
                 )
                 if rendered is not None:
                     lines.extend(rendered)

--- a/tools/migrate_lua_first.py
+++ b/tools/migrate_lua_first.py
@@ -24571,6 +24571,11 @@ def render_participant_string_expression(
     avatar_expression: str | None, npc_expression: str | None,
 ) -> str | None:
     """Resolve a string independently of the character being queried or changed."""
+    if isinstance(value, dict) and value.get("i18n") is True and "str" in value:
+        if set(value) - {"str", "i18n", "//~"} or not isinstance(value["str"], str):
+            return None
+        return render_participant_translation_expression(
+            value, target_expression, avatar_expression, npc_expression)
     if isinstance(value, dict) and value.get("mutator") == "game_option":
         if set(value) != {"mutator", "option"}:
             return None
@@ -26896,36 +26901,32 @@ def render_eoc_condition_expression(
             "services.gameplay.environment.dimension() == "
             f"{lua_quote(condition['current_dimension'])}"
         )
-    if set(condition) == {"is_season"} and isinstance(
-        condition["is_season"], str
+    for selector, current in (
+        ("is_season", "services.time_snapshot().season_id"),
+        ("is_weather", "services.weather.current().weather.value"),
     ):
-        return (
-            "services.time_snapshot().season_id == "
-            f"{lua_quote(condition['is_season'])}"
-        )
-    if set(condition) == {"is_weather"}:
-        weather_value = condition["is_weather"]
-        if isinstance(weather_value, str):
-            if not safe_platform_id(weather_value):
+        if set(condition) != {selector}:
+            continue
+        value = condition[selector]
+        if isinstance(value, dict) and "str" in value:
+            # str_or_var accepts this object through its explicit translation
+            # mutator only. A plain {str: ...} object is not a string literal.
+            if (set(value) - {"str", "i18n", "//~"} or
+                    value.get("i18n") is not True or
+                    not isinstance(value["str"], str)):
                 return None
-            weather_expression = lua_quote(weather_value)
-        elif isinstance(weather_value, dict) and len(weather_value) == 1:
-            variable_key = next(iter(weather_value))
-            if variable_key not in {"context_val", "u_val", "global_val"}:
-                return None
-            if variable_key == "u_val" and not avatar_actor_proven:
-                return None
-            weather_expression = render_eoc_string_expression(
-                weather_value, "actor"
-            )
-            if weather_expression is None:
-                return None
+            requested = render_participant_translation_expression(
+                value, "actor", "actor" if avatar_actor_proven else None,
+                npc_query_actor)
         else:
-            return None
-        return (
-            "services.weather.current().weather.value == "
-            f"{weather_expression}"
-        )
+            if isinstance(value, dict) and not set(value).intersection({
+                "u_val", "npc_val", "global_val", "context_val", "var_val", "mutator",
+            }):
+                return None
+            requested = render_participant_string_expression(
+                value, "actor", "actor" if avatar_actor_proven else None,
+                npc_query_actor)
+        return None if requested is None else f"{current} == {requested}"
     if (
         set(condition) == {"map_furniture_with_flag", "loc"} and
         bounded_utf8_string(condition.get("map_furniture_with_flag"), 256)

--- a/tools/migrate_lua_first.py
+++ b/tools/migrate_lua_first.py
@@ -4999,7 +4999,7 @@ def render_static_false_effect(
         return [line.replace("    ", "        ", 1) for line in rendered]
     if isinstance(effect, dict) and "set_string_var" in effect:
         rendered = render_static_character_string_var(
-            effect, avatar_actor_proven, npc_actor_proven
+            effect, avatar_actor_proven, npc_actor_proven, npc_actor_expression
         )
         if rendered is None:
             return None

--- a/tools/test_migrate_lua_first.py
+++ b/tools/test_migrate_lua_first.py
@@ -16,6 +16,68 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
 class LuaFirstMigrationTest(unittest.TestCase):
     @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_input_translated_variables_preserve_native_evaluation_order(self) -> None:
+        lines = migrate_lua_first.render_static_character_string_var(
+            {"set_string_var": "original", "target_var": {"context_val": "output"},
+             "string_input": {"title": {"npc_val": "title"}, "default_text": {"u_val": "initial"},
+                              "description": {"str": "Help", "ctxt": "input"},
+                              "identifier": {"context_val": "history"}}}, True, True, "partner")
+        self.assertIsNotNone(lines)
+        script = r"""
+local actor={initial='alpha initial'}
+local partner={title='beta title'}
+local context={data={history='input_history'}}
+local order={}
+local function service_value(r) assert(r.ok);return r.value end
+local services={
+ variables={resolve=function(data,owner,scope,key)
+  order[#order+1]=key;return {ok=true,value={value=owner[key]}}
+ end},
+ translate=function(text,ctxt)
+  assert(text=='Help' and ctxt=='input');order[#order+1]='description';return 'translated help'
+ end,
+ interaction={input_text=function(title,options)
+  assert(table.concat(order,',')=='title,initial,title,description')
+  assert(title=='beta title' and options.default=='alpha initial')
+  assert(options.description=='translated help' and options.identifier=='input_history')
+  assert(options.width==50);return {accepted=true,cancelled=false,value='entered'}
+ end}
+}
+BODY
+assert(context.data.output=='entered')
+""".replace("BODY", "\n".join(lines))
+        result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_translated_variable_default_is_lazy_and_preserves_empty_values(self) -> None:
+        expression = migrate_lua_first.render_participant_translation_expression(
+            {"npc_val": "input", "default": {"str": "Fallback", "ctxt": "default"}},
+            "actor", "actor", "partner")
+        self.assertIsNotNone(expression)
+        for present in (True, False):
+            script = r"""
+local actor={}
+local partner={}
+local context={data={}}
+local calls=0
+local function service_value(r) assert(r.ok);return r.value end
+local services={
+ variables={resolve=function(data,owner,scope,key)
+  assert(owner==partner);return {ok=true,value={value=PRESENT and '' or nil}}
+ end},
+ translate=function(text,ctxt)
+  assert(text=='Fallback' and ctxt=='default');calls=calls+1;return 'translated default'
+ end
+}
+local result=EXPRESSION
+assert(result==(PRESENT and '' or 'translated default'))
+assert(calls==(PRESENT and 0 or 1))
+""".replace("PRESENT", "true" if present else "false").replace("EXPRESSION", expression)
+            result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
     def test_string_i18n_translates_literals_but_not_stored_variables(self) -> None:
         cases = [("Hello", True, "translated", "nil"),
                  ({"str": "Hello", "ctxt": "greeting"}, True, "translated", '"greeting"'),
@@ -67,6 +129,7 @@ local context={data={}}
 local phase=0
 local function service_value(r) assert(r.ok);return r.value end
 local services={
+ translate=function(text) return text end,
  characters={avatar=function() return player end},
  interaction={input_text=function(title,options)
   assert(phase==0 and title=='Title' and options.default=='' and options.initial==nil);phase=1

--- a/tools/test_migrate_lua_first.py
+++ b/tools/test_migrate_lua_first.py
@@ -16,6 +16,31 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
 class LuaFirstMigrationTest(unittest.TestCase):
     @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_false_branch_string_assignment_preserves_beta_expression(self) -> None:
+        lines = migrate_lua_first.render_static_false_effect(
+            {"set_string_var": {"npc_val": "input"}, "target_var": {"npc_val": "output"}},
+            True, True, {}, npc_actor_expression="partner")
+        self.assertIsNotNone(lines)
+        script = r"""
+local actor={input='alpha'}
+local partner={input='beta'}
+local context={data={}}
+local function service_value(r) assert(r.ok);return r.value end
+local services={variables={
+ resolve=function(data,owner,scope,key)
+  assert(owner==partner and scope=='npc');return {ok=true,value={value=owner[key]}}
+ end,
+ set=function(owner,key,value) assert(owner==partner);owner[key]=value end
+}}
+if false then error('wrong branch') else
+BODY
+end
+assert(partner.output=='beta' and actor.output==nil)
+""".replace("BODY", "\n".join(lines))
+        result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
     def test_real_selector_example_string_setup_preserves_translation(self) -> None:
         source = json.loads((REPOSITORY_ROOT / "data/json/effects_on_condition/example_eocs.json").read_text())
         eoc = next(entry for entry in source if entry.get("id") == "EOC_selector_test")

--- a/tools/test_migrate_lua_first.py
+++ b/tools/test_migrate_lua_first.py
@@ -16,6 +16,36 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
 class LuaFirstMigrationTest(unittest.TestCase):
     @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_one_in_native_range_and_owner_are_not_clamped(self) -> None:
+        values = (2147483647.9, -2147483648.9,
+                  {"npc_val": "chance"}, [-2147483648, 2147483647])
+        for value in values:
+            expression = migrate_lua_first.render_eoc_condition_expression(
+                {"one_in_chance": value}, avatar_actor_proven=True,
+                npc_actor_expression="partner")
+            self.assertIsNotNone(expression)
+            expected = 2147483647 if isinstance(value, (dict, list)) else value
+            script = r"""
+local actor,partner={},{}
+local context={data={}}
+local reads=0
+local function service_value(r) assert(r.ok);return r.value end
+local services={variables={resolve=function(data,owner,scope,key)
+ assert(owner==partner and scope=='npc' and key=='chance')
+ reads=reads+1;return {ok=true,value={value=2147483647}}
+end},random={int=function(lo,hi)
+ assert(lo==-2147483648 and hi==2147483647);return hi
+end,one_in=function(n) assert(n==EXPECTED);return true end}}
+assert(EXPRESSION)
+assert(reads==READS)
+""".replace("EXPECTED", str(expected)).replace("EXPRESSION", expression)
+            script = script.replace("READS", "1" if isinstance(value, dict) else "0")
+            result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+            self.assertEqual(result.returncode, 0, result.stderr)
+        for invalid in (2147483648, -2147483649, [0, 2147483648]):
+            self.assertIsNone(migrate_lua_first.render_eoc_condition_expression({"one_in_chance": invalid}))
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
     def test_environment_nested_string_mutator_preserves_explicit_translation(self) -> None:
         expression = migrate_lua_first.render_eoc_condition_expression({
             "is_season": {"mutator": "mon_faction", "mtype_id": {"str": "original", "i18n": True}}})
@@ -852,7 +882,7 @@ assert(adds==1 and random_calls==2 and reads==READS)
                     self.assertEqual(result.returncode, 0, result.stderr)
 
     def test_effect_intensity_rejects_malformed_ranges(self) -> None:
-        for value in ([], [1], [1, 2, 3], [[1, 2], 3], [True, 2], [0, 1000000001]):
+        for value in ([], [1], [1, 2, 3], [[1, 2], 3], [True, 2], [0, 2147483648], [-2147483649, 0]):
             self.assertIsNone(migrate_lua_first.render_effect_condition(
                 {"u_has_effect": "bleed", "intensity": value}, "actor", None))
             self.assertIsNone(migrate_lua_first.render_dynamic_character_effect(

--- a/tools/test_migrate_lua_first.py
+++ b/tools/test_migrate_lua_first.py
@@ -16,6 +16,111 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
 class LuaFirstMigrationTest(unittest.TestCase):
     @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_environment_nested_string_mutator_preserves_explicit_translation(self) -> None:
+        expression = migrate_lua_first.render_eoc_condition_expression({
+            "is_season": {"mutator": "mon_faction", "mtype_id": {"str": "original", "i18n": True}}})
+        self.assertIsNotNone(expression)
+        script = r"""
+local services={time_snapshot=function() return {season_id='spring'} end,
+ translate=function(text) assert(text=='original');return 'translated' end,
+ registry={get=function(kind,id)
+ assert(kind=='monster' and id=='translated');return {default_faction={value='spring'}}
+end}}
+assert(EXPRESSION)
+""".replace("EXPRESSION", expression)
+        result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_environment_explicit_translation_is_not_a_plain_string(self) -> None:
+        for selector in ("is_season", "is_weather"):
+            expression = migrate_lua_first.render_eoc_condition_expression(
+                {selector: {"str": "spring", "i18n": True}})
+            self.assertIsNotNone(expression)
+            script = r"""
+local translations=0
+local services={time_snapshot=function() return {season_id='spring'} end,
+ weather={current=function() return {weather={value='spring'}} end},
+ translate=function(text) assert(text=='spring');translations=translations+1;return 'printemps' end}
+assert(not (EXPRESSION))
+assert(translations==1)
+""".replace("EXPRESSION", expression)
+            result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            for invalid in ({"str": "spring"}, {"str": "spring", "i18n": False}, {"math": ["1"]}):
+                self.assertIsNone(migrate_lua_first.render_eoc_condition_expression({selector: invalid}))
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_real_environment_condition_literals_execute(self) -> None:
+        conditions = []
+
+        def collect(value):
+            if isinstance(value, dict):
+                for key in ("is_season", "is_weather"):
+                    if key in value:
+                        conditions.append({key: value[key]})
+                for child in value.values():
+                    collect(child)
+            elif isinstance(value, list):
+                for child in value:
+                    collect(child)
+
+        for relative in (
+            "data/json/effects_on_condition/mutation_eocs/mutation_effect_eocs.json",
+            "data/json/effects_on_condition/item_eocs.json",
+        ):
+            collect(json.loads((REPOSITORY_ROOT / relative).read_text()))
+        self.assertTrue(any("is_season" in value for value in conditions))
+        self.assertTrue(any("is_weather" in value for value in conditions))
+        lines = ["local services={time_snapshot=function() return {season_id='spring'} end,"
+                 "weather={current=function() return {weather={value='rain'}} end}}"]
+        for condition in conditions:
+            key, value = next(iter(condition.items()))
+            self.assertIsInstance(value, str)
+            expression = migrate_lua_first.render_eoc_condition_expression(condition)
+            self.assertIsNotNone(expression)
+            expected = value == ("spring" if key == "is_season" else "rain")
+            lines.append(f"assert(({expression})=={'true' if expected else 'false'})")
+        result = subprocess.run(["lua", "-"], input="\n".join(lines), text=True, capture_output=True, timeout=10)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_environment_string_queries_preserve_participant_and_fallback(self) -> None:
+        for selector, current in (("is_season", "spring"), ("is_weather", "rain")):
+            for key in ("u_val", "npc_val", "global_val", "context_val", "var_val"):
+                for present in (False, True):
+                    value = {key: "reference" if key == "var_val" else "wanted", "default": current}
+                    expression = migrate_lua_first.render_eoc_condition_expression(
+                        {selector: value}, avatar_actor_proven=True,
+                        npc_actor_expression="partner")
+                    self.assertIsNotNone(expression)
+                    script = r"""
+local actor,partner={},{}
+local context={data={reference='n_wanted'}}
+local reads=0
+local function service_value(r) assert(r.ok);return r.value end
+local services={time_snapshot=function() return {season_id=CURRENT} end,
+ weather={current=function() return {weather={value=CURRENT}} end},
+ variables={resolve=function(data,owner,scope,key)
+ assert(key=='wanted')
+ if SCOPE=='u_val' then assert(scope=='u' and owner==actor)
+ elseif SCOPE=='npc_val' or SCOPE=='var_val' then assert(scope=='npc' and owner==partner)
+ elseif SCOPE=='global_val' then assert(scope=='global')
+ else assert(scope=='context') end
+ reads=reads+1
+ return {ok=true,value={exists=PRESENT,value=nil}}
+end}}
+assert((EXPRESSION)==EXPECTED)
+assert(reads==1)
+""".replace("CURRENT", migrate_lua_first.lua_quote(current))
+                    script = script.replace("SCOPE", migrate_lua_first.lua_quote(key))
+                    script = script.replace("PRESENT", "true" if present else "false")
+                    script = script.replace("EXPECTED", "false" if present else "true")
+                    script = script.replace("EXPRESSION", expression)
+                    result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+                    self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
     def test_is_day_real_conditions_use_live_environment_without_actor(self) -> None:
         # Real content uses this parameterless predicate both directly and negated.
         source = json.loads((REPOSITORY_ROOT / "data/json/npcs/TALK_TEST.json").read_text())
@@ -3324,7 +3429,7 @@ assert(not ok and string.find(message, 'stale_world', 1, true))
                 1,
             )
 
-    def test_dynamic_or_unproven_is_season_shapes_stay_partial(self) -> None:
+    def test_dynamic_is_season_converts_but_numeric_shape_stays_partial(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             source = Path(temporary) / "source.json"
             source.write_text(
@@ -3356,12 +3461,12 @@ assert(not ok and string.find(message, 'stale_world', 1, true))
             main = result.files[Path("main.lua")]
             report = result.files[Path("MIGRATION_REPORT.md")]
 
-            self.assertEqual(result.converted, [])
-            self.assertEqual(len(result.partial), 2)
-            self.assertNotIn("services.time_snapshot", main)
+            self.assertEqual(len(result.converted), 1)
+            self.assertEqual(len(result.partial), 1)
+            self.assertIn("services.time_snapshot", main)
             self.assertEqual(
                 report.count("condition TODO: translate the legacy condition into a Lua predicate"),
-                2,
+                1,
             )
 
     def test_translates_literal_is_weather_through_current_snapshot(self) -> None:
@@ -3459,8 +3564,8 @@ assert(not ok and string.find(message, 'stale_world', 1, true))
             main = result.files[Path("main.lua")]
             report = result.files[Path("MIGRATION_REPORT.md")]
 
-            self.assertEqual(len(result.converted), 3)
-            self.assertEqual(len(result.partial), 3)
+            self.assertEqual(len(result.converted), 4)
+            self.assertEqual(len(result.partial), 2)
             self.assertIn(
                 'services.weather.current().weather.value == '
                 'tostring((context.data["context_weather"]) or "")',
@@ -3479,10 +3584,10 @@ assert(not ok and string.find(message, 'stale_world', 1, true))
                 main,
             )
             self.assertNotIn('weather.value == 5', main)
-            self.assertNotIn('weather.value == ""', main)
+            self.assertIn('weather.value == ""', main)
             self.assertEqual(
                 report.count("condition TODO: translate the legacy condition into a Lua predicate"),
-                3,
+                2,
             )
 
     def test_translates_proven_avatar_activity_cancellation(self) -> None:

--- a/tools/test_migrate_lua_first.py
+++ b/tools/test_migrate_lua_first.py
@@ -16,6 +16,37 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
 class LuaFirstMigrationTest(unittest.TestCase):
     @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_is_day_real_conditions_use_live_environment_without_actor(self) -> None:
+        # Real content uses this parameterless predicate both directly and negated.
+        source = json.loads((REPOSITORY_ROOT / "data/json/npcs/TALK_TEST.json").read_text())
+        predicates = []
+        for topic in source:
+            for response in topic.get("responses", []):
+                condition = response.get("condition")
+                if condition == "is_day" or condition == {"not": "is_day"}:
+                    predicates.append(condition)
+        self.assertEqual(len(predicates), 2)
+        for condition in predicates:
+            expression = migrate_lua_first.render_eoc_condition_expression(condition)
+            self.assertIsNotNone(expression)
+            expected = "night" if isinstance(condition, dict) else "not night"
+            script = """
+local night=false
+local reads=0
+local services={gameplay={environment={is_night=function()
+ reads=reads+1;return night
+end}}}
+local function predicate() return EXPRESSION end
+for _,value in ipairs({false,true,false}) do
+ night=value
+ assert(predicate()==(EXPECTED))
+end
+assert(reads==3)
+""".replace("EXPRESSION", expression).replace("EXPECTED", expected)
+            result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
     def test_probability_operands_preserve_large_values_and_single_owner_reads(self) -> None:
         for chance in ({"x": 1000000000000, "y": 2000000000000},
                        {"x": {"u_val": "x"}, "y": {"npc_val": "y"}}):
@@ -2065,7 +2096,6 @@ assert(not ok and string.find(message, 'stale_world', 1, true))
                 {"is_season": "spring"},
                 {"is_weather": "rain"},
                 "is_day",
-                "is_night",
                 {"u_has_trait": "SAMPLE_TRAIT"},
                 {"u_has_any_trait": ["SAMPLE_TRAIT", "TOUGH"]},
                 {"u_has_martial_art": "style_karate"},
@@ -3256,6 +3286,12 @@ assert(not ok and string.find(message, 'stale_world', 1, true))
                 ),
                 1,
             )
+
+    def test_unregistered_night_condition_is_not_invented_during_migration(self) -> None:
+        path = REPOSITORY_ROOT / "data/reference/json/ccb_eoc_conditions.json"
+        inventory = json.loads(path.read_text())
+        self.assertNotIn("is_night", {entry["key"] for entry in inventory["entries"]})
+        self.assertIsNone(migrate_lua_first.render_eoc_condition_expression("is_night"))
 
     def test_dynamic_or_unproven_is_day_shapes_stay_partial(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:

--- a/tools/test_migrate_lua_first.py
+++ b/tools/test_migrate_lua_first.py
@@ -16,6 +16,57 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
 class LuaFirstMigrationTest(unittest.TestCase):
     @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_real_mp3_dimension_comparison_executes_as_lua(self) -> None:
+        source = json.loads((REPOSITORY_ROOT / "data/json/effects_on_condition/anomalous_mp3_eocs.json").read_text())
+        eoc = next(entry for entry in source if entry.get("id") == "EOC_MP3_REVERBERATION_REVERBERATION_LISTENER")
+        expression = migrate_lua_first.render_eoc_condition_expression(eoc["effect"][1]["if"])
+        self.assertIsNotNone(expression)
+        for dimension, expected in (("radiosphere", True), ("cabins", False), ("", False)):
+            script = "local context={data={dim_name=" + migrate_lua_first.lua_quote(dimension) + "}}\n"
+            script += f"assert({expression} == {str(expected).lower()})"
+            result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_string_comparisons_preserve_owners_and_short_circuit(self) -> None:
+        for key, beta, expected in (("compare_string", "alpha", True),
+                                    ("compare_string_match_all", "different", False)):
+            condition = {key: [{"u_val": "input"}, {"npc_val": "input"},
+                               {"mutator": "game_option", "option": "unreached"}]}
+            expression = migrate_lua_first.render_eoc_condition_expression(
+                condition, avatar_actor_proven=True, npc_actor_proven=True, npc_actor_expression="partner")
+            self.assertIsNotNone(expression)
+            script = r"""
+local actor={input='alpha'}
+local partner={input=BETA}
+local context={data={}}
+local calls=0
+local function service_value(r) assert(r.ok);return r.value end
+local services={variables={resolve=function(data,owner,scope,key)
+ calls=calls+1;assert((calls==1 and owner==actor) or (calls==2 and owner==partner))
+ return {ok=true,value={value=owner[key]}}
+end},gameplay={options={get=function() error('must short circuit') end}}}
+assert(EXPRESSION==EXPECTED and calls==2)
+""".replace("BETA", migrate_lua_first.lua_quote(beta)).replace("EXPRESSION", expression)
+            script = script.replace("EXPECTED", "true" if expected else "false")
+            result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_string_comparisons_accept_native_empty_singleton_and_long_lists(self) -> None:
+        cases = [("compare_string", [], False), ("compare_string", ["a"], False),
+                 ("compare_string_match_all", ["a"], True),
+                 ("compare_string", [str(i) for i in range(300)], False),
+                 ("compare_string_match_all", ["same"] * 300, True)]
+        for key, values, expected in cases:
+            expression = migrate_lua_first.render_eoc_condition_expression({key: values})
+            self.assertIsNotNone(expression)
+            result = subprocess.run(["lua", "-"], input=f"assert({expression} == {str(expected).lower()})",
+                                    text=True, capture_output=True, timeout=10)
+            self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIsNone(migrate_lua_first.render_eoc_condition_expression({"compare_string_match_all": []}))
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
     def test_copy_variable_preserves_owners_types_and_empty_write(self) -> None:
         addresses = [("u_val", "actor", None), ("npc_val", "partner", None),
                      ("context_val", "context.data", None), ("global_val", "globals", None),
@@ -2000,8 +2051,8 @@ assert(not ok and string.find(message, 'stale_world', 1, true))
 
             self.assertEqual(len(result.converted), len(predicates))
             self.assertEqual(result.partial, [])
-            self.assertIn("services.gameplay.strings.any_equal", main)
-            self.assertIn("services.gameplay.strings.all_equal", main)
+            self.assertIn("if seen[value] then return true end", main)
+            self.assertIn("~= first then return false end", main)
             self.assertIn("services.random.one_in(3)", main)
             self.assertIn("services.random.probability(1.5, 4)", main)
             self.assertIn("services.random.contested(2, 5, 8)", main)
@@ -18632,8 +18683,8 @@ assert(not ok and string.find(message, 'stale_world', 1, true))
 
             self.assertEqual(result.partial, [])
             self.assertEqual(result.todos, [])
-            self.assertIn("services.gameplay.strings.any_equal", main)
-            self.assertIn("services.gameplay.strings.all_equal", main)
+            self.assertIn("if seen[value] then return true end", main)
+            self.assertIn("~= first then return false end", main)
             self.assertIn("services.gameplay.math.apply", main)
 
     def test_phase_move_and_global_overmap_point_keep_avatar_context(self) -> None:

--- a/tools/test_migrate_lua_first.py
+++ b/tools/test_migrate_lua_first.py
@@ -16,6 +16,49 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
 class LuaFirstMigrationTest(unittest.TestCase):
     @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_probability_operands_preserve_large_values_and_single_owner_reads(self) -> None:
+        for chance in ({"x": 1000000000000, "y": 2000000000000},
+                       {"x": {"u_val": "x"}, "y": {"npc_val": "y"}}):
+            expression = migrate_lua_first.render_eoc_condition_expression(
+                {"x_in_y_chance": chance}, avatar_actor_proven=True,
+                npc_actor_proven=True, npc_actor_expression="partner")
+            self.assertIsNotNone(expression)
+            script = r"""
+local actor={x=1000000000000}
+local partner={y=2000000000000}
+local context={data={}}
+local reads={}
+local function service_value(r) assert(r.ok);return r.value end
+local services={variables={resolve=function(data,owner,scope,key)
+ assert((key=='x' and owner==actor) or (key=='y' and owner==partner))
+ reads[key]=(reads[key] or 0)+1;assert(reads[key]==1)
+ return {ok=true,value={exists=true,value=owner[key]}}
+end},random={probability=function(x,y)
+ assert(x==1000000000000 and y==2000000000000 and x/y==0.5);return true
+end}}
+assert(EXPRESSION)
+""".replace("EXPRESSION", expression)
+            result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_probability_ranges_preserve_integer_sampling(self) -> None:
+        expression = migrate_lua_first.render_eoc_condition_expression(
+            {"x_in_y_chance": {"x": [2.5, 2.5], "y": [4.9, 4.9]}})
+        self.assertIsNotNone(expression)
+        script = r"""
+local samples=0
+local services={random={int=function(lo,hi)
+ assert(lo==hi);samples=samples+1;return lo
+end,probability=function(x,y)
+ assert(samples==2 and x==2 and y==4);return true
+end}}
+assert(EXPRESSION)
+""".replace("EXPRESSION", expression)
+        result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
     def test_string_defaults_distinguish_stored_null_from_missing(self) -> None:
         for key in ("u_val", "npc_val", "global_val", "var_val"):
             for present in (True, False):

--- a/tools/test_migrate_lua_first.py
+++ b/tools/test_migrate_lua_first.py
@@ -16,6 +16,31 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
 class LuaFirstMigrationTest(unittest.TestCase):
     @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_real_gateway_copy_uses_native_copy_between_participants(self) -> None:
+        source = json.loads((REPOSITORY_ROOT / "data/mods/MindOverMatter/powers/teleportation_eoc.json").read_text())
+        effects = [effect for entry in source for effect in entry.get("effect", [])
+                   if isinstance(effect, dict) and effect.get("copy_var") == {"npc_val": "gateway_destination_1"}]
+        self.assertEqual(len(effects), 1)
+        lines = migrate_lua_first.render_static_character_copy_var(effects[0], True, True, "partner")
+        self.assertIsNotNone(lines)
+        script = r"""
+local actor={}
+local partner={}
+local context={data={}}
+local calls=0
+local function service_value(r) assert(r.ok);return r.value end
+local services={variables={copy=function(source,key,target,out)
+ assert(source==partner and key=='gateway_destination_1')
+ assert(target==actor and out=='dilated_gateway_location')
+ calls=calls+1;return {ok=true,value={source_exists=true,destination_existed=false}}
+end}}
+BODY
+assert(calls==1)
+""".replace("BODY", "\n".join(lines))
+        result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
     def test_copy_variable_preserves_owners_types_and_empty_write(self) -> None:
         addresses = [("u_val", "actor", None), ("npc_val", "partner", None),
                      ("context_val", "context.data", None), ("global_val", "globals", None),
@@ -38,6 +63,10 @@ SOURCE_STORE.input=VALUE
 local writes=0
 local function service_value(r) assert(r.ok);return r.value end
 local services={variables={
+ copy=function(source,key,target,out)
+  assert((source or globals)==SOURCE_STORE and (target or globals)==TARGET_STORE)
+  assert(key=='input' and out=='output');writes=writes+1;return {ok=true,value={}}
+ end,
  resolve=function(data,owner,scope,key)
   local store=scope=='global' and globals or scope=='context' and data or owner
   assert(store==SOURCE_STORE and key=='input')

--- a/tools/test_migrate_lua_first.py
+++ b/tools/test_migrate_lua_first.py
@@ -16,6 +16,29 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
 class LuaFirstMigrationTest(unittest.TestCase):
     @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_real_selector_example_string_setup_preserves_translation(self) -> None:
+        source = json.loads((REPOSITORY_ROOT / "data/json/effects_on_condition/example_eocs.json").read_text())
+        eoc = next(entry for entry in source if entry.get("id") == "EOC_selector_test")
+        effects = eoc["effect"][:3]
+        self.assertTrue(all("set_string_var" in effect for effect in effects))
+        bodies = [migrate_lua_first.render_static_character_string_var(effect, False, False) for effect in effects]
+        self.assertTrue(all(body is not None for body in bodies))
+        script = r"""
+local context={data={}}
+local translated={}
+local services={translate=function(text)
+ translated[#translated+1]=text;return 'localized:'..text
+end}
+BODY
+assert(context.data.title=='localized:EOC Selector Test')
+assert(context.data.name=='name_3')
+assert(context.data.description=='localized:option 3')
+assert(#translated==2)
+""".replace("BODY", "\n".join(line for body in bodies for line in body))
+        result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
     def test_input_translated_variables_preserve_native_evaluation_order(self) -> None:
         lines = migrate_lua_first.render_static_character_string_var(
             {"set_string_var": "original", "target_var": {"context_val": "output"},

--- a/tools/test_migrate_lua_first.py
+++ b/tools/test_migrate_lua_first.py
@@ -16,6 +16,47 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
 class LuaFirstMigrationTest(unittest.TestCase):
     @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_string_defaults_distinguish_stored_null_from_missing(self) -> None:
+        for key in ("u_val", "npc_val", "global_val", "var_val"):
+            for present in (True, False):
+                expression = migrate_lua_first.render_participant_string_expression(
+                    {key: "reference" if key == "var_val" else "input", "default": "fallback"},
+                    "actor", "actor", "partner")
+                self.assertIsNotNone(expression)
+                script = r"""
+local actor,partner={},{}
+local context={data={reference='n_input'}}
+local function service_value(r) assert(r.ok);return r.value end
+local services={variables={resolve=function(data,owner,scope,name)
+ assert(name=='input');return {ok=true,value={exists=PRESENT,value=nil}}
+end}}
+assert(EXPRESSION==(PRESENT and '' or 'fallback'))
+""".replace("PRESENT", "true" if present else "false").replace("EXPRESSION", expression)
+                result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_translated_defaults_do_not_translate_stored_null(self) -> None:
+        for key in ("u_val", "npc_val", "global_val"):
+            for present in (True, False):
+                expression = migrate_lua_first.render_participant_translation_expression(
+                    {key: "input", "default": "fallback"}, "actor", "actor", "partner")
+                self.assertIsNotNone(expression)
+                script = r"""
+local actor,partner={},{}
+local context={data={}}
+local calls=0
+local function service_value(r) assert(r.ok);return r.value end
+local services={variables={resolve=function(data,owner,scope,name)
+ return {ok=true,value={exists=PRESENT,value=nil}}
+end},translate=function(value) calls=calls+1;return 'translated:'..value end}
+assert(EXPRESSION==(PRESENT and '' or 'translated:fallback'))
+assert(calls==(PRESENT and 0 or 1))
+""".replace("PRESENT", "true" if present else "false").replace("EXPRESSION", expression)
+                result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
     def test_real_gateway_copy_uses_native_copy_between_participants(self) -> None:
         source = json.loads((REPOSITORY_ROOT / "data/mods/MindOverMatter/powers/teleportation_eoc.json").read_text())
         effects = [effect for entry in source for effect in entry.get("effect", [])
@@ -189,7 +230,7 @@ local calls=0
 local function service_value(r) assert(r.ok);return r.value end
 local services={
  variables={resolve=function(data,owner,scope,key)
-  assert(owner==partner);return {ok=true,value={value=PRESENT and '' or nil}}
+  assert(owner==partner);return {ok=true,value={exists=PRESENT,value=PRESENT and '' or nil}}
  end},
  translate=function(text,ctxt)
   assert(text=='Fallback' and ctxt=='default');calls=calls+1;return 'translated default'
@@ -1569,7 +1610,8 @@ local actor, partner = {}, {}
 local context = {data={}}
 local function service_value(r) assert(r.ok); return r.value end
 local services = {variables={resolve=function(data, character, scope, key)
- return {ok=true,value={value=character and character[key] or data[key]}}
+ local value = character and character[key] or data[key]
+ return {ok=true,value={exists=value~=nil,value=value}}
 end}}
 local function read() return EXPRESSION end
 assert(read() == 'fallback')

--- a/tools/test_migrate_lua_first.py
+++ b/tools/test_migrate_lua_first.py
@@ -16,6 +16,54 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
 class LuaFirstMigrationTest(unittest.TestCase):
     @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
+    def test_copy_variable_preserves_owners_types_and_empty_write(self) -> None:
+        addresses = [("u_val", "actor", None), ("npc_val", "partner", None),
+                     ("context_val", "context.data", None), ("global_val", "globals", None),
+                     ("var_val", "actor", "u_"), ("var_val", "partner", "n_"),
+                     ("var_val", "context.data", "_"), ("var_val", "globals", "")]
+        for source, source_store, source_prefix in addresses:
+            for target, target_store, target_prefix in addresses:
+                for value in ('"text"', '0', 'nil'):
+                    lines = migrate_lua_first.render_static_character_copy_var(
+                        {"copy_var": {source: "source_ref" if source_prefix is not None else "input"},
+                         "target_var": {target: "target_ref" if target_prefix is not None else "output"}},
+                        True, True, "partner")
+                    self.assertIsNotNone(lines)
+                    script = r"""
+local actor={input='alpha'}
+local partner={input='beta'}
+local globals={input='global'}
+local context={data={input='context',source_ref=SOURCE_REF,target_ref=TARGET_REF}}
+SOURCE_STORE.input=VALUE
+local writes=0
+local function service_value(r) assert(r.ok);return r.value end
+local services={variables={
+ resolve=function(data,owner,scope,key)
+  local store=scope=='global' and globals or scope=='context' and data or owner
+  assert(store==SOURCE_STORE and key=='input')
+  return {ok=true,value={exists=store[key]~=nil,value=store[key]}}
+ end,
+ set_resolved=function(data,owner,scope,key,value)
+  local store=scope=='global' and globals or scope=='context' and data or owner
+  assert(store==TARGET_STORE and key=='output' and value==VALUE)
+  writes=writes+1;return {ok=true,value={}}
+ end
+}}
+BODY
+assert(writes==1)
+""".replace("SOURCE_REF", migrate_lua_first.lua_quote((source_prefix or '') + 'input'))
+                    script = script.replace("TARGET_REF", migrate_lua_first.lua_quote((target_prefix or '') + 'output'))
+                    script = script.replace("SOURCE_STORE", source_store).replace("TARGET_STORE", target_store)
+                    script = script.replace("VALUE", value).replace("BODY", "\n".join(lines))
+                    result = subprocess.run(["lua", "-"], input=script, text=True, capture_output=True, timeout=10)
+                    self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_copy_variable_keeps_missing_participants_partial(self) -> None:
+        for source in ("u_val", "npc_val", "var_val"):
+            self.assertIsNone(migrate_lua_first.render_static_character_copy_var(
+                {"copy_var": {source: "input"}, "target_var": {"global_val": "output"}}, False, False))
+
+    @unittest.skipUnless(shutil.which("lua"), "Lua interpreter required")
     def test_false_branch_string_assignment_preserves_beta_expression(self) -> None:
         lines = migrate_lua_first.render_static_false_effect(
             {"set_string_var": {"npc_val": "input"}, "target_var": {"npc_val": "output"}},
@@ -2774,8 +2822,8 @@ assert(not ok and string.find(message, 'stale_world', 1, true))
             self.assertIn('tostring(services.turn())', main)
             self.assertIn('context.data["required"] ~= nil', main)
             self.assertIn("1 == 1", main)
-            self.assertIn('services.variables.get(actor, "source")', main)
-            self.assertIn('services.variables.remove(actor, "target")', main)
+            self.assertIn('copy_source_key = "u", actor, "source"', main)
+            self.assertNotIn('services.variables.remove(actor, "target")', main)
             self.assertIn(
                 'services.variables.set(\n        actor, "label"',
                 main,


### PR DESCRIPTION
输入标题、默认文本和说明原先经 display_text 处理，变量和翻译结构可能被静默丢失。现在按原生 translation_or_var 语义生成动态表达式，标识使用普通字符串表达式，并保留标题宽度计算、默认文本、标题再次求值、说明和标识的顺序。

共享翻译表达式同时修复直接变量默认值：仅缺失时翻译，已存储的空字符串保持不变。间接翻译默认值尚未支持，保留未迁移状态。

基于 #793。399 项迁移测试、flake8、git diff --check 通过。无 C++ 改动，未重新编译。输入宽度仍受公开服务 10..240 约束，未做交互式验收或整个 selector 完成声明。

#### Responsible human
@LYHGLYTX

#### Documentation impact
迁移行为修复，公开 API 不变。

#### Related CCB-Docs PR
https://github.com/CrimsonCrossBunker/CCB-Docs/pull/49

#### Affected documentation IDs
cpp.lua-bridge

#### Generated reference impact
集成收尾时本 PR 将纳入其依赖链上的 Lua API、LuaLS 声明及迁移修复；相关 Platform API／覆盖清单已由生成器刷新，配套说明统一由 CCB-Docs #49 承接。具体通过状态以当前提交的 CI 为准。
