### PR TITLE
修复加热液体后直接饮用导致的活动释放后访问

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -12735,8 +12735,43 @@ void heat_activity_actor::finish( player_activity &act, Character &p )
 {
     map &here = get_map();
 
-    for( drop_location &ait : to_heat ) {
+    // Liquid handling may assign ACT_CONSUME and destroy this actor. Retire
+    // heating before that handoff and keep its remaining work on the stack.
+    const drop_locations heating_targets = to_heat;
+    heater heat_source = heater_data;
+    const heating_requirements heating_cost = requirements;
+    act.set_to_null();
+
+    for( const drop_location &target : heating_targets ) {
+        if( !target.first ) {
+            p.add_msg_if_player( _( "Some of the food you selected is gone." ) );
+            return;
+        }
+    }
+
+    if( heat_source.consume_flag ) {
+        if( heat_source.pseudo_flag ) {
+            const optional_vpart_position vp = here.veh_at( heat_source.vpt );
+            if( !vp ) {
+                p.add_msg_if_player( _( "You can't find the appliance any more." ) );
+                return;
+            }
+            vp->vehicle().discharge_battery( here, heating_cost.ammo * heat_source.heating_effect );
+        } else {
+            if( !heat_source.loc ) {
+                p.add_msg_if_player( _( "You can't find the heater any more." ) );
+                return;
+            }
+            heat_source.loc->activation_consume( heating_cost.ammo, heat_source.loc.pos_bub( here ), &p );
+        }
+    }
+
+    for( const drop_location &ait : heating_targets ) {
         item_location cold_item = ait.first;
+        if( !cold_item ) {
+            p.add_msg_if_player( _( "Some of the food you selected is gone." ) );
+            continue;
+        }
         if( cold_item->count_by_charges() ) {
             item copy( *cold_item );
             copy.charges = ait.second;
@@ -12760,19 +12795,9 @@ void heat_activity_actor::finish( player_activity &act, Character &p )
             }
         }
     }
-    if( heater_data.consume_flag ) {
-        if( heater_data.pseudo_flag ) {
-            here.veh_at( heater_data.vpt ).value().vehicle().discharge_battery( here, requirements.ammo *
-                    heater_data.heating_effect );
-        } else {
-            heater_data.loc->activation_consume( requirements.ammo, heater_data.loc.pos_bub( here ), &p );
-        }
-    }
     p.add_msg_if_player( m_good, _( "You heated your items." ) );
 
     p.invalidate_crafting_inventory();
-
-    act.set_to_null();
 }
 
 void heat_activity_actor::serialize( JsonOut &jsout ) const

--- a/tests/heating_activity_test.cpp
+++ b/tests/heating_activity_test.cpp
@@ -1,0 +1,51 @@
+#include "activity_actor_definitions.h"
+#include "avatar.h"
+#include "cata_catch.h"
+#include "item.h"
+#include "item_location.h"
+#include "iuse.h"
+#include "player_activity.h"
+#include "player_helpers.h"
+#include "type_id.h"
+#include "units.h"
+
+static const itype_id itype_water_clean( "water_clean" );
+
+TEST_CASE( "heating_completion_handles_removed_target", "[activity][heating]" )
+{
+    clear_avatar();
+    avatar &guy = get_avatar();
+    item_location water = guy.i_add( item( itype_water_clean ) );
+    REQUIRE( water );
+    heating_requirements cost{ 250_ml, 1, 100 };
+    heater source{};
+    source.consume_flag = false;
+    guy.assign_activity( heat_activity_actor( { { water, 1 } }, cost, source ) );
+    water.remove_item();
+    REQUIRE_FALSE( water );
+
+    guy.activity.actor->finish( guy.activity, guy );
+
+    CHECK_FALSE( guy.activity );
+    CHECK( guy.backlog.empty() );
+}
+
+TEST_CASE( "heating_completion_handles_removed_heater", "[activity][heating]" )
+{
+    clear_avatar();
+    avatar &guy = get_avatar();
+    item_location water = guy.i_add( item( itype_water_clean ) );
+    REQUIRE( water );
+    const int charges = water->charges;
+    heating_requirements cost{ 250_ml, 1, 100 };
+    heater source{};
+    source.consume_flag = true;
+    // A heater location may become invalid while the activity completes.
+    guy.assign_activity( heat_activity_actor( { { water, 1 } }, cost, source ) );
+
+    guy.activity.actor->finish( guy.activity, guy );
+
+    CHECK_FALSE( guy.activity );
+    REQUIRE( water );
+    CHECK( water->charges == charges );
+}


### PR DESCRIPTION
## 问题与修改
加热完成时选择直接饮用，handle_all_liquid 会经 perform_liquid_transfer 分配 ACT_CONSUME。分配活动会替换并销毁正在执行 finish 的 heat_activity_actor，而原函数随后仍遍历成员 to_heat、读取 heater_data/requirements，并把新的饮用活动清空。喝掉最后一份热水可进入这条释放后访问路径。

现在先把待处理目标、热源和费用保存到局部变量，结束加热活动并扣除本次加热费用，再处理热水去向。液体菜单可安全创建饮用活动；完成函数不会把它取消，也不会把已结束的加热活动放回待恢复队列。补充完成时目标或热源已移除的保护。

## 验证
- 原样提取修改前后 heat_activity_actor::finish，使用会在饮用时销毁 actor 的隔离夹具运行 AddressSanitizer：原代码报 heap-use-after-free；修改后通过，最后一份水移除、饮用活动保留、费用只扣一次、没有遗留加热 backlog。此实验验证原函数的生命周期行为，不等同于完整游戏实机复现。
- SDL2 配置定向编译 src/activity_actor.cpp 和 tests/heating_activity_test.cpp 通过。
- 新增两个原生回归测试，覆盖完成时目标消失和热源消失；已编译，尚未链接运行完整原生测试。
- git diff --check 通过。未进行 Android APK/实机测试，尚未收到聊天中提到的存档和外部 mods。

#### Responsible human
@LYHGLYTX

#### Documentation impact
无。修复原有加热与饮用活动衔接，不改变公开配置或 API。

#### Related CCB-Docs PR
N/A

#### Affected documentation IDs
N/A

#### Generated reference impact
无。

变更规模：98 行（87 增、11 删），1 个 commit。