### PR TITLE
修复安卓轮盘连走时拖动转向失效

### DIFF
--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -6219,6 +6219,8 @@ static void CheckMessages()
     quick_shortcuts_t &qsl = quick_shortcuts_map[get_quick_shortcut_name(
                                  touch_input_context.get_category() )];
 
+    const bool allow_touch_repeat = !needupdate;
+
     // Don't do this logic if we already need an update, otherwise we're likely to overload the game with too much input on hold repeat events
     if( !needupdate ) {
 
@@ -6423,42 +6425,6 @@ static void CheckMessages()
                     env->DeleteLocalRef( activity );
                     env->DeleteLocalRef( clazz );
                 }
-            }
-        }
-
-        // Handle repeating inputs from touch + holds
-        if( !android_imgui_touch_state.captures_touch && !is_quick_shortcut_touch &&
-            !is_two_finger_touch && !is_three_finger_touch &&
-            finger_down_time > 0 &&
-            ticks - finger_down_time > static_cast<uint32_t>
-            ( get_option<int>( "ANDROID_INITIAL_DELAY" ) ) ) {
-            const float held_distance = std::hypot( finger_curr_x - finger_down_x,
-                                                    finger_curr_y - finger_down_y );
-            const float hold_deadzone = get_option<float>( "ANDROID_DEADZONE_RANGE" ) *
-                                        std::max( WindowWidth, WindowHeight );
-            const bool precision_hold = android_ui_mode::is_new_ui_build() && is_default_mode &&
-                                        get_option<bool>( "ANDROID_LONG_PRESS_CONTEXT" ) &&
-                                        held_distance < hold_deadzone;
-            if( !precision_hold && ticks - finger_repeat_time > finger_repeat_delay ) {
-                handle_finger_input( ticks );
-                finger_repeat_time = ticks;
-                // Prevent repeating inputs on the next call to this function if there is a fingerup event
-                while( SDL_PollEvent( &ev ) ) {
-                    if( ev.type == CATA_FINGERUP ) {
-                        third_finger_down_x = third_finger_curr_x = second_finger_down_x = second_finger_curr_x =
-                                                  finger_down_x = finger_curr_x = -1.0f;
-                        third_finger_down_y = third_finger_curr_y = second_finger_down_y = second_finger_curr_y =
-                                                  finger_down_y = finger_curr_y = -1.0f;
-                        is_two_finger_touch = false;
-                        is_three_finger_touch = false;
-                        finger_down_time = 0;
-                        finger_repeat_time = 0;
-                        finger_slot_clear( GetFingerID( ev ) );
-                        // let the next call decide if needupdate should be true
-                        break;
-                    }
-                }
-                return;
             }
         }
 
@@ -7376,6 +7342,28 @@ static void CheckMessages()
     }
 #if defined(__ANDROID__)
     android_service_imgui_touch( GetTicks() );
