### PR TITLE
修复电池和工具误显示射击后保持完好的说明

### DIFF
--- a/src/item_info.cpp
+++ b/src/item_info.cpp
@@ -1013,7 +1013,7 @@ void item::ammo_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
             _( "This ammo has been loaded with <bad>blackpowder</bad>, and will quickly "
                "clog up most guns, and cause rust if the gun is not cleaned." ) );
     }
-    if( parts->test( iteminfo_parts::AMMO_FX_RECOVER ) ) {
+    if( ammo.recovery_chance > 0 && parts->test( iteminfo_parts::AMMO_FX_RECOVER ) ) {
         if( ammo.recovery_chance <= 75 ) {
             fx.emplace_back( _( "Stands a <bad>very low</bad> chance of remaining intact once fired." ) );
         } else if( ammo.recovery_chance <= 80 ) {

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -2145,6 +2145,25 @@ TEST_CASE( "ammunition", "[iteminfo][ammo]" )
     }
 }
 
+TEST_CASE( "ammo_recovery_info_requires_recoverable_ammo", "[iteminfo][ammo]" )
+{
+    clear_avatar();
+    const std::vector<iteminfo_parts> parts = {
+        iteminfo_parts::AMMO_REMAINING_OR_TYPES, iteminfo_parts::AMMO_FX_RECOVER
+    };
+
+    const item battery( itype_test_battery_disposable );
+    REQUIRE( battery.ammo_data() );
+    REQUIRE( battery.ammo_data()->ammo->recovery_chance == 0 );
+    CHECK( item_info_str( battery, parts ).empty() );
+
+    const item rock( itype_test_rock );
+    REQUIRE( rock.ammo_data() );
+    REQUIRE( rock.ammo_data()->ammo->recovery_chance > 0 );
+    CHECK( item_info_str( rock, parts ).find( "chance of remaining intact once fired" ) !=
+           std::string::npos );
+}
+
 // Functions:
 // item::food_info
 TEST_CASE( "nutrients_in_food", "[iteminfo][food]" )


### PR DESCRIPTION
## 修改
电池复用弹药数据，recovery_chance 默认 0。物品说明原先将 0 也归入极低回收概率，导致装电池的手机等工具显示射击后保持完好的提示。

仅在 recovery_chance > 0 时显示回收说明。保留已有概率分级，不改变电池、弹药或 Mod 数据。

## 验证
- 新增 Catch2 回归：零回收率电池说明为空，可回收测试石块保留说明。
- 提取实际显示代码块，在隔离 C++ 夹具检查 0、1、75、76、80、81、90、91、95、96、100：修改前零概率断言失败，修改后通过。
- git diff --check 通过。
- 新增 Catch2 测试未进行完整原生编译/运行；未实机验证。隔离夹具不等于完整游戏回归。

#### Responsible human
@LYHGLYTX

#### Documentation impact
无，仅修正错误提示的显示条件。

#### Related CCB-Docs PR
N/A

#### Affected documentation IDs
N/A

#### Generated reference impact
无。

21 行变更，1 个提交，符合小改动 15 个提交以内的本地规则。