### PR TITLE
修复空岛返岛立即清理任务地图导致旧存档丢失落点

### DIFF
--- a/data/mods/Sky_Island/effectoncondition/teleport.json
+++ b/data/mods/Sky_Island/effectoncondition/teleport.json
@@ -17,6 +17,7 @@
         "if": { "not": { "mod_is_loaded": "backrooms" } },
         "then": { "run_eocs": [ "EOC_raid_challenge_mode_pre_raid" ] }
       },
+      { "clear_dimension": { "global_val": "sky_island_target_region_settings" } },
       { "u_location_variable": { "global_val": "OM_HQ_origin" } },
       { "u_location_variable": { "global_val": "OM_HQ_origin_npc" } },
       { "copy_var": { "global_val": "OM_HQ_origin" }, "target_var": { "global_val": "OM_temp" } },
@@ -229,7 +230,6 @@
           "EOC_return_heal"
         ]
       },
-      { "clear_dimension": { "global_val": "sky_island_target_region_settings" } },
       {
         "if": { "math": [ "skyisland_merchant_stall == 1" ] },
         "then": { "run_eocs": "EOC_SKY_ISLAND_RANDOM_MERCHANTS" }


### PR DESCRIPTION
## 问题与修改
玩家在任务维度手动保存后返岛，EOC_return_OM_teleport 会立即删除任务维度。此时角色文件仍可能指向刚刚被删除的任务地图；在岛上快速读取或闪退后读档，就可能落入重建后的地图而不是原撤离地点。

将已有 clear_dimension 从返岛流程移到下一次出发流程：先确定本次挑战使用的维度，再清理该维度，之后才改变玩家坐标和进入任务维度。返岛到下一次出发之间保留旧存档依赖的地图，同时维持新任务重建地图的行为。继续使用动态 sky_island_target_region_settings，覆盖当前挑战模式的维度选择。

历史核对：90cbc732095 曾采用延后清理；f5e09ff99d1 删除了其 game_save 事件，5c317a90b91 又加入了返岛清理。本次不恢复旧的空维度 ID 或保存前清理事件，仅调整现有操作时机。

## 验证及边界
- 仓库 JSON formatter 检查通过，git diff --check 通过。
- 对修改前后实际 JSON 检查操作顺序并模拟保存地图集合：原返岛流程删除保存引用的任务地图；修改后保留，下一次出发仍在进入所选维度前清理。
- 未取得报告中的存档、视频或外部 mod 包，未进行完整数据加载和游戏实机回归。这不是对所有空岛丢物现象的完整复现证明，也不能恢复已经删除的地图/装备。
- 本修复保护返岛后、下一次出发前的旧存档依赖；下一次主动出发仍按玩法重置目标任务维度，不引入完整世界回滚或多代存档事务。

#### Responsible human
@LYHGLYTX

#### Documentation impact
无。恢复任务地图清理时机，不改变公开配置、玩法入口或 API。

#### Related CCB-Docs PR
N/A

#### Affected documentation IDs
N/A

#### Generated reference impact
无。

变更规模：2 行（1 增、1 删），1 个 commit。