### PR TITLE
修复安卓旧摇杆逐条触摸事件重复重绘菜单

### DIFF
--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -150,7 +150,7 @@ static bool needupdate = false;
 // instead of replacing them with the (usually stale) hardware mouse position.
 static bool last_input_has_explicit_mouse_pos = false;
 #if defined(__ANDROID__)
-static hover_mouse_input_state android_hover_mouse_input;
+    static hover_mouse_input_state android_hover_mouse_input;
 #endif
 static bool need_invalidate_framebuffers = false;
 palette_array windowsPalette;

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -6974,10 +6974,10 @@ static void CheckMessages()
                             if( !is_quick_shortcut_touch ) {
                                 update_finger_repeat_delay();
                             }
-                            // Legacy joystick and shortcut overlays still redraw while
-                            // moving. New UI ImGui touches are coalesced below instead.
+                            // Repaint the joystick/shortcuts at the end of the event
+                            // batch. Redrawing the whole ImGui menu for each motion
+                            // makes touch input accumulate behind recipe previews.
                             needupdate = true;
-                            ui_manager::redraw_invalidated();
                         }
 
                         if( !android_imgui_touch_state.captures_touch &&
@@ -7045,8 +7045,8 @@ static void CheckMessages()
                             // Do not hover or press a widget until this gesture is
                             // known to be a tap or a control drag.
                         } else {
-                            ui_manager::redraw_invalidated();
-                            // Ensure virtual joystick and quick shortcuts redraw.
+                            // The overlays are drawn by refresh_display(). Menu
+                            // contents redraw once in their own input loop.
                             needupdate = true;
                         }
                     } else if( slot == 1 ) {


### PR DESCRIPTION
## 问题与修改
安卓旧摇杆路径在每条 FINGERMOTION 以及 FINGERDOWN 事件里调用 redraw_invalidated。ImGui 窗口每次都会重画，因此连续拖动会在 SDL 事件队列中反复生成制作界面的详情；方向连发只能等这一批事件处理完再继续。

移除这两处同步菜单重绘，保留 needupdate 标志。摇杆和快捷键覆盖层仍由 refresh_display 绘制，菜单仍在自身输入循环重绘。新 UI 的直接触摸滚动路径不变。

此 PR 处理安卓视频对应路径中的重复工作，不声称已复现并解决 PC 下方向键延迟；也不包含尚未确认关联的配方缓存优化。

## 验证
- git diff --check 通过。
- 从修改前后源码提取原样的旧摇杆 motion 分支，编译为 SDL2 事件队列实验：120 条 motion 加一条 finger-up；菜单重绘调用由 120 次降为 0 次，120 次连发速度更新、重绘请求及松手事件均保留。这是事件处理验证，不是实机耗时测量。
- 未运行完整游戏、Android APK 构建或安卓实机回归。需要设备验证摇杆持续下移、松手、快捷键提示及制作菜单响应。

#### Responsible human
@LYHGLYTX

#### Documentation impact
无，修复输入处理，不改变公开配置或操作方式。
#### Related CCB-Docs PR
N/A
#### Affected documentation IDs
N/A
#### Generated reference impact
无。

变更规模：12 行（6 增、6 删），2 个 commit；其中一行是 CI 要求的既有缩进修正。