+    // Dispatch queued motion and release events before using the held direction.
+    // Never drain SDL events here: the normal dispatcher must see every event.
+    // Handle repeating inputs from touch + holds
+    if( allow_touch_repeat && !quit && last_input.type == input_event_t::error &&
+        !android_imgui_touch_state.captures_touch && !is_quick_shortcut_touch &&
+        !is_two_finger_touch && !is_three_finger_touch &&
+        finger_down_time > 0 &&
+        ticks - finger_down_time > static_cast<uint32_t>
+        ( get_option<int>( "ANDROID_INITIAL_DELAY" ) ) ) {
+        const float held_distance = std::hypot( finger_curr_x - finger_down_x,
+                                                finger_curr_y - finger_down_y );
+        const float hold_deadzone = get_option<float>( "ANDROID_DEADZONE_RANGE" ) *
+                                    std::max( WindowWidth, WindowHeight );
+        const bool precision_hold = android_ui_mode::is_new_ui_build() && is_default_mode &&
+                                    get_option<bool>( "ANDROID_LONG_PRESS_CONTEXT" ) &&
+                                    held_distance < hold_deadzone;
+        if( !precision_hold && ticks - finger_repeat_time > finger_repeat_delay ) {
+            handle_finger_input( ticks );
+            finger_repeat_time = ticks;
+        }
+    }
+
 #endif
     if( needupdate ) {
         try_sdl_update();

--- a/tools/test_android_joystick_repeat.py
+++ b/tools/test_android_joystick_repeat.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Compile the production Android hold-repeat block in a small event fixture.
+
+This checks scheduling and input ownership without an Android device. The SDL
+queue and normal dispatcher are simulated; this is not a full SDL/game test.
+Set CCB_SDLTILES_SOURCE to compare against an older src/sdltiles.cpp.
+"""
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = Path(os.environ.get("CCB_SDLTILES_SOURCE", ROOT / "src/sdltiles.cpp"))
+
+
+def braced_block(source, start):
+    opening = source.index("{", start)
+    depth = 1
+    end = opening + 1
+    while depth:
+        depth += (source[end] == "{") - (source[end] == "}")
+        end += 1
+    return source[start:end]
+
+
+class JoystickRepeatTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        source = SOURCE.read_text()
+        function = braced_block(source, source.index("static void CheckMessages()"))
+        start = function.index("// Handle repeating inputs from touch + holds")
+        block = braced_block(function, function.index("if(", start))
+        # Preserve the production ordering relative to the normal SDL dispatcher.
+        dispatcher = function.index("while( SDL_PollEvent( &ev ) )", function.index("using cata::options::mouse"))
+        body = ("dispatch();\n" + block if start > dispatcher else "if(!needupdate) {" + block + "}\ndispatch();")
+        cls.temp = tempfile.TemporaryDirectory()
+        root = Path(cls.temp.name)
+        cpp = root / "probe.cpp"
+        cpp.write_text(FIXTURE.replace("// PRODUCTION_REPEAT", body))
+        cls.binary = root / "probe"
+        subprocess.run([os.environ.get("CXX", "c++"), "-std=c++17", "-Wall", "-Wextra",
+                        str(cpp), "-o", str(cls.binary)], check=True, capture_output=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.temp.cleanup()
+
+    def check_case(self, case):
+        result = subprocess.run([str(self.binary), case], capture_output=True, text=True)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_turn_left(self):
+        self.check_case("left")
+
+    def test_turn_right(self):
+        self.check_case("right")
+
+    def test_latest_motion_wins(self):
+        self.check_case("burst")
+
+    def test_release_stops_without_extra_step(self):
+        self.check_case("release")
+
+    def test_keyboard_not_discarded_or_overwritten(self):
+        self.check_case("keyboard")
+
+    def test_quit_not_discarded(self):
+        self.check_case("quit")
+
+    def test_second_finger_suppresses_single_finger_repeat(self):
+        self.check_case("second")
+
+    def test_repeat_interval_respected(self):
+        self.check_case("early")
+
+    def test_motion_redraw_does_not_starve_repeat(self):
+        self.check_case("continuous")
+
+    def test_pending_redraw_still_defers_repeat(self):
+        self.check_case("redraw")
+
+
+FIXTURE = r'''#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <deque>
+#include <string>
+struct Event { int type; float x = 0; float y = 0; } ev;
+enum { motion, CATA_FINGERUP, key, close_window, second_down };
+std::deque<Event> events;
+bool SDL_PollEvent(Event *out) {
+    if(events.empty()) return false;
+    *out = events.front(); events.pop_front(); return true;
+}
+int GetFingerID(Event) { return 0; }
+void finger_slot_clear(int) {}
+enum class input_event_t { error, keyboard_char };
+struct { input_event_t type = input_event_t::error; int direction = 0; } last_input;
+struct { bool captures_touch = false; } android_imgui_touch_state;
+namespace android_ui_mode { bool is_new_ui_build() { return true; } }
+bool is_quick_shortcut_touch = false, is_two_finger_touch = false;
+bool is_three_finger_touch = false, is_default_mode = true;
+bool needupdate = false, quit = false;
+float finger_down_x = 0, finger_down_y = 0, finger_curr_x = 0, finger_curr_y = 100;
+float second_finger_down_x, second_finger_curr_x, third_finger_down_x, third_finger_curr_x;
+float second_finger_down_y, second_finger_curr_y, third_finger_down_y, third_finger_curr_y;
+uint32_t ticks = 1000, finger_down_time = 1, finger_repeat_time = 800, finger_repeat_delay = 100;
+int WindowWidth = 1000, WindowHeight = 500, repeats = 0;
+template<class T> T get_option(const char *name) {
+    const std::string s(name);
+    if(s == "ANDROID_INITIAL_DELAY") return T(250);
+    if(s == "ANDROID_DEADZONE_RANGE") return T(0.04);
+    return T(false);
+}
+void handle_finger_input(uint32_t) {
+    ++repeats;
+    last_input.type = input_event_t::keyboard_char;
+    last_input.direction = finger_curr_x < 0 ? -1 : finger_curr_x > 0 ? 1 : 2;
+}
+void dispatch() {
+    while(SDL_PollEvent(&ev)) {
+        if(ev.type == motion) { finger_curr_x = ev.x; finger_curr_y = ev.y; needupdate = true; }
+        if(ev.type == CATA_FINGERUP) { finger_down_time = 0; finger_repeat_time = 0; }
+        if(ev.type == key) { last_input.type = input_event_t::keyboard_char; last_input.direction = 9; }
+        if(ev.type == close_window) quit = true;
+        if(ev.type == second_down) is_two_finger_touch = true;
+    }
+}
+void pump() {
+    [[maybe_unused]] const bool allow_touch_repeat = !needupdate;
+    // PRODUCTION_REPEAT
+}
+int main(int argc, char **argv) {
+    assert(argc == 2);
+    const std::string scenario(argv[1]);
+    if(scenario == "left") events.push_back({motion, -100, 0});
+    if(scenario == "right") events.push_back({motion, 100, 0});
+    if(scenario == "burst") { events.push_back({motion, -100, 0}); events.push_back({motion, 100, 0}); }
+    if(scenario == "release") events.push_back({CATA_FINGERUP});
+    if(scenario == "keyboard") events.push_back({key});
+    if(scenario == "quit") events.push_back({close_window});
+    if(scenario == "second") events.push_back({second_down});
+    if(scenario == "early") ticks = 850;
+    if(scenario == "redraw") needupdate = true;
+    if(scenario == "continuous") {
+        for(int i = 0; i < 20; ++i) {
+            int direction = i % 2 ? 1 : -1;
+            events.push_back({motion, float(direction * 100), 0});
+            last_input.type = input_event_t::error;
+            needupdate = false;
+            ticks += 101;
+            pump();
+            assert(last_input.direction == direction);
+        }
+        assert(repeats == 20);
+        return 0;
+    }
+    pump();
+    if(scenario == "left") assert(last_input.direction == -1 && repeats == 1);
+    if(scenario == "right" || scenario == "burst") assert(last_input.direction == 1 && repeats == 1);
+    if(scenario == "release") assert(finger_down_time == 0 && repeats == 0);
+    if(scenario == "keyboard") assert(last_input.direction == 9 && repeats == 0);
+    if(scenario == "quit") assert(quit && repeats == 0);
+    if(scenario == "second") assert(is_two_finger_touch && repeats == 0);
+    if(scenario == "early" || scenario == "redraw") assert(repeats == 0);
+    assert(events.empty());
+}
+'''
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 问题与修改
安卓虚拟轮盘向下连走后拖到左/右仍继续向下，偶尔才响应。原连走分支在正常事件派发前生成旧方向输入，然后用 SDL_PollEvent 清空队列，只处理松手，丢弃拖动、按键和退出等事件。重复间隔较短时更容易持续命中此分支。

将连走计算移到正常 SDL 事件派发之后，删除单独清空队列的循环。使用最新手指坐标和接触状态决定连走；已有输入、退出、双指/三指或 ImGui 捕获时不生成覆盖输入。保留进入本轮时的刷新节流状态，避免拖动触发 needupdate 后反而阻止连续移动。重复间隔配置与默认值不变。

## 验证
- `python3 tools/test_android_joystick_repeat.py`：10 项通过。覆盖左右转向、连续事件取最后方向、松手不追加连走、按键和退出保留、第二根手指、重复间隔、持续拖动与刷新节流。
- 通过 CCB_SDLTILES_SOURCE 指向修改前源码重跑同组用例：8 项失败，修复后全部通过。
- 测试提取真实生产连走代码块，并保留它相对正常事件派发的位置；SDL 队列和正常派发器为模拟夹具，不是完整 SDL/游戏集成测试。
- 修改行 AStyle 格式检查及 git diff --check 通过。
- 未构建 Android APK、未运行完整游戏或安卓实机；仍需实机验证持续转向、松手及多指手势。

#### Responsible human
@LYHGLYTX

#### Documentation impact
无。修复现有轮盘事件处理，不改变配置或公开 API。

#### Related CCB-Docs PR
N/A

#### Affected documentation IDs
N/A

#### Generated reference impact
无。

变更规模：234 行（198 增、36 删，含 174 行回归夹具），按本地规则 15 个 commit 以内，实际 1 个完整提交